### PR TITLE
added parallel certificate verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ base64 = "~0.2.0"
 log = { version = "0.3.6", optional = true }
 ring = { version = "0.6.0-alpha1", features = ["rsa_signing"] }
 webpki = "0.8.0"
+crossbeam = "0.2.10"
+rayon = "0.6.0"
 
 [features]
 default = ["logging"]
@@ -27,3 +29,6 @@ mio = "0.5.1"
 docopt = "0.6"
 rustc-serialize = "0.3"
 webpki-roots = "0.6.0"
+
+[replace]
+"webpki:0.8.0" = {path = "/Users/ddh/mozilla/servo/webpki" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,9 @@ extern crate base64;
 #[macro_use]
 extern crate log;
 
+extern crate crossbeam;
+extern crate rayon;
+
 #[cfg(not(feature = "logging"))]
 #[macro_use]
 mod compile_out_log {
@@ -226,7 +229,7 @@ pub mod internal {
 /* The public interface is: */
 pub use error::TLSError;
 pub use session::Session;
-pub use verify::{RootCertStore};
+pub use verify::{RootCertStore, verify_server_cert, parallel_verify_server_cert};
 pub use client::{StoresClientSessions, ClientSessionMemoryCache, ClientConfig, ClientSession};
 pub use server::{StoresServerSessions, ServerSessionMemoryCache, ServerConfig, ServerSession};
 pub use server::ProducesTickets;


### PR DESCRIPTION
I'm working on using webpki and rustls in Servo. This PR will allow that.

When evaluating performance, I found that verify_server_cert was slower than using openssl, so I created two parallel functions to improve performance.

**Performance evaluation**: I connected to 13 https sites using verify_server_cert, parallel_verify_server_cert, and the openssl code currently used in servo.

Average time to establish a connection using:
* verify_server_cert: 110.6259529
* parallel_verify_server_cert: 87.99443197
* openssl: 77.41738468 ms

I plan to continue to look for improvements.