### PR TITLE
Avoid cloning peer cert. chain in `get_peer_certificates()`.

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -489,17 +489,8 @@ impl ClientSessionImpl {
         Ok(())
     }
 
-    pub fn get_peer_certificates(&self) -> Option<Vec<key::Certificate>> {
-        if self.server_cert_chain.is_empty() {
-            return None;
-        }
-
-        let mut r = Vec::new();
-        for cert in &self.server_cert_chain {
-            r.push(cert.clone());
-        }
-
-        Some(r)
+    pub fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
+        Some(&self.server_cert_chain)
     }
 
     pub fn get_alpn_protocol(&self) -> Option<String> {
@@ -561,7 +552,7 @@ impl Session for ClientSession {
         self.imp.common.send_close_notify()
     }
 
-    fn get_peer_certificates(&self) -> Option<Vec<key::Certificate>> {
+    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
         self.imp.get_peer_certificates()
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -489,7 +489,7 @@ impl ClientSessionImpl {
         Ok(())
     }
 
-    pub fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
+    pub fn get_peer_certificates(&self) -> Option<&[key::Certificate]> {
         Some(&self.server_cert_chain)
     }
 
@@ -552,7 +552,7 @@ impl Session for ClientSession {
         self.imp.common.send_close_notify()
     }
 
-    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
+    fn get_peer_certificates(&self) -> Option<&[key::Certificate]> {
         self.imp.get_peer_certificates()
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -486,8 +486,8 @@ impl ServerSessionImpl {
         self.common.start_encryption_tls12(self.secrets.as_ref().unwrap());
     }
 
-    pub fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
-        self.client_cert_chain.as_ref()
+    pub fn get_peer_certificates(&self) -> Option<&[key::Certificate]> {
+        self.client_cert_chain.as_ref().map(|c| c.as_ref())
     }
 
     pub fn get_alpn_protocol(&self) -> Option<String> {
@@ -581,7 +581,7 @@ impl Session for ServerSession {
         self.imp.common.send_close_notify()
     }
 
-    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
+    fn get_peer_certificates(&self) -> Option<&[key::Certificate]> {
         self.imp.get_peer_certificates()
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -486,18 +486,8 @@ impl ServerSessionImpl {
         self.common.start_encryption_tls12(self.secrets.as_ref().unwrap());
     }
 
-    pub fn get_peer_certificates(&self) -> Option<Vec<key::Certificate>> {
-        if self.client_cert_chain.is_none() {
-            return None;
-        }
-
-        let mut r = Vec::new();
-
-        for cert in self.client_cert_chain.as_ref().unwrap() {
-            r.push(cert.clone());
-        }
-
-        Some(r)
+    pub fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
+        self.client_cert_chain.as_ref()
     }
 
     pub fn get_alpn_protocol(&self) -> Option<String> {
@@ -591,7 +581,7 @@ impl Session for ServerSession {
         self.imp.common.send_close_notify()
     }
 
-    fn get_peer_certificates(&self) -> Option<Vec<key::Certificate>> {
+    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>> {
         self.imp.get_peer_certificates()
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -83,7 +83,7 @@ pub trait Session: Read + Write + Send {
     /// if client authentication was completed.
     ///
     /// The return value is None until this value is available.
-    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>>;
+    fn get_peer_certificates(&self) -> Option<&[key::Certificate]>;
 
     /// Retrieves the protocol agreed with the peer via ALPN.
     ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -83,7 +83,7 @@ pub trait Session: Read + Write + Send {
     /// if client authentication was completed.
     ///
     /// The return value is None until this value is available.
-    fn get_peer_certificates(&self) -> Option<Vec<key::Certificate>>;
+    fn get_peer_certificates(&self) -> Option<&Vec<key::Certificate>>;
 
     /// Retrieves the protocol agreed with the peer via ALPN.
     ///

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -287,7 +287,7 @@ fn client_can_get_server_cert() {
     do_handshake(&mut client, &mut server);
 
     let certs = client.get_peer_certificates();
-    assert_eq!(certs, Some(&get_chain()));
+    assert_eq!(certs, Some(get_chain().as_ref()));
 }
 
 #[test]
@@ -303,7 +303,7 @@ fn server_can_get_client_cert() {
     do_handshake(&mut client, &mut server);
 
     let certs = server.get_peer_certificates();
-    assert_eq!(certs, Some(&get_chain()));
+    assert_eq!(certs, Some(get_chain().as_ref()));
 }
 
 fn check_read_and_close(reader: &mut io::Read, expect: &[u8]) {

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -287,7 +287,7 @@ fn client_can_get_server_cert() {
     do_handshake(&mut client, &mut server);
 
     let certs = client.get_peer_certificates();
-    assert_eq!(certs, Some(get_chain()));
+    assert_eq!(certs, Some(&get_chain()));
 }
 
 #[test]
@@ -303,7 +303,7 @@ fn server_can_get_client_cert() {
     do_handshake(&mut client, &mut server);
 
     let certs = server.get_peer_certificates();
-    assert_eq!(certs, Some(get_chain()));
+    assert_eq!(certs, Some(&get_chain()));
 }
 
 fn check_read_and_close(reader: &mut io::Read, expect: &[u8]) {


### PR DESCRIPTION
If the caller wants a copy, it can make its own copy.
