### PR TITLE
Split and rename WebPKIClientAuth.

### DIFF
--- a/examples/internal/bench.rs
+++ b/examples/internal/bench.rs
@@ -13,7 +13,7 @@ use rustls::{ClientConfig, ClientSession};
 use rustls::{ServerConfig, ServerSession};
 use rustls::ServerSessionMemoryCache;
 use rustls::ClientSessionMemoryCache;
-use rustls::{NoClientAuth, RootCertStore, WebPKIClientAuth};
+use rustls::{NoClientAuth, RootCertStore, AllowAnyAuthenticatedClient};
 use rustls::Session;
 use rustls::Ticketer;
 use rustls::internal::pemfile;
@@ -129,7 +129,7 @@ fn make_server_config(version: rustls::ProtocolVersion,
             for root in roots {
                 client_auth_roots.add(&root).unwrap();
             }
-            WebPKIClientAuth::mandatory(client_auth_roots)
+            AllowAnyAuthenticatedClient::new(client_auth_roots)
         },
         &ClientAuth::No => {
             NoClientAuth::new()

--- a/examples/tlsserver.rs
+++ b/examples/tlsserver.rs
@@ -21,7 +21,8 @@ extern crate env_logger;
 
 extern crate rustls;
 
-use rustls::{RootCertStore, Session, NoClientAuth, WebPKIClientAuth};
+use rustls::{RootCertStore, Session, NoClientAuth, AllowAnyAuthenticatedClient,
+             AllowAnyAnonymousOrAuthenticatedClient};
 
 // Token for our listening socket.
 const LISTENER: mio::Token = mio::Token(0);
@@ -505,9 +506,9 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
             client_auth_roots.add(&root).unwrap();
         }
         if args.flag_require_auth {
-            WebPKIClientAuth::mandatory(client_auth_roots)
+            AllowAnyAuthenticatedClient::new(client_auth_roots)
         } else {
-            WebPKIClientAuth::optional(client_auth_roots)
+            AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots)
         }
     } else {
         NoClientAuth::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,8 @@ pub use server::{ServerConfig, ServerSession};
 pub use server::ResolvesServerCert;
 pub use server::ProducesTickets;
 pub use ticketer::Ticketer;
-pub use verify::{NoClientAuth, WebPKIClientAuth};
+pub use verify::{NoClientAuth, AllowAnyAuthenticatedClient,
+                 AllowAnyAnonymousOrAuthenticatedClient};
 pub use suites::{ALL_CIPHERSUITES, SupportedCipherSuite};
 pub use key::{Certificate, PrivateKey};
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -276,7 +276,7 @@ impl ServerConfig {
     ///
     /// Publicly-available web servers on the internet generally don't do client
     /// authentication; for this use case, `client_cert_verifier` should be a
-    /// `NoClientAuth`. Otherwise, use `WebPKIClientAuth` or another
+    /// `NoClientAuth`. Otherwise, use `AllowAnyAuthenticatedClient` or another
     /// implementation to enforce client authentication.
     //
     // We don't provide a default for `client_cert_verifier` because the safest

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -15,7 +15,7 @@ use rustls::TLSError;
 use rustls::sign;
 use rustls::{Certificate, PrivateKey};
 use rustls::internal::pemfile;
-use rustls::{RootCertStore, NoClientAuth, WebPKIClientAuth};
+use rustls::{RootCertStore, NoClientAuth, AllowAnyAuthenticatedClient};
 
 extern crate webpki;
 
@@ -64,7 +64,8 @@ fn make_server_config_with_mandatory_client_auth() -> ServerConfig {
         client_auth_roots.add(&root).unwrap();
     }
 
-    let mut cfg = ServerConfig::new(WebPKIClientAuth::mandatory(client_auth_roots));
+    let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
+    let mut cfg = ServerConfig::new(client_auth);
     cfg.set_single_cert(get_chain(), get_key());
 
     cfg


### PR DESCRIPTION
The name WebPKIClientAuth will make less and less sense going forward
as we add new ways of authenticating and authorizing clients. The new
names also do a better job of emphasizing that no authorization by
name is being done.