### PR TITLE
Make ClientConfig Sync

### DIFF
--- a/src/client_hs.rs
+++ b/src/client_hs.rs
@@ -46,7 +46,7 @@ fn find_session(sess: &mut ClientSessionImpl) -> Option<persist::ClientSessionVa
   let key = persist::ClientSessionKey::for_dns_name(&sess.handshake_data.dns_name);
   let key_buf = key.get_encoding();
 
-  let mut persist = sess.config.session_persistence.borrow_mut();
+  let mut persist = sess.config.session_persistence.lock().expect("");
   let maybe_value = persist.get(&key_buf);
 
   if maybe_value.is_none() {
@@ -403,7 +403,7 @@ fn save_session(sess: &mut ClientSessionImpl) {
                                                sess.secrets_current.get_master_secret());
   let value_buf = value.get_encoding();
 
-  let mut persist = sess.config.session_persistence.borrow_mut();
+  let mut persist = sess.config.session_persistence.lock().expect("");
   let worked = persist.put(key_buf, value_buf);
 
   if worked {

--- a/src/session.rs
+++ b/src/session.rs
@@ -127,11 +127,11 @@ pub trait MessageCipher {
 }
 
 impl MessageCipher {
-  pub fn invalid() -> Box<MessageCipher> {
+  pub fn invalid() -> Box<MessageCipher + Send + Sync> {
     Box::new(InvalidMessageCipher {})
   }
 
-  pub fn new(scs: &'static SupportedCipherSuite, secrets: &SessionSecrets) -> Box<MessageCipher> {
+  pub fn new(scs: &'static SupportedCipherSuite, secrets: &SessionSecrets) -> Box<MessageCipher + Send + Sync> {
     /* Make a key block, and chop it up. */
     let key_block = secrets.make_key_block(scs.key_block_len());
 
@@ -414,7 +414,7 @@ impl MessageCipher for InvalidMessageCipher {
 
 /* --- Common (to client and server) session functions --- */
 pub struct SessionCommon {
-  message_cipher: Box<MessageCipher>,
+  message_cipher: Box<MessageCipher + Send + Sync>,
   write_seq: u64,
   read_seq: u64,
   peer_eof: bool,


### PR DESCRIPTION
Replacing RefCell with Mutex, mark some boxes as Send + Sync.

I had to do this to make rustls work with hyper.  [Here's where I did the hyper integration](https://github.com/brson/rustup.rs/blob/rustls/src/download/src/lib.rs#L289).