### PR TITLE
Fixes #68 -- first attempt at an API for disable client certificate verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ webpki = "0.12"
 [features]
 default = ["logging"]
 logging = ["log"]
+dangerous_configuration = []
 
 [dev-dependencies]
 log = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,8 @@ pub use client::{ClientConfig, ClientSession};
 pub use client::ResolvesClientCert;
 pub use server::{StoresServerSessions, ServerSessionMemoryCache};
 pub use server::{ServerConfig, ServerSession};
+#[cfg(feature = "dangerous_configuration")]
+pub use server::{DangerousServerConfig};
 pub use server::ResolvesServerCert;
 pub use server::ProducesTickets;
 pub use ticketer::Ticketer;


### PR DESCRIPTION
Curious what your thoughts on this API is. It requires you to go through two hoops to enable it, and if libraries enable it, the use of `features` will propagate that to things which depend on them, hopefully meaning libraries will not be able to do bad things without their users being aware.