### PR TITLE
Enlarge deframer internal buffer

### DIFF
--- a/src/msgs/deframer.rs
+++ b/src/msgs/deframer.rs
@@ -19,7 +19,7 @@ pub struct MessageDeframer {
   buf: Vec<u8>,
 
   /// A buffer into which we read.
-  chunk: [u8; 2048]
+  chunk: [u8; 16384]
 }
 
 impl MessageDeframer {
@@ -27,7 +27,7 @@ impl MessageDeframer {
     MessageDeframer {
       frames: VecDeque::new(),
       buf: Vec::new(),
-      chunk: [0u8; 2048]
+      chunk: [0u8; 16384]
     }
   }
 


### PR DESCRIPTION
Bump `MessageDeframer.chunk` size from 2K to 16K to avoid an excessive number of `read()` syscalls for large transfers. In my testing with rustup it easily gave about 2.5x the throughput.