### PR TITLE
Take the DNS hostname as a webpki::DNSNameRef in ClientSession.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ untrusted = "0.5.1"
 base64 = "0.6"
 log = { version = "0.3.6", optional = true }
 ring = { version = "0.12", features = ["rsa_signing"] }
-webpki = "0.17"
+webpki = { git = "https://github.com/briansmith/webpki" }
 sct = "0.2"
 
 [features]
@@ -29,7 +29,7 @@ mio = "0.6"
 docopt = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
-webpki-roots = "0.13"
+webpki-roots = { git = "https://github.com/briansmith/webpki-roots", branch = "webpki-github" }
 ct-logs = "0.2"
 regex = "0.2"
 

--- a/examples/internal/bench.rs
+++ b/examples/internal/bench.rs
@@ -18,6 +18,8 @@ use rustls::Ticketer;
 use rustls::internal::pemfile;
 use rustls::internal::msgs::enums::SignatureAlgorithm;
 
+extern crate webpki;
+
 fn duration_nanos(d: Duration) -> f64 {
     (d.as_secs() as f64) + (d.subsec_nanos() as f64) / 1e9
 }
@@ -179,7 +181,8 @@ fn bench_handshake(version: rustls::ProtocolVersion,
     let mut server_time = 0f64;
 
     for _ in 0..rounds {
-        let mut client = ClientSession::new(&client_config, "localhost");
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+        let mut client = ClientSession::new(&client_config, dns_name);
         let mut server = ServerSession::new(&server_config);
 
         server_time += time(|| {
@@ -240,7 +243,8 @@ fn bench_bulk(version: rustls::ProtocolVersion, suite: &'static rustls::Supporte
         return;
     }
 
-    let mut client = ClientSession::new(&client_config, "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&client_config, dns_name);
     let mut server = ServerSession::new(&server_config);
 
     do_handshake(&mut client, &mut server);

--- a/examples/internal/bogo_shim.rs
+++ b/examples/internal/bogo_shim.rs
@@ -141,7 +141,7 @@ impl rustls::ServerCertVerifier for NoVerification {
     fn verify_server_cert(&self,
                           _roots: &rustls::RootCertStore,
                           _certs: &[rustls::Certificate],
-                          _hostname: &str,
+                          _hostname: webpki::DNSNameRef,
                           _ocsp: &[u8]) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
         Ok(rustls::ServerCertVerified::assertion())
     }
@@ -534,8 +534,10 @@ fn main() {
             let s = Box::new(rustls::ServerSession::new(server_cfg.as_ref().unwrap()));
             s as Box<rustls::Session>
         } else {
+            let dns_name =
+                webpki::DNSNameRef::try_from_ascii_str(&opts.host_name).unwrap();
             let s = Box::new(rustls::ClientSession::new(client_cfg.as_ref().unwrap(),
-                                                        &opts.host_name));
+                                                        dns_name));
             s as Box<rustls::Session>
         }
     };

--- a/examples/internal/trytls_shim.rs
+++ b/examples/internal/trytls_shim.rs
@@ -5,6 +5,7 @@
 //
 
 extern crate rustls;
+extern crate webpki;
 extern crate webpki_roots;
 
 use std::io::{Read, Write, BufReader};
@@ -43,8 +44,9 @@ fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<Error>
 }
 
 fn communicate(host: String, port: u16, config: ClientConfig) -> Result<Verdict, Box<Error>> {
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str(&host).unwrap();
     let rc_config = Arc::new(config);
-    let mut client = ClientSession::new(&rc_config, &host);
+    let mut client = ClientSession::new(&rc_config, dns_name);
     let mut stream = TcpStream::connect((&*host, port))?;
 
     client.write_all(b"GET / HTTP/1.0\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")?;

--- a/examples/simpleclient.rs
+++ b/examples/simpleclient.rs
@@ -4,13 +4,15 @@ use std::net::TcpStream;
 use std::io::{Read, Write, stdout};
 
 extern crate rustls;
+extern crate webpki;
 extern crate webpki_roots;
 
 fn main() {
     let mut config = rustls::ClientConfig::new();
     config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 
-    let mut sess = rustls::ClientSession::new(&Arc::new(config), "google.com");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("google.com").unwrap();
+    let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut sess, &mut sock);
     tls.write(concat!("GET / HTTP/1.1\r\n",

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
+extern crate webpki;
 
 use rustls::{ClientConfig, ClientSession, Session};
 use std::io;
@@ -8,6 +9,7 @@ use std::sync::Arc;
 
 fuzz_target!(|data: &[u8]| {
     let config = Arc::new(ClientConfig::new());
-    let mut client = ClientSession::new(&config, "example.com");
+    let example_com = webpki::DNSNameRef::try_from_ascii_str("example.com").unwrap();
+    let mut client = ClientSession::new(&config, example_com);
     let _ = client.read_tls(&mut io::Cursor::new(data));
 });

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -10,6 +10,7 @@ use session::SessionRandoms;
 use hash_hs;
 use sign;
 use suites;
+use webpki;
 
 use std::mem;
 
@@ -53,18 +54,18 @@ pub struct HandshakeDetails {
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub session_id: SessionID,
-    pub dns_name: String,
+    pub dns_name: webpki::DNSName,
 }
 
 impl HandshakeDetails {
-    pub fn new(host_name: &str) -> HandshakeDetails {
+    pub fn new(host_name: webpki::DNSName) -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
             resuming_session: None,
             randoms: SessionRandoms::for_client(),
             using_ems: false,
             session_id: SessionID::empty(),
-            dns_name: host_name.to_string(),
+            dns_name: host_name,
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,6 +18,7 @@ use std::io;
 use std::fmt;
 
 use sct;
+use webpki;
 
 mod hs;
 mod common;
@@ -324,7 +325,8 @@ impl fmt::Debug for ClientSessionImpl {
 }
 
 impl ClientSessionImpl {
-    pub fn new(config: &Arc<ClientConfig>, hostname: &str) -> ClientSessionImpl {
+    pub fn new(config: &Arc<ClientConfig>, hostname: webpki::DNSName)
+               -> ClientSessionImpl {
         let mut cs = ClientSessionImpl {
             config: config.clone(),
             secrets: None,
@@ -520,8 +522,8 @@ impl ClientSession {
     /// Make a new ClientSession.  `config` controls how
     /// we behave in the TLS protocol, `hostname` is the
     /// hostname of who we want to talk to.
-    pub fn new(config: &Arc<ClientConfig>, hostname: &str) -> ClientSession {
-        ClientSession { imp: ClientSessionImpl::new(config, hostname) }
+    pub fn new(config: &Arc<ClientConfig>, hostname: webpki::DNSNameRef) -> ClientSession {
+        ClientSession { imp: ClientSessionImpl::new(config, hostname.into()) }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,9 @@ pub enum TLSError {
 
     /// We failed to figure out what time it currently is.
     FailedToGetCurrentTime,
+
+    /// A syntactically-invalid DNS hostname was given.
+    InvalidDNSName(String),
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -122,6 +125,7 @@ impl Error for TLSError {
             TLSError::InvalidSCT(_) => "invalid certificate timestamp",
             TLSError::General(_) => "unexpected error", // (please file a bug),
             TLSError::FailedToGetCurrentTime => "failed to get current time",
+            TLSError::InvalidDNSName(_) => "Invalid DNS name",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,13 @@
 //! know what to expect to find in the server's certificate.
 //!
 //! ```no_run
+//! # extern crate rustls;
+//! # extern crate webpki;
 //! # use std::sync::Arc;
 //! # let mut config = rustls::ClientConfig::new();
 //! let rc_config = Arc::new(config);
-//! let mut client = rustls::ClientSession::new(&rc_config, "example.com");
+//! let example_com = webpki::DNSNameRef::try_from_ascii_str("example.com").unwrap();
+//! let mut client = rustls::ClientSession::new(&rc_config, example_com);
 //! ```
 //!
 //! Now you should do appropriate IO for the `client` object.  If `client.wants_read()` yields

--- a/src/msgs/handshake.rs
+++ b/src/msgs/handshake.rs
@@ -371,21 +371,6 @@ impl ConvertServerNameList for ServerNameRequest {
     }
 }
 
-pub fn same_hostname_or_both_none(a: Option<&ServerName>,
-                                  b: Option<&ServerName>) -> bool {
-    match (a, b) {
-        (Some(a), Some(b)) => {
-            match (&a.payload, &b.payload) {
-                (&ServerNamePayload::HostName(ref a_str),
-                 &ServerNamePayload::HostName(ref b_str)) => a_str == b_str,
-                (_, _) => false,
-            }
-        },
-        (None, None) => true,
-        _ => false,
-    }
-}
-
 pub type ProtocolNameList = VecU16OfPayloadU8;
 
 pub trait ConvertProtocolNameList {

--- a/src/msgs/handshake.rs
+++ b/src/msgs/handshake.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 use std::collections;
 use std::mem;
 use key;
+use webpki;
 
 macro_rules! declare_u8_vec(
   ($name:ident, $itemtype:ty) => {
@@ -720,10 +721,11 @@ impl Codec for ClientExtension {
 
 impl ClientExtension {
     /// Make a basic SNI ServerNameRequest quoting `hostname`.
-    pub fn make_sni(hostname: &str) -> ClientExtension {
+    pub fn make_sni(dns_name: webpki::DNSNameRef) -> ClientExtension {
+        let dns_name_str: &str = dns_name.into();
         let name = ServerName {
             typ: ServerNameType::HostName,
-            payload: ServerNamePayload::HostName(hostname.to_string()),
+            payload: ServerNamePayload::HostName(dns_name_str.to_string()),
         };
 
         ClientExtension::ServerName(vec![ name ])

--- a/src/msgs/persist.rs
+++ b/src/msgs/persist.rs
@@ -35,17 +35,19 @@ impl Codec for ClientSessionKey {
 }
 
 impl ClientSessionKey {
-    pub fn session_for_dns_name(dns_name: &str) -> ClientSessionKey {
+    pub fn session_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
+        let dns_name_str: &str = dns_name.into();
         ClientSessionKey {
             kind: b"session",
-            dns_name: PayloadU8::new(dns_name.as_bytes().to_vec()),
+            dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),
         }
     }
 
-    pub fn hint_for_dns_name(dns_name: &str) -> ClientSessionKey {
+    pub fn hint_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
+        let dns_name_str: &str = dns_name.into();
         ClientSessionKey {
             kind: b"kx-hint",
-            dns_name: PayloadU8::new(dns_name.as_bytes().to_vec()),
+            dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),
         }
     }
 }

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -1005,11 +1005,10 @@ impl State for ExpectClientHello {
 
         // Choose a certificate.
         let mut certkey = {
-            let sni_str: Option<&str> =
-                sni.as_ref().map(|dns_name| dns_name.as_ref().into());
-            debug!("sni {:?}", sni_str);
+            let sni_ref = sni.as_ref().map(|dns_name| dns_name.as_ref());
+            debug!("sni {:?}", sni_ref);
             debug!("sig schemes {:?}", sigschemes_ext);
-            let certkey = sess.config.cert_resolver.resolve(sni_str, sigschemes_ext);
+            let certkey = sess.config.cert_resolver.resolve(sni_ref, sigschemes_ext);
             certkey.ok_or_else(|| {
                 sess.common.send_fatal_alert(AlertDescription::AccessDenied);
                 TLSError::General("no server certificate chain resolved".to_string())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -92,7 +92,7 @@ pub trait ResolvesServerCert : Send + Sync {
     /// The certificate chain is returned as a vec of `Certificate`s,
     /// the key is inside a `SigningKey`.
     fn resolve(&self,
-               server_name: Option<&str>,
+               server_name: Option<webpki::DNSNameRef>,
                sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey>;
 }
@@ -239,7 +239,7 @@ struct FailResolveChain {}
 
 impl ResolvesServerCert for FailResolveChain {
     fn resolve(&self,
-               _server_name: Option<&str>,
+               _server_name: Option<webpki::DNSNameRef>,
                _sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey> {
         None
@@ -274,7 +274,7 @@ impl AlwaysResolvesChain {
 
 impl ResolvesServerCert for AlwaysResolvesChain {
     fn resolve(&self,
-               _server_name: Option<&str>,
+               _server_name: Option<webpki::DNSNameRef>,
                _sigschemes: &[SignatureScheme])
                -> Option<sign::CertifiedKey> {
         Some(self.0.clone())

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -93,7 +93,11 @@ impl ServerCertVerifier for WebPKIVerifier {
             info!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
         }
 
-        cert.verify_is_valid_for_dns_name(untrusted::Input::from(dns_name.as_bytes()))
+        let dns_name = webpki::DNSNameRef::try_from_ascii(
+                untrusted::Input::from(dns_name.as_bytes()))
+            .map_err(|()| TLSError::InvalidDNSName(dns_name.into()))?;
+
+        cert.verify_is_valid_for_dns_name(dns_name)
             .map_err(TLSError::WebPKIError)
             .map(|_| ServerCertVerified::assertion())
     }

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -54,7 +54,11 @@ fn test_reddit_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(reddit)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "reddit.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("reddit.com")
+          .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -66,7 +70,11 @@ fn test_github_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(github)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "github.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("github.com")
+          .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -79,7 +87,11 @@ fn test_arstechnica_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(arstechnica)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "arstechnica.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("arstechnica.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -92,7 +104,11 @@ fn test_servo_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(servo)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "servo.org", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("servo.org")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -104,7 +120,10 @@ fn test_twitter_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(twitter)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "twitter.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("twitter.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap(); });
 }
 
 #[test]
@@ -116,7 +135,11 @@ fn test_wikipedia_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(wikipedia)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "wikipedia.org", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("wikipedia.org")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -129,7 +152,11 @@ fn test_google_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(google)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "www.google.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.google.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -142,7 +169,11 @@ fn test_hn_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(hn)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "news.ycombinator.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("news.ycombinator.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -154,7 +185,11 @@ fn test_stackoverflow_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(stackoverflow)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "stackoverflow.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("stackoverflow.com")
+          .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -166,7 +201,11 @@ fn test_duckduckgo_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(duckduckgo)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "duckduckgo.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("duckduckgo.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -179,7 +218,11 @@ fn test_rustlang_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(rustlang)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "www.rust-lang.org", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.rust-lang.org")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 
 #[test]
@@ -192,6 +235,10 @@ fn test_wapo_cert() {
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     bench(100, "verify_server_cert(wapo)", 
           || (),
-          |_| { V.verify_server_cert(&anchors, &chain[..], "www.washingtonpost.com", &[]).unwrap(); });
+          |_| {
+        let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.washingtonpost.com")
+            .unwrap();
+        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+    });
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -93,7 +93,8 @@ fn alpn_test(server_protos: Vec<String>, client_protos: Vec<String>, agreed: Opt
     client_config.alpn_protocols = client_protos;
     server_config.alpn_protocols = server_protos;
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     assert_eq!(client.get_alpn_protocol(), None);
@@ -147,7 +148,8 @@ fn version_test(client_versions: Vec<ProtocolVersion>,
         server_config.versions = server_versions;
     }
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     assert_eq!(client.get_protocol_version(), None);
@@ -208,7 +210,8 @@ fn check_read(reader: &mut io::Read, bytes: &[u8]) {
 fn buffered_client_data_sent() {
     let client_config = make_client_config();
     let server_config = make_server_config();
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     assert_eq!(5, client.write(b"hello").unwrap());
@@ -224,7 +227,8 @@ fn buffered_client_data_sent() {
 fn buffered_server_data_sent() {
     let client_config = make_client_config();
     let server_config = make_server_config();
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     assert_eq!(5, server.write(b"hello").unwrap());
@@ -240,7 +244,8 @@ fn buffered_server_data_sent() {
 fn buffered_both_data_sent() {
     let client_config = make_client_config();
     let server_config = make_server_config();
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     assert_eq!(12, server.write(b"from-server!").unwrap());
@@ -261,7 +266,8 @@ fn buffered_both_data_sent() {
 fn client_can_get_server_cert() {
     let client_config = make_client_config();
     let server_config = make_server_config();
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     do_handshake(&mut client, &mut server);
@@ -278,7 +284,8 @@ fn server_can_get_client_cert() {
     server_config.set_client_auth_roots(get_chain(), true);
     client_config.set_single_client_cert(get_chain(), get_key());
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     do_handshake(&mut client, &mut server);
@@ -306,7 +313,8 @@ fn server_close_notify() {
     server_config.set_client_auth_roots(get_chain(), true);
     client_config.set_single_client_cert(get_chain(), get_key());
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     do_handshake(&mut client, &mut server);
@@ -333,7 +341,8 @@ fn client_close_notify() {
     server_config.set_client_auth_roots(get_chain(), true);
     client_config.set_single_client_cert(get_chain(), get_key());
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     do_handshake(&mut client, &mut server);
@@ -393,7 +402,8 @@ fn server_cert_resolve_with_sni() {
 
     server_config.cert_resolver = Arc::new(ServerCheckCertResolve::new("the-value-from-sni"));
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "the-value-from-sni");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("the-value-from-sni").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -405,7 +415,8 @@ fn server_checks_own_certificate_against_sni() {
     let client_config = make_client_config();
     let server_config = make_server_config();
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "not-the-right-hostname.com");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("not-the-right-hostname.com").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -439,7 +450,8 @@ fn server_checks_own_certificate_chain_for_emptiness() {
     let badcert_resolver = Arc::new(ServerBadCertResolver(real_resolver, CertInvalid::EmptyChain));
     server_config.cert_resolver = badcert_resolver;
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -455,7 +467,8 @@ fn server_checks_own_certificate_for_validity() {
     let badcert_resolver = Arc::new(ServerBadCertResolver(real_resolver, CertInvalid::BadDER));
     server_config.cert_resolver = badcert_resolver;
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -514,7 +527,8 @@ fn client_cert_resolve() {
     client_config.client_auth_cert_resolver = Arc::new(ClientCheckCertResolve::new(1));
     server_config.set_client_auth_roots(get_chain(), true);
 
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     let mut server = ServerSession::new(&Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -524,7 +538,8 @@ fn client_cert_resolve() {
 #[test]
 fn client_error_is_sticky() {
     let client_config = make_client_config();
-    let mut client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(client_config), dns_name);
     client.read_tls(&mut b"\x16\x03\x03\x00\x08\x0f\x00\x00\x04junk".as_ref()).unwrap();
     let mut err = client.process_new_packets();
     assert_eq!(err.is_err(), true);
@@ -553,13 +568,15 @@ fn server_is_send() {
 #[test]
 fn client_is_send() {
     let client_config = make_client_config();
-    let client = ClientSession::new(&Arc::new(client_config), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let client = ClientSession::new(&Arc::new(client_config), dns_name);
     &client as &Send;
 }
 
 #[test]
 fn server_respects_buffer_limit_pre_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     server.set_buffer_limit(32);
@@ -576,7 +593,8 @@ fn server_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn server_respects_buffer_limit_post_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     // this test will vary in behaviour depending on the default suites
@@ -594,7 +612,8 @@ fn server_respects_buffer_limit_post_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_pre_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     client.set_buffer_limit(32);
@@ -611,7 +630,8 @@ fn client_respects_buffer_limit_pre_handshake() {
 
 #[test]
 fn client_respects_buffer_limit_post_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     do_handshake(&mut client, &mut server);
@@ -673,7 +693,8 @@ impl<'a> io::Write for OtherSession<'a> {
 
 #[test]
 fn client_complete_io_for_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     assert_eq!(true, client.is_handshaking());
@@ -684,7 +705,8 @@ fn client_complete_io_for_handshake() {
 
 #[test]
 fn client_complete_io_for_handshake_eof() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut input = io::Cursor::new(Vec::new());
 
     assert_eq!(true, client.is_handshaking());
@@ -694,7 +716,8 @@ fn client_complete_io_for_handshake_eof() {
 
 #[test]
 fn client_complete_io_for_write() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     do_handshake(&mut client, &mut server);
@@ -712,7 +735,8 @@ fn client_complete_io_for_write() {
 
 #[test]
 fn client_complete_io_for_read() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     do_handshake(&mut client, &mut server);
@@ -729,7 +753,8 @@ fn client_complete_io_for_read() {
 
 #[test]
 fn server_complete_io_for_handshake() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     assert_eq!(true, server.is_handshaking());
@@ -750,7 +775,8 @@ fn server_complete_io_for_handshake_eof() {
 
 #[test]
 fn server_complete_io_for_write() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     do_handshake(&mut client, &mut server);
@@ -768,7 +794,8 @@ fn server_complete_io_for_write() {
 
 #[test]
 fn server_complete_io_for_read() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     do_handshake(&mut client, &mut server);
@@ -785,7 +812,8 @@ fn server_complete_io_for_read() {
 
 #[test]
 fn client_stream_write() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     {
@@ -798,7 +826,8 @@ fn client_stream_write() {
 
 #[test]
 fn client_stream_read() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     server.write(b"world").unwrap();
@@ -812,7 +841,8 @@ fn client_stream_read() {
 
 #[test]
 fn server_stream_write() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     {
@@ -825,7 +855,8 @@ fn server_stream_write() {
 
 #[test]
 fn server_stream_read() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     client.write(b"world").unwrap();
@@ -849,7 +880,8 @@ fn client_config_is_clone() {
 
 #[test]
 fn client_session_is_debug() {
-    let client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     println!("{:?}", client);
 }
 
@@ -861,7 +893,8 @@ fn server_session_is_debug() {
 
 #[test]
 fn server_complete_io_for_handshake_ending_with_alert() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "localhost");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server_config = make_server_config();
     server_config.ciphersuites = vec![];
     let mut server = ServerSession::new(&Arc::new(server_config));
@@ -881,7 +914,9 @@ fn server_complete_io_for_handshake_ending_with_alert() {
 
 #[test]
 fn server_exposes_offered_sni() {
-    let mut client = ClientSession::new(&Arc::new(make_client_config()), "second.testserver.com");
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str("second.testserver.com")
+        .unwrap();
+    let mut client = ClientSession::new(&Arc::new(make_client_config()), dns_name);
     let mut server = ServerSession::new(&Arc::new(make_server_config()));
 
     assert_eq!(None, server.get_sni_hostname());


### PR DESCRIPTION
Make it clear that the name passed into ClientSession is a DNS name
and cannot be empty (""), an IP address, an internationalized domain
name, etc. It has to be a DNS hostname because it is put into the SNI
extension in the client hello.
