### PR TITLE
Give the certificate resolver a webpki::DNSNameRef.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ untrusted = "0.5.1"
 base64 = "0.6"
 log = { version = "0.3.6", optional = true }
 ring = { version = "0.12", features = ["rsa_signing"] }
-webpki = "0.17"
+webpki = { git = "https://github.com/briansmith/webpki" }
 sct = "0.2"
 
 [features]
@@ -29,7 +29,7 @@ mio = "0.6"
 docopt = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
-webpki-roots = "0.13"
+webpki-roots = { git = "https://github.com/briansmith/webpki-roots", branch = "webpki-github" }
 ct-logs = "0.2"
 regex = "0.2"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,9 @@ pub enum TLSError {
 
     /// We failed to figure out what time it currently is.
     FailedToGetCurrentTime,
+
+    /// A syntactically-invalid DNS hostname was given.
+    InvalidDNSName(String),
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -122,6 +125,7 @@ impl Error for TLSError {
             TLSError::InvalidSCT(_) => "invalid certificate timestamp",
             TLSError::General(_) => "unexpected error", // (please file a bug),
             TLSError::FailedToGetCurrentTime => "failed to get current time",
+            TLSError::InvalidDNSName(_) => "Invalid DNS name",
         }
     }
 }

--- a/src/msgs/handshake.rs
+++ b/src/msgs/handshake.rs
@@ -371,21 +371,6 @@ impl ConvertServerNameList for ServerNameRequest {
     }
 }
 
-pub fn same_hostname_or_both_none(a: Option<&ServerName>,
-                                  b: Option<&ServerName>) -> bool {
-    match (a, b) {
-        (Some(a), Some(b)) => {
-            match (&a.payload, &b.payload) {
-                (&ServerNamePayload::HostName(ref a_str),
-                 &ServerNamePayload::HostName(ref b_str)) => a_str == b_str,
-                (_, _) => false,
-            }
-        },
-        (None, None) => true,
-        _ => false,
-    }
-}
-
 pub type ProtocolNameList = VecU16OfPayloadU8;
 
 pub trait ConvertProtocolNameList {

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -1005,11 +1005,10 @@ impl State for ExpectClientHello {
 
         // Choose a certificate.
         let mut certkey = {
-            let sni_str: Option<&str> =
-                sni.as_ref().map(|dns_name| dns_name.as_ref().into());
-            debug!("sni {:?}", sni_str);
+            let sni_ref = sni.as_ref().map(|dns_name| dns_name.as_ref());
+            debug!("sni {:?}", sni_ref);
             debug!("sig schemes {:?}", sigschemes_ext);
-            let certkey = sess.config.cert_resolver.resolve(sni_str, sigschemes_ext);
+            let certkey = sess.config.cert_resolver.resolve(sni_ref, sigschemes_ext);
             certkey.ok_or_else(|| {
                 sess.common.send_fatal_alert(AlertDescription::AccessDenied);
                 TLSError::General("no server certificate chain resolved".to_string())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -92,7 +92,7 @@ pub trait ResolvesServerCert : Send + Sync {
     /// The certificate chain is returned as a vec of `Certificate`s,
     /// the key is inside a `SigningKey`.
     fn resolve(&self,
-               server_name: Option<&str>,
+               server_name: Option<webpki::DNSNameRef>,
                sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey>;
 }
@@ -239,7 +239,7 @@ struct FailResolveChain {}
 
 impl ResolvesServerCert for FailResolveChain {
     fn resolve(&self,
-               _server_name: Option<&str>,
+               _server_name: Option<webpki::DNSNameRef>,
                _sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey> {
         None
@@ -274,7 +274,7 @@ impl AlwaysResolvesChain {
 
 impl ResolvesServerCert for AlwaysResolvesChain {
     fn resolve(&self,
-               _server_name: Option<&str>,
+               _server_name: Option<webpki::DNSNameRef>,
                _sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey> {
         Some(self.0.clone())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -93,7 +93,11 @@ impl ServerCertVerifier for WebPKIVerifier {
             info!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
         }
 
-        cert.verify_is_valid_for_dns_name(untrusted::Input::from(dns_name.as_bytes()))
+        let dns_name = webpki::DNSNameRef::try_from_ascii(
+                untrusted::Input::from(dns_name.as_bytes()))
+            .map_err(|()| TLSError::InvalidDNSName(dns_name.into()))?;
+
+        cert.verify_is_valid_for_dns_name(dns_name)
             .map_err(TLSError::WebPKIError)
             .map(|_| ServerCertVerified::assertion())
     }


### PR DESCRIPTION
Allow the resolver to rely on the fact that the name is a valid DNS
name. In particular it allows it to know that the DNS name is given
in the IDN ASCII (punycode) encoding.