### PR TITLE
0.5.4: Require *ring* 0.6.3 to pick up possible security fix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"
@@ -13,8 +13,8 @@ untrusted = "0.3.1"
 time = "0.1.35"
 base64 = "~0.2.0"
 log = { version = "0.3.6", optional = true }
-ring = { version = "0.6.0-alpha1", features = ["rsa_signing"] }
-webpki = "0.8.0"
+ring = { version = "0.6.3", features = ["rsa_signing"] }
+webpki = "0.9.2"
 
 [features]
 default = ["logging"]
@@ -26,4 +26,4 @@ env_logger = "0.3.3"
 mio = "0.5.1"
 docopt = "0.6"
 rustc-serialize = "0.3"
-webpki-roots = "0.6.0"
+webpki-roots = "0.6.1"


### PR DESCRIPTION
The dependencies on webpki and webpki-roots are updated to match.

Note that this depends on webpki-roots-0.6.1, which hasn't been released yet.