### PR TITLE
Dummy Debug implemnetation for ClientSession and ServerSession

### DIFF
--- a/src/anchors.rs
+++ b/src/anchors.rs
@@ -10,6 +10,7 @@ use std::io;
 /// This is like a `webpki::TrustAnchor`, except it owns
 /// rather than borrows its memory.  That prevents lifetimes
 /// leaking up the object tree.
+#[derive(Debug)]
 pub struct OwnedTrustAnchor {
     subject: Vec<u8>,
     spki: Vec<u8>,
@@ -36,6 +37,7 @@ impl OwnedTrustAnchor {
 
 /// A container for root certificates able to provide a root-of-trust
 /// for connection authentication.
+#[derive(Debug)]
 pub struct RootCertStore {
     pub roots: Vec<OwnedTrustAnchor>,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,6 +19,7 @@ use key;
 use std::collections;
 use std::sync::{Arc, Mutex};
 use std::io;
+use std::fmt;
 
 /// A trait for the ability to store client session data.
 /// The keys and values are opaque.
@@ -345,6 +346,12 @@ pub struct ClientSessionImpl {
     pub state: &'static client_hs::State,
 }
 
+impl fmt::Debug for ClientSessionImpl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ClientSessionImpl").finish()
+    }
+}
+
 impl ClientSessionImpl {
     pub fn new(config: &Arc<ClientConfig>, hostname: &str) -> ClientSessionImpl {
         let mut cs = ClientSessionImpl {
@@ -536,6 +543,7 @@ impl ClientSessionImpl {
 }
 
 /// This represents a single TLS client session.
+#[derive(Debug)]
 pub struct ClientSession {
     // We use the pimpl idiom to hide unimportant details.
     imp: ClientSessionImpl,

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@ use key;
 use std::collections;
 use std::sync::{Arc, Mutex};
 use std::io;
+use std::fmt;
 
 /// A trait for the ability to generate Session IDs, and store
 /// server session data. The keys and values are opaque.
@@ -391,6 +392,12 @@ pub struct ServerSessionImpl {
     pub state: &'static server_hs::State,
 }
 
+impl fmt::Debug for ServerSessionImpl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ServerSessionImpl").finish()
+    }
+}
+
 impl ServerSessionImpl {
     pub fn new(server_config: &Arc<ServerConfig>) -> ServerSessionImpl {
         let mut sess = ServerSessionImpl {
@@ -541,6 +548,7 @@ impl ServerSessionImpl {
 ///
 /// Send TLS-protected data to the peer using the `io::Write` trait implementation.
 /// Read data from the peer using the `io::Read` trait implementation.
+#[derive(Debug)]
 pub struct ServerSession {
     // We use the pimpl idiom to hide unimportant details.
     imp: ServerSessionImpl,


### PR DESCRIPTION
It is not very useful per se, but at least `#[derive(Debug)]` will
work on user data structs containing `ClientSession` of `ServerSession`.