### PR TITLE
client: make ClientSessionImpl Sync-compatible

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -313,7 +313,7 @@ pub struct ClientSessionImpl {
     pub alpn_protocol: Option<String>,
     pub common: SessionCommon,
     pub error: Option<TLSError>,
-    pub state: Option<Box<hs::State + Send>>,
+    pub state: Option<Box<hs::State + Send + Sync>>,
     pub server_cert_chain: CertificatePayload,
 }
 


### PR DESCRIPTION
Otherwise rustls can be tough to use in some multi threaded environment.