### PR TITLE
Using more recent version of ring and webpki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ untrusted = "0.3.1"
 time = "0.1.35"
 base64 = "~0.2.0"
 log = { version = "0.3.6", optional = true }
-ring = { version = "0.4", features = ["rsa_signing"] }
-webpki = "0.3.0"
+ring = { version = "0.6.0-alpha1", features = ["rsa_signing"] }
+webpki = "0.8.0"
 
 [features]
 default = ["logging"]
@@ -26,4 +26,4 @@ env_logger = "0.3.3"
 mio = "0.5.1"
 docopt = "0.6"
 rustc-serialize = "0.3"
-webpki-roots = "0.5.0"
+webpki-roots = "0.6.0"

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -20,14 +20,10 @@ type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
 /// Which signature verification mechanisms we support.  No particular
 /// order.
 static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
-  &webpki::ECDSA_P256_SHA1,
   &webpki::ECDSA_P256_SHA256,
   &webpki::ECDSA_P256_SHA384,
-  &webpki::ECDSA_P256_SHA512,
-  &webpki::ECDSA_P384_SHA1,
   &webpki::ECDSA_P384_SHA256,
   &webpki::ECDSA_P384_SHA384,
-  &webpki::ECDSA_P384_SHA512,
   &webpki::RSA_PKCS1_2048_8192_SHA1,
   &webpki::RSA_PKCS1_2048_8192_SHA256,
   &webpki::RSA_PKCS1_2048_8192_SHA384,
@@ -209,17 +205,11 @@ pub fn verify_client_cert(roots: &RootCertStore,
     .map(|_| ())
 }
 
-static ECDSA_SHA1: SignatureAlgorithms = &[
-  &webpki::ECDSA_P256_SHA1, &webpki::ECDSA_P384_SHA1
-];
 static ECDSA_SHA256: SignatureAlgorithms = &[
   &webpki::ECDSA_P256_SHA256, &webpki::ECDSA_P384_SHA256
 ];
 static ECDSA_SHA384: SignatureAlgorithms = &[
   &webpki::ECDSA_P256_SHA384, &webpki::ECDSA_P384_SHA384
-];
-static ECDSA_SHA512: SignatureAlgorithms = &[
-  &webpki::ECDSA_P256_SHA512, &webpki::ECDSA_P384_SHA512
 ];
 
 static RSA_SHA1: SignatureAlgorithms = &[ &webpki::RSA_PKCS1_2048_8192_SHA1 ];
@@ -232,10 +222,8 @@ fn convert_alg(sh: &SignatureAndHashAlgorithm) -> Result<SignatureAlgorithms, TL
   use msgs::enums::HashAlgorithm::{SHA1, SHA256, SHA384, SHA512};
 
   match (&sh.sign, &sh.hash) {
-    (&ECDSA, &SHA1)   => Ok(ECDSA_SHA1),
     (&ECDSA, &SHA256) => Ok(ECDSA_SHA256),
     (&ECDSA, &SHA384) => Ok(ECDSA_SHA384),
-    (&ECDSA, &SHA512) => Ok(ECDSA_SHA512),
     (&RSA, &SHA1)     => Ok(RSA_SHA1),
     (&RSA, &SHA256)   => Ok(RSA_SHA256),
     (&RSA, &SHA384)   => Ok(RSA_SHA384),


### PR DESCRIPTION
Without this pull request, rustls is not usable in code that also uses more recent version of ring because of name clashes at link. For example, pijul needs both rustls and thrussh.

Also, a number of deprecated features have been dropped from webpki for security reasons, which probably means rustls should also stop using them.
