### PR TITLE
Laying ground work to remove more allocations.

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -121,7 +121,7 @@ impl MessageCipher for GCMMessageCipher {
       Message {
         typ: msg.typ,
         version: msg.version,
-        payload: MessagePayload::opaque(buf)
+        payload: MessagePayload::opaque(buf.as_slice())
       }
     )
   }
@@ -172,7 +172,7 @@ impl MessageCipher for GCMMessageCipher {
     Ok(Message {
       typ: typ,
       version: version,
-      payload: MessagePayload::opaque(result)
+      payload: MessagePayload::opaque(result.as_slice())
     })
   }
 }
@@ -271,7 +271,7 @@ impl MessageCipher for ChaCha20Poly1305MessageCipher {
       Message {
         typ: msg.typ,
         version: msg.version,
-        payload: MessagePayload::opaque(buf)
+        payload: MessagePayload::opaque(buf.as_slice())
       }
     )
   }
@@ -310,7 +310,7 @@ impl MessageCipher for ChaCha20Poly1305MessageCipher {
     Ok(Message {
       typ: typ,
       version: version,
-      payload: MessagePayload::opaque(buf)
+      payload: MessagePayload::opaque(buf.as_slice())
     })
   }
 }

--- a/src/msgs/base.rs
+++ b/src/msgs/base.rs
@@ -3,7 +3,7 @@ use msgs::codec::{Codec, Reader};
 
 /// An externally length'd payload
 #[derive(Debug, Clone, PartialEq)]
-pub struct Payload( pub Vec<u8>);
+pub struct Payload(pub Vec<u8>);
 
 impl Codec for Payload {
   fn encode(&self, bytes: &mut Vec<u8>) {

--- a/src/msgs/base.rs
+++ b/src/msgs/base.rs
@@ -3,7 +3,7 @@ use msgs::codec::{Codec, Reader};
 
 /// An externally length'd payload
 #[derive(Debug, Clone, PartialEq)]
-pub struct Payload(pub Vec<u8>);
+pub struct Payload( pub Vec<u8>);
 
 impl Codec for Payload {
   fn encode(&self, bytes: &mut Vec<u8>) {
@@ -21,9 +21,14 @@ impl Payload {
   }
 
   pub fn empty() -> Payload {
-    Payload::new(Vec::new())
+    Payload::new(Vec::with_capacity(2048))
   }
-
+  
+  pub fn from_slice(data: &[u8]) -> Payload {
+    let mut v = Vec::with_capacity(data.len()+5);
+    v.extend_from_slice(data);
+    Payload(v)
+  }
   pub fn len(&self) -> usize { self.0.len() }
 }
 

--- a/src/msgs/fragmenter.rs
+++ b/src/msgs/fragmenter.rs
@@ -39,7 +39,7 @@ impl MessageFragmenter {
       let cm = Message {
         typ: typ,
         version: version,
-        payload: MessagePayload::opaque(chunk.to_vec())
+        payload: MessagePayload::opaque(chunk)
       };
       out.push_back(cm);
     }
@@ -74,7 +74,7 @@ mod tests {
     let m = Message {
       typ: typ,
       version: version,
-      payload: MessagePayload::opaque(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec())
+      payload: MessagePayload::opaque(b"\x01\x02\x03\x04\x05\x06\x07\x08")
     };
 
     let frag = MessageFragmenter::new(3);
@@ -91,7 +91,7 @@ mod tests {
     let m = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec())
+      payload: MessagePayload::opaque(b"\x01\x02\x03\x04\x05\x06\x07\x08")
     };
 
     let frag = MessageFragmenter::new(8);

--- a/src/msgs/handshake.rs
+++ b/src/msgs/handshake.rs
@@ -6,7 +6,7 @@ use msgs::enums::ECCurveType;
 use msgs::base::{Payload, PayloadU8, PayloadU16, PayloadU24};
 use msgs::codec;
 use msgs::codec::{Codec, Reader};
-
+use std::fmt;
 use std::io::Write;
 use std::collections;
 
@@ -43,6 +43,7 @@ macro_rules! declare_u16_vec(
 );
 
 #[derive(Debug)]
+#[repr(C)]
 pub struct Random {
   pub gmt_unix_time: u32,
   pub opaque: [u8; 28]
@@ -75,43 +76,82 @@ impl Random {
     bytes.write(&buf).unwrap();
   }
 }
-
-#[derive(Debug, PartialEq, Clone)]
+#[repr(C)]
 pub struct SessionID {
-  bytes: Vec<u8>
+    data: [u8;33]
 }
-
+impl fmt::Debug for SessionID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SessionID len: {} data:[{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}]", self.data[0],self.data[1],self.data[2],self.data[3],self.data[4],self.data[5],self.data[6],self.data[7],self.data[8],self.data[9],self.data[10],self.data[11],self.data[12],self.data[13],self.data[14],self.data[15],self.data[16],self.data[17],self.data[18],self.data[19],self.data[20],self.data[21],self.data[22],self.data[23],self.data[24],self.data[25],self.data[26],self.data[27],self.data[28],self.data[29],self.data[30],self.data[31],self.data[32])
+    }
+}
+impl Clone for SessionID {
+    fn clone(&self) -> Self {
+        let mut d = [0u8;33];
+        for i in 0..33 {
+            d[i] = self.data[i]
+        }
+        SessionID{ data: d }
+    }
+}
+impl PartialEq for SessionID {
+    fn eq(&self, other: &Self) -> bool {
+        if self.data[0] != other.data[0] {
+            return false;
+        }
+        let l = self.data[0] as usize;
+        let mut flag = true;
+        for i in 1..l {
+            flag &= self.data[i] == other.data[i]
+        }
+        flag
+    }
+}
 impl Codec for SessionID {
   fn encode(&self, bytes: &mut Vec<u8>) {
-    debug_assert!(self.bytes.len() <= 32);
-    bytes.push(self.bytes.len() as u8);
-    bytes.extend_from_slice(&self.bytes);
+    debug_assert!(self.len() <= 32);
+    let l = self.len();
+    bytes.push( l as u8);
+    for x in 0..l {
+        bytes.push(self.data[x+1]);
+    }
   }
 
   fn read(r: &mut Reader) -> Option<SessionID> {
     let len = try_ret!(codec::read_u8(r));
-    let bytes = try_ret!(r.take(len as usize));
-
-    if len <= 32 {
-      Some(SessionID { bytes: bytes.to_vec() })
-    } else {
-      None
+    if len > 32 {
+      return None;
+    }
+    match r.take(len as usize) {
+      Option::None => None,
+      Option::Some(x) => {
+        let mut d = [0u8;33];
+        d[0] = len;
+        for (i,b) in x.iter().enumerate() {
+          d[i+1] = *b;
+        }
+        Some(SessionID{ data: d })
+      }
     }
   }
 }
 
 impl SessionID {
-  pub fn new(mut bytes: Vec<u8>) -> SessionID {
-    bytes.truncate(32);
-    SessionID { bytes: bytes }
+  pub fn new(bytes: Vec<u8>) -> SessionID {
+    let mut d = [0u8;33];
+    d[0] = bytes.len() as u8;
+    for (i,b) in bytes.iter().skip(1).take(32).enumerate() {
+        d[i+1] = *b;
+    }
+    SessionID { data: d }
   }
 
   pub fn empty() -> SessionID {
-    SessionID::new(Vec::new())
+    SessionID { data: [0u8;33] }
   }
 
   pub fn len(&self) -> usize {
-    return self.bytes.len()
+    self.data[0] as usize
   }
 
   pub fn is_empty(&self) -> bool {

--- a/src/msgs/hsjoiner.rs
+++ b/src/msgs/hsjoiner.rs
@@ -116,13 +116,13 @@ mod tests {
     let wanted = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"hello world".to_vec())
+      payload: MessagePayload::opaque(b"hello world")
     };
 
     let unwanted = Message {
       typ: ContentType::Alert,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"ponytown".to_vec())
+      payload: MessagePayload::opaque(b"ponytown")
     };
 
     assert_eq!(hj.want_message(&wanted), true);
@@ -149,7 +149,7 @@ mod tests {
     let msg = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec()) /* two HelloRequests. */
+      payload: MessagePayload::opaque(b"\x00\x00\x00\x00\x00\x00\x00\x00") /* two HelloRequests. */
     };
 
     assert_eq!(hj.want_message(&msg), true);
@@ -178,7 +178,7 @@ mod tests {
     let msg = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x01\x00\x00\x02\xff\xff".to_vec()) /* short ClientHello. */
+      payload: MessagePayload::opaque(b"\x01\x00\x00\x02\xff\xff") /* short ClientHello. */
     };
 
     assert_eq!(hj.want_message(&msg), true);
@@ -195,7 +195,7 @@ mod tests {
     let mut msg = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec())
+      payload: MessagePayload::opaque(b"\x14\x00\x00\x10\x00\x01\x02\x03\x04")
     };
 
     assert_eq!(hj.want_message(&msg), true);
@@ -206,7 +206,7 @@ mod tests {
     msg = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec())
+      payload: MessagePayload::opaque(b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e")
     };
 
     assert_eq!(hj.want_message(&msg), true);
@@ -217,7 +217,7 @@ mod tests {
     msg = Message {
       typ: ContentType::Handshake,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(b"\x0f".to_vec())
+      payload: MessagePayload::opaque(b"\x0f")
     };
 
     assert_eq!(hj.want_message(&msg), true);

--- a/src/msgs/message.rs
+++ b/src/msgs/message.rs
@@ -61,8 +61,8 @@ impl MessagePayload {
     }
   }
 
-  pub fn opaque(data: Vec<u8>) -> MessagePayload {
-    MessagePayload::Opaque(Payload::new(data))
+  pub fn opaque(data: &[u8]) -> MessagePayload {
+    MessagePayload::Opaque(Payload::from_slice(data))
   }
 }
 
@@ -175,7 +175,7 @@ impl Message {
     Message {
       typ: self.typ,
       version: self.version,
-      payload: MessagePayload::opaque(buf)
+      payload: MessagePayload::opaque(buf.as_slice())
     }
   }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -344,7 +344,7 @@ impl SessionCommon {
     let m = Message {
       typ: ContentType::ApplicationData,
       version: ProtocolVersion::TLSv1_2,
-      payload: MessagePayload::opaque(data)
+      payload: MessagePayload::opaque(data.as_slice())
     };
 
     self.send_msg_encrypt(m);


### PR DESCRIPTION
I'm trying to remove some of the dependency on the short lived small vectors where I can.

This patch really just cleans up `SessionID` and shrinks `Random`'s size. I want to make `PayLoad` be a slice in the future, and try to get `VecBuf` so it's using internal slices. I'm not sure we'll see. 

