### PR TITLE
Update dependencies to work with *ring* 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ untrusted = "0.5"
 time = "0.1.37"
 base64 = "0.5"
 log = { version = "0.3.6", optional = true }
-ring = { version = "0.8", features = ["rsa_signing"] }
-webpki = "0.11"
+ring = { version = "0.9", features = ["rsa_signing"] }
+webpki = "0.12"
 
 [features]
 default = ["logging"]
@@ -27,7 +27,7 @@ env_logger = "0.4.2"
 mio = "0.6"
 docopt = "0.7"
 rustc-serialize = "0.3"
-webpki-roots = "0.9"
+webpki-roots = "0.10"
 regex = "0.2"
 
 [[example]]

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -39,7 +39,7 @@ fn test_reddit_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-reddit.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = verify::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_trust_anchors(&webpki_roots::ROOTS[..]);
     bench(100, "verify_server_cert(reddit)", 
           || (),
           |_| verify::verify_server_cert(&anchors, &chain[..], "reddit.com").unwrap());
@@ -151,7 +151,7 @@ fn test_duckduckgo_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-duckduckgo.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = verify::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_trust_anchors(&webpki_roots::ROOTS[..]);
     bench(100, "verify_server_cert(duckduckgo)", 
           || (),
           |_| verify::verify_server_cert(&anchors, &chain[..], "duckduckgo.com").unwrap());
@@ -164,7 +164,7 @@ fn test_rustlang_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-rustlang.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = verify::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_trust_anchors(&webpki_roots::ROOTS[..]);
     bench(100, "verify_server_cert(rustlang)", 
           || (),
           |_| verify::verify_server_cert(&anchors, &chain[..], "www.rust-lang.org").unwrap());
@@ -177,7 +177,7 @@ fn test_wapo_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-wapo.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = verify::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_trust_anchors(&webpki_roots::ROOTS[..]);
     bench(100, "verify_server_cert(wapo)", 
           || (),
           |_| verify::verify_server_cert(&anchors, &chain[..], "www.washingtonpost.com").unwrap());


### PR DESCRIPTION
I am not sure why rustc just started complaining about the
array -> slice coercions in src/verifybench.rs. I just updated the file
to make the errors go away.

This depends on https://github.com/ctz/webpki-roots/pull/8.