### PR TITLE
0.11.0: Update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ time = "0.1.37"
 base64 = "0.6"
 log = { version = "0.3.6", optional = true }
 ring = { version = "0.11", features = ["rsa_signing"] }
-webpki = "0.14"
+webpki = "0.16"
 sct = "0.1.2"
 
 [features]
@@ -30,7 +30,7 @@ mio = "0.6"
 docopt = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
-webpki-roots = "0.11"
+webpki-roots = "0.13"
 ct-logs = "0.1"
 regex = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 license = "Apache-2.0/ISC/MIT"
 readme = "README.md"
@@ -10,13 +10,13 @@ repository = "https://github.com/ctz/rustls"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-untrusted = "0.5"
+untrusted = "0.5.1"
 time = "0.1.37"
 base64 = "0.6"
 log = { version = "0.3.6", optional = true }
-ring = { version = "0.11", features = ["rsa_signing"] }
-webpki = "0.16"
-sct = "0.1.2"
+ring = { version = "0.12", features = ["rsa_signing"] }
+webpki = "0.17"
+sct = "0.2"
 
 [features]
 default = ["logging"]
@@ -31,7 +31,7 @@ docopt = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 webpki-roots = "0.13"
-ct-logs = "0.1"
+ct-logs = "0.2"
 regex = "0.2"
 
 [[example]]

--- a/examples/internal/trytls_shim.rs
+++ b/examples/internal/trytls_shim.rs
@@ -25,7 +25,7 @@ fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<Error>
     let mut config = ClientConfig::new();
     match args.len() {
         3 => {
-            config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+            config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
         }
         4 => {
             let f = File::open(&args[3])?;

--- a/examples/simpleclient.rs
+++ b/examples/simpleclient.rs
@@ -8,7 +8,7 @@ extern crate webpki_roots;
 
 fn main() {
     let mut config = rustls::ClientConfig::new();
-    config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+    config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 
     let mut sess = rustls::ClientSession::new(&Arc::new(config), "google.com");
     let mut sock = TcpStream::connect("google.com:443").unwrap();

--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -438,7 +438,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
             .add_pem_file(&mut reader)
             .unwrap();
     } else {
-        config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
         config.ct_logs = Some(&ct_logs::LOGS);
     }
 

--- a/src/anchors.rs
+++ b/src/anchors.rs
@@ -87,7 +87,9 @@ impl RootCertStore {
 
     /// Adds all the given TrustAnchors `anchors`.  This does not
     /// fail.
-    pub fn add_trust_anchors(&mut self, anchors: &[webpki::TrustAnchor]) {
+    pub fn add_server_trust_anchors(&mut self,
+                                    &webpki::TLSServerTrustAnchors(anchors):
+                                        &webpki::TLSServerTrustAnchors) {
         for ta in anchors {
             self.roots.push(OwnedTrustAnchor::from_trust_anchor(ta));
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,9 @@ pub enum TLSError {
 
     /// A catch-all error for unlikely errors.
     General(String),
+
+    /// We failed to figure out what time it currently is.
+    FailedToGetCurrentTime,
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -117,7 +120,8 @@ impl Error for TLSError {
             TLSError::AlertReceived(_) => "received fatal alert",
             TLSError::WebPKIError(_) => "invalid certificate",
             TLSError::InvalidSCT(_) => "invalid certificate timestamp",
-            TLSError::General(_) => "unexpected error", // (please file a bug)
+            TLSError::General(_) => "unexpected error", // (please file a bug),
+            TLSError::FailedToGetCurrentTime => "failed to get current time",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //! the Mozilla set of root certificates.
 //!
 //! ```rust,ignore
-//! config.root_store.add_trust_anchors(&webpki_roots::ROOTS);
+//! config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 //! ```
 //!
 //! Now we can make a session.  You need to provide the server's hostname so we
@@ -194,7 +194,7 @@ extern crate webpki;
 // *ring* for cryptography.
 extern crate ring;
 
-// time for feeding webpki the time.
+// TODO: Remove this dependency.
 extern crate time;
 
 // untrusted for feeding ring and webpki.

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -7,10 +7,11 @@
 use std::time::{Duration, Instant};
 
 use anchors;
+use error::TLSError;
 use verify;
 use verify::ServerCertVerifier;
 use key;
-use time;
+use webpki;
 
 extern crate webpki_roots;
 
@@ -36,11 +37,8 @@ fn bench<Fsetup, Ftest, S>(count: usize, name: &'static str, f_setup: Fsetup, f_
              times.iter().min().unwrap() / 1000);
 }
 
-fn fixed_time() -> time::Timespec {
-    time::Timespec {
-        sec: 1500000000,
-        nsec: 0,
-    }
+fn fixed_time() -> Result<webpki::Time, TLSError> {
+    Ok(webpki::Time::from_seconds_since_unix_epoch(1500000000))
 }
 
 static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier {
@@ -53,7 +51,7 @@ fn test_reddit_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-reddit.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(reddit)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "reddit.com", &[]).unwrap(); });
@@ -65,7 +63,7 @@ fn test_github_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-github.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(github)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "github.com", &[]).unwrap(); });
@@ -78,7 +76,7 @@ fn test_arstechnica_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-arstechnica.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(arstechnica)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "arstechnica.com", &[]).unwrap(); });
@@ -91,7 +89,7 @@ fn test_servo_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-servo.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(servo)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "servo.org", &[]).unwrap(); });
@@ -103,7 +101,7 @@ fn test_twitter_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-twitter.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(twitter)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "twitter.com", &[]).unwrap(); });
@@ -115,7 +113,7 @@ fn test_wikipedia_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-wikipedia.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(wikipedia)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "wikipedia.org", &[]).unwrap(); });
@@ -128,7 +126,7 @@ fn test_google_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-google.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(google)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "www.google.com", &[]).unwrap(); });
@@ -141,7 +139,7 @@ fn test_hn_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-hn.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(hn)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "news.ycombinator.com", &[]).unwrap(); });
@@ -153,7 +151,7 @@ fn test_stackoverflow_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-stackoverflow.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(stackoverflow)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "stackoverflow.com", &[]).unwrap(); });
@@ -165,7 +163,7 @@ fn test_duckduckgo_cert() {
     let cert1 = key::Certificate(include_bytes!("testdata/cert-duckduckgo.1.der").to_vec());
     let chain = [ cert0, cert1 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(duckduckgo)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "duckduckgo.com", &[]).unwrap(); });
@@ -178,7 +176,7 @@ fn test_rustlang_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-rustlang.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(rustlang)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "www.rust-lang.org", &[]).unwrap(); });
@@ -191,7 +189,7 @@ fn test_wapo_cert() {
     let cert2 = key::Certificate(include_bytes!("testdata/cert-wapo.2.der").to_vec());
     let chain = [ cert0, cert1, cert2 ];
     let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_trust_anchors(&webpki_roots::ROOTS);
+    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(wapo)", 
           || (),
           |_| { V.verify_server_cert(&anchors, &chain[..], "www.washingtonpost.com", &[]).unwrap(); });


### PR DESCRIPTION
* Ensure Rust 1.20 compatibility, possibly breaking compatibility with older versions (it seems to work with Rust 1.19 at least).

* Prepare for better client authentication, breaking API due to webpki and webpki-roots API changes.