### PR TITLE
Add a Session trait to allow being generic over client/server TLS sessions

### DIFF
--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -19,6 +19,8 @@ use docopt::Docopt;
 
 extern crate rustls;
 
+use rustls::Session;
+
 const CLIENT: mio::Token = mio::Token(0);
 
 /// This encapsulates the TCP-level connection, some connection

--- a/examples/tlsserver.rs
+++ b/examples/tlsserver.rs
@@ -21,6 +21,8 @@ extern crate env_logger;
 
 extern crate rustls;
 
+use rustls::Session;
+
 /* Token for our listening socket. */
 const LISTENER: mio::Token = mio::Token(0);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use msgs::enums::CipherSuite;
-use session::{SessionSecrets, SessionCommon};
+use msgs::enums::AlertDescription;
+use session::{Session, SessionSecrets, SessionCommon};
 use suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use msgs::handshake::{CertificatePayload, DigitallySignedStruct, SessionID};
 use msgs::enums::ContentType;
@@ -324,6 +325,10 @@ impl ClientSessionImpl {
 
     Ok(())
   }
+
+  pub fn send_close_notify(&mut self) {
+    self.common.send_warning_alert(AlertDescription::CloseNotify)
+  }
 }
 
 /// This represents a single TLS client session.
@@ -340,7 +345,9 @@ impl ClientSession {
              hostname: &str) -> ClientSession {
     ClientSession { imp: ClientSessionImpl::new(config, hostname) }
   }
+}
 
+impl Session for ClientSession {
   /// Read TLS content from `rd`.  This method does internal
   /// buffering, so `rd` can supply TLS messages in arbitrary-
   /// sized chunks (like a socket or pipe might).
@@ -350,12 +357,12 @@ impl ClientSession {
   ///
   /// The returned error only relates to IO on `rd`.  TLS-level
   /// errors are emitted from `process_new_packets`.
-  pub fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
+  fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
     self.imp.common.read_tls(rd)
   }
 
   /// Writes TLS messages to `wr`.
-  pub fn write_tls(&mut self, wr: &mut io::Write) -> io::Result<()> {
+  fn write_tls(&mut self, wr: &mut io::Write) -> io::Result<()> {
     self.imp.common.write_tls(wr)
   }
 
@@ -365,20 +372,27 @@ impl ClientSession {
   ///
   /// Success from this function can mean new plaintext is available:
   /// obtain it using `read`.
-  pub fn process_new_packets(&mut self) -> Result<(), TLSError> {
+  fn process_new_packets(&mut self) -> Result<(), TLSError> {
     self.imp.process_new_packets()
   }
 
   /// Returns true if the caller should call `read_tls` as soon
   /// as possible.
-  pub fn wants_read(&self) -> bool {
+  fn wants_read(&self) -> bool {
     self.imp.wants_read()
   }
 
   /// Returns true if the caller should call `write_tls` as soon
   /// as possible.
-  pub fn wants_write(&self) -> bool {
+  fn wants_write(&self) -> bool {
     self.imp.wants_write()
+  }
+
+  /// Queues a close_notify fatal alert to be sent in the next
+  /// `write_tls` call.  This informs the peer that the
+  /// connection is being closed.
+  fn send_close_notify(&mut self) {
+    self.imp.send_close_notify()
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ pub mod internal {
 
 /* The public interface is: */
 pub use error::TLSError;
+pub use session::Session;
 pub use client::{StoresClientSessions, ClientConfig, ClientSession};
 pub use verify::{RootCertStore};
 pub use server::{ServerConfig, ServerSession};

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use session::{SessionSecrets, SessionCommon};
+use session::{Session, SessionSecrets, SessionCommon};
 use suites::{SupportedCipherSuite, ALL_CIPHERSUITES, KeyExchange};
 use msgs::enums::ContentType;
 use msgs::enums::AlertDescription;
@@ -339,7 +339,9 @@ impl ServerSession {
   pub fn new(config: &Arc<ServerConfig>) -> ServerSession {
     ServerSession { imp: ServerSessionImpl::new(config) }
   }
+}
 
+impl Session for ServerSession {
   /// Read TLS content from `rd`.  This method does internal
   /// buffering, so `rd` can supply TLS messages in arbitrary-
   /// sized chunks (like a socket or pipe might).
@@ -349,12 +351,12 @@ impl ServerSession {
   ///
   /// The returned error only relates to IO on `rd`.  TLS-level
   /// errors are emitted from `process_new_packets`.
-  pub fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
+  fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
     self.imp.common.read_tls(rd)
   }
 
   /// Writes TLS messages to `wr`.
-  pub fn write_tls(&mut self, wr: &mut io::Write) -> io::Result<()> {
+  fn write_tls(&mut self, wr: &mut io::Write) -> io::Result<()> {
     self.imp.common.write_tls(wr)
   }
 
@@ -364,19 +366,19 @@ impl ServerSession {
   ///
   /// Success from this function can mean new plaintext is available:
   /// obtain it using `read`.
-  pub fn process_new_packets(&mut self) -> Result<(), TLSError> {
+  fn process_new_packets(&mut self) -> Result<(), TLSError> {
     self.imp.process_new_packets()
   }
 
   /// Returns true if the caller should call `read_tls` as soon
   /// as possible.
-  pub fn wants_read(&self) -> bool {
+  fn wants_read(&self) -> bool {
     self.imp.wants_read()
   }
 
   /// Returns true if the caller should call `write_tls` as soon
   /// as possible.
-  pub fn wants_write(&self) -> bool {
+  fn wants_write(&self) -> bool {
     self.imp.wants_write()
   }
 
@@ -387,7 +389,7 @@ impl ServerSession {
   /// Returns false if an alert cannot be sent thanks to the
   /// current state of the connection (ie, they cannot be sent
   /// during handshake).
-  pub fn send_close_notify(&mut self) {
+  fn send_close_notify(&mut self) {
     self.imp.send_close_notify()
   }
 }


### PR DESCRIPTION
@ctz this is useful for writing P2P protocols on top of TLS, where there is no distinction between client/server after the TLS session is established. Note that this is (minorly) backwards-incompatible, since it requires importing the trait directly to use its methods.

I've also added `send_close_notify` to the trait, since [it can (and should) be sent by both parties](https://tools.ietf.org/html/rfc5246#section-7.2.1).