### PR TITLE
added dangerous feature for accepting self signed certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ webpki = "0.9.2"
 [features]
 default = ["logging"]
 logging = ["log"]
+dangerous = []
 
 [dev-dependencies]
 log = "0.3.6"

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -12,7 +12,10 @@ use x509;
 use key;
 use std::io;
 
-/// Disable all verifications, for testing purposes.
+#[cfg(feature = "dangerous")]
+const DANGEROUS_DISABLE_VERIFY: bool = true;
+
+#[cfg(not(feature = "dangerous"))]
 const DANGEROUS_DISABLE_VERIFY: bool = false;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];


### PR DESCRIPTION
The `const` is already there and needs to be manually set for testing. Using a feature, we can avoid editing source and this could be passed along by projects using `rustls` as a dependency. Sometimes it is necessary to accept a self signed certificate (internal networks, ephemeral certificate creation, etc).