### PR TITLE
Allows disabling of hostname verification.

### DIFF
--- a/admin/capture-certdata
+++ b/admin/capture-certdata
@@ -71,6 +71,6 @@ if __name__ == '__main__':
         print '    anchors.add_trust_anchors(&webpki_roots::ROOTS);'
         print '    bench(100, "verify_server_cert(%s)", ' % name
         print '          || (),'
-        print '          |_| verify::verify_server_cert(&anchors, &chain[..], "%s").unwrap());' % hostname
+        print '          |_| verify::verify_server_cert(&anchors, &chain[..], "%s", false).unwrap());' % hostname
         print '}'
         print

--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -304,7 +304,7 @@ Options:
                         May be used multiple times to offer serveral protocols.
     --cache CACHE       Save session cache to file CACHE.
     --no-tickets        Disable session ticket support.
-    --insecure          Allow connections to sites without certs.
+    --insecure          Do not do hostname verification on presented server certificates.
     --verbose           Emit log output.
     --mtu MTU           Limit outgoing messages to MTU bytes.
     --version, -v       Show tool version.

--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -304,6 +304,7 @@ Options:
                         May be used multiple times to offer serveral protocols.
     --cache CACHE       Save session cache to file CACHE.
     --no-tickets        Disable session ticket support.
+    --insecure          Allow connections to sites without certs.
     --verbose           Emit log output.
     --mtu MTU           Limit outgoing messages to MTU bytes.
     --version, -v       Show tool version.
@@ -324,6 +325,7 @@ struct Args {
     flag_auth_key: Option<String>,
     flag_auth_certs: Option<String>,
     arg_hostname: String,
+    flag_insecure: bool,
 }
 
 // TODO: um, well, it turns out that openssl s_client/s_server
@@ -413,6 +415,10 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
 
     if args.flag_no_tickets {
         config.enable_tickets = false;
+    }
+
+    if args.flag_insecure {
+        config.danger_disable_host_name_verification();
     }
 
     let persist = Box::new(PersistCache::new(&args.flag_cache));

--- a/src/client.rs
+++ b/src/client.rs
@@ -188,6 +188,11 @@ pub struct ClientConfig {
     /// Supported versions, in no particular order.  The default
     /// is all supported versions.
     pub versions: Vec<ProtocolVersion>,
+
+    /// Whether to do host name verification or not.  WARNING: turning
+    /// this off is *insecure* as the host will not be verified to be
+    /// who it says it is.
+    host_verification: bool,
 }
 
 impl ClientConfig {
@@ -204,6 +209,7 @@ impl ClientConfig {
             client_auth_cert_resolver: Box::new(FailResolveClientCert {}),
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
+            host_verification: true,
         }
     }
 
@@ -248,6 +254,25 @@ impl ClientConfig {
                                   key_der: key::PrivateKey) {
         self.client_auth_cert_resolver = Box::new(AlwaysResolvesClientCert::new_rsa(cert_chain,
                                                                                     &key_der));
+    }
+
+    /// Allow creation of a TLS stream without verification of host
+    /// names.  WARNING: This is a dangerous option to enable, as it
+    /// will allow any valid certificate for any site to be trusted
+    /// for any other site.  This opens up a major risk of
+    /// man-in-the-middle attaks.
+    pub fn danger_disable_host_name_verification(&mut self) {
+        self.host_verification = false;
+    }
+
+    /// Enable host name verification.
+    pub fn enable_host_name_verification(&mut self) {
+        self.host_verification = true;
+    }
+
+    /// Should this connection do host name verification
+    pub fn do_host_name_verification(&self) -> bool {
+        self.host_verification
     }
 }
 

--- a/src/client_hs.rs
+++ b/src/client_hs.rs
@@ -839,11 +839,12 @@ fn handle_certificate_verify(sess: &mut ClientSessionImpl,
 
     info!("Server cert is {:?}", sess.handshake_data.server_cert_chain);
 
-    // 1. Verify the certificate chain.
+    // 1. Verify the certificate chain. (unless configured not to)
     // 2. Verify their signature on the handshake.
     try!(verify::verify_server_cert(&sess.config.root_store,
                                   &sess.handshake_data.server_cert_chain,
-                                  &sess.handshake_data.dns_name));
+                                  &sess.handshake_data.dns_name,
+                                  !sess.config.do_host_name_verification()));
 
     let handshake_hash = sess.handshake_data.transcript.get_current_hash();
     try!(verify::verify_tls13(&sess.handshake_data.server_cert_chain[0],
@@ -1076,7 +1077,7 @@ fn handle_server_hello_done(sess: &mut ClientSessionImpl,
     info!("Server cert is {:?}", sess.handshake_data.server_cert_chain);
     info!("Server DNS name is {:?}", sess.handshake_data.dns_name);
 
-    // 1. Verify the cert chain.
+    // 1. Verify the cert chain. (unless configured not to)
     // 2. Verify that the top certificate signed their kx.
     // 3. If doing client auth, send our Certificate.
     // 4. Complete the key exchange:
@@ -1090,7 +1091,8 @@ fn handle_server_hello_done(sess: &mut ClientSessionImpl,
     // 1.
     try!(verify::verify_server_cert(&sess.config.root_store,
                                   &sess.handshake_data.server_cert_chain,
-                                  &sess.handshake_data.dns_name));
+                                  &sess.handshake_data.dns_name,
+                                  !sess.config.do_host_name_verification()));
 
     // 2.
     // Build up the contents of the signed message.

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -42,7 +42,7 @@ fn test_reddit_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(reddit)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "reddit.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "reddit.com", false).unwrap());
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn test_github_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(github)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "github.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "github.com", false).unwrap());
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_arstechnica_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(arstechnica)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "arstechnica.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "arstechnica.com", false).unwrap());
 }
 
 #[test]
@@ -80,7 +80,7 @@ fn test_servo_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(servo)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "servo.org").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "servo.org", false).unwrap());
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn test_twitter_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(twitter)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "twitter.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "twitter.com", false).unwrap());
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn test_wikipedia_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(wikipedia)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "wikipedia.org").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "wikipedia.org", false).unwrap());
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn test_google_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(google)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "www.google.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "www.google.com", false).unwrap());
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn test_hn_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(hn)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "news.ycombinator.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "news.ycombinator.com", false).unwrap());
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn test_stackoverflow_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(stackoverflow)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "stackoverflow.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "stackoverflow.com", false).unwrap());
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn test_duckduckgo_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(duckduckgo)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "duckduckgo.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "duckduckgo.com", false).unwrap());
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn test_rustlang_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(rustlang)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "www.rust-lang.org").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "www.rust-lang.org", false).unwrap());
 }
 
 #[test]
@@ -180,6 +180,17 @@ fn test_wapo_cert() {
     anchors.add_trust_anchors(&webpki_roots::ROOTS);
     bench(100, "verify_server_cert(wapo)", 
           || (),
-          |_| verify::verify_server_cert(&anchors, &chain[..], "www.washingtonpost.com").unwrap());
+          |_| verify::verify_server_cert(&anchors, &chain[..], "www.washingtonpost.com", false).unwrap());
 }
 
+#[test]
+fn test_no_hostname_verification() {
+    let cert0 = key::Certificate(include_bytes!("testdata/cert-stackoverflow.0.der").to_vec());
+    let cert1 = key::Certificate(include_bytes!("testdata/cert-stackoverflow.1.der").to_vec());
+    let chain = [ cert0, cert1 ];
+    let mut anchors = verify::RootCertStore::empty();
+    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    bench(100, "verify_server_cert(no_hostname_verification)",
+          || (),
+          |_| verify::verify_server_cert(&anchors, &chain[..], "NOTstackoverflow.com", true).unwrap());
+}


### PR DESCRIPTION
This PR would allow a user to call: `danger_disable_host_name_verification` on a ClientConfig to disable host-name verification.

I know this has been sort-of submitted as a PR before and rejected but I do think there are use cases for this and this tries to make it clear that there is a risk to doing this.  A few things to consider:

- This forces user to call danger_disable_host_name_verification to make it clear this has risks
- The hyper-openssl has something very similar: https://docs.rs/hyper-openssl/0.2.6/hyper_openssl/struct.OpensslClient.html#method.danger_disable_hostname_verification
- curl has the --insecure option for this

My use case is building a tool that integrates with existing infrastructure, where in some cases the existing things are configured to use a cert that doesn't verify.  I imagine this isn't an isolated case (hence all the other tools that support this), and as long as it's very clear what you're doing it's nice to support.