### PR TITLE
Use *ring* and webpki from crates.io.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,8 @@ untrusted = "0.3.1"
 time = "0.1.35"
 base64 = "~0.2.0"
 log = "0.3.6"
-
-[replace]
-"ring:0.2.0" = { git = "https://github.com/briansmith/ring", rev = "ec39fbd" }
-
-[dependencies.ring]
-git = "https://github.com/briansmith/ring"
-features = [ "rsa_signing" ]
-rev = "ec39fbd"
-
-[dependencies.webpki]
-git = "https://github.com/ctz/webpki"
-rev = "9c855fd"
+ring = { version = "0.3", features = ["rsa_signing"] }
+webpki = "0.2.1"
 
 [dev-dependencies]
 env_logger = "0.3.3"


### PR DESCRIPTION
The maintainer of *ring* and webpki intends to update the leftmost
non-zero version number of *ring* and webpki whenever a
backward-incompatible change is made, similar to what has been done
with untrusted on crates.io, so these dependencies should be relatively
safe in the case of known/intended breakage. See
http://doc.crates.io/specifying-dependencies.html#specifying-dependencies-from-cratesio
for how this works.