### PR TITLE
Pre-life Time annotation structure changes

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -35,3 +35,87 @@ impl Expectation {
   }
 }
 
+/*
+ * Server Expectations
+ */
+pub static SERVER_EXPECT_CLIENT_HELLO: Expectation = Expectation {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::ClientHello]
+};
+pub static SERVER_EXPECT_CERTIFICATE: Expectation = Expectation {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::Certificate]
+};
+pub static SERVER_EXPECT_CLIENT_KX: Expectation = Expectation {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::ClientKeyExchange]
+};
+pub static SERVER_EXPECT_CERTIFICATE_VERIFY: Expectation = Expectation {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::CertificateVerify]
+};
+pub static SERVER_EXPECT_CCS: Expectation = Expectation {
+  content_types: &[ContentType::ChangeCipherSpec],
+  handshake_types: &[]
+};
+pub static SERVER_EXPECT_FINISHED: Expectation = Expectation {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::Finished]
+};
+pub static SERVER_TRAFFIC: Expectation = Expectation {
+  content_types: &[ContentType::ApplicationData],
+  handshake_types: &[]
+};
+
+/*
+ * Client Expectations
+ */
+pub static CLIENT_EXPECT_SERVER_HELLO: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::ServerHello]
+};
+pub static CLIENT_EXPECT_CERTIFICATE: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::Certificate]
+};
+pub static CLIENT_EXPECT_SERVER_KX: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::ServerKeyExchange]
+};
+pub static CLIENT_EXPECT_DONE_OR_CERTREQ: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::CertificateRequest, HandshakeType::ServerHelloDone]
+};
+pub static CLIENT_EXPECT_SERVER_HELLO_DONE: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::ServerHelloDone]
+};
+pub static CLIENT_EXPECT_CCS: Expectation = Expectation  {
+  content_types: &[ContentType::ChangeCipherSpec],
+  handshake_types: &[]
+};
+pub static CLIENT_EXPECT_NEW_TICKET: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::NewSessionTicket]
+};
+pub static CLIENT_EXPECT_CCS_RESUME: Expectation = Expectation  {
+  content_types: &[ContentType::ChangeCipherSpec],
+  handshake_types: &[]
+};
+pub static CLIENT_EXPECT_NEW_TICKET_RESUME: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::NewSessionTicket]
+};
+pub static CLIENT_EXPECT_FINISHED: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[HandshakeType::Finished]
+};
+
+pub static CLIENT_EXPECT_FINISHED_RESUME: Expectation = Expectation  {
+  content_types: &[ContentType::Handshake],
+  handshake_types: &[]
+};
+pub static CLIENT_TRAFFIC: Expectation = Expectation  {
+  content_types: &[ContentType::ApplicationData],
+  handshake_types: &[]
+};


### PR DESCRIPTION
These are the main structural changes I faced when adding lifetime annotations.

Added them first to main the merge easier.

# Cipher/Message

### Problem:

- Post lifetimes `Message` becomes `Message<'a>` and sending/receiving a lifetime to a trait object got _really_ awkward. 
- In some cases `Message`'s already `Opaque` vector is cloned internally. 
- That was my fault in many places from my previous patch.

### Solution:

- Pass a structure in by reference that holds `ContentType` and `ProtocolVersion`.  [code](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/msgs/message.rs#L89,#L109)
- Pass/Receive a `Vec<u8>` from encryption. [code](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/cipher.rs#L19,#L22)
- Remove vector duplications within encryption/decryption step. 
- Implemented the trait `MessagePayload::From<Vec<u8>>` to allow for `Message::Opaque` to be constructed without allocations (undoing some of the performance losses from my previous patch) [code](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/msgs/message.rs#L74,#L79)

### Comments:

- I think passing/receiving a `Vec<u8>` makes more sense as it gives more flexibility if compression is used in the future. 
- The above changes resulted in fairly _massive_ performance gains. Nearly 5-10% in handshaking and 20-30% in cipher thoughtput. 

# Handler/Expectation/ServerSession/ClientSession

### Problem

- `ServerSessionImpl` and `ClientSessnionImpl` will have lifetime annotations added. `Handler` is `'static` while the buffers inside of `*SessionImpl` are not. 
- So `Handler` type needs to have the `'static` assigned lifetime assigned to half itself, and created a _different_ lifetime based on an arg passed to it. I just couldn't make that work.

### Solution:

- I'm using `ConnState` to dispatch to the proper expectation and handler. 
- [Here is the server code](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/server.rs#L343,#L366)
- [Here is the client code](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/client.rs#L305,#L338)

### Comments:

- This made the [handshake module](https://github.com/valarauca/rustls/blob/f2d350ab04b1df3b17bc395f6246f78a6c9d3026/src/handshake.rs). Pretty much _all_ constants now.
- Some functions in `server_hs` and `client_hs` are public now, the ones originally passed in `Hander` type.
- Overall this caused a ~1-0.5% performance regression

# Performance Report

- Handshaking performance +4-5% 
- Cipher thought-put +20-30%

# Closing Remarks

I added `Result<(),TLSError>` to the `send_close_notify` as there are internal errors it may trigger. This isn't breaking anything. But there are a fair number of warnings now. 

I can remove this and re-submit if you'd like.