### PR TITLE
Add target/ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Cargo.lock
+target/


### PR DESCRIPTION
This is useful for people that work on rustls using the defaults
settings for the compiler, where things get built into target/.