### PR TITLE
Avoid cloning ALPN protocol in `get_alpn_protocol()`.

### DIFF
--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -404,9 +404,9 @@ fn validate_server_hello_tls13(sess: &mut ClientSessionImpl,
 }
 
 fn process_alpn_protocol(sess: &mut ClientSessionImpl,
-                         proto: Option<String>)
+                         proto: Option<&str>)
                          -> Result<(), TLSError> {
-    sess.alpn_protocol = proto;
+    sess.alpn_protocol = proto.map(|s| s.to_owned());
     if sess.alpn_protocol.is_some() &&
         !sess.config.alpn_protocols.contains(sess.alpn_protocol.as_ref().unwrap()) {
         return Err(illegal_param(sess, "server sent non-offered ALPN protocol"));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -502,8 +502,8 @@ impl ClientSessionImpl {
         Some(r)
     }
 
-    pub fn get_alpn_protocol(&self) -> Option<String> {
-        self.alpn_protocol.clone()
+    pub fn get_alpn_protocol(&self) -> Option<&str> {
+        self.alpn_protocol.as_ref().map(|s| s.as_ref())
     }
 
     pub fn get_protocol_version(&self) -> Option<ProtocolVersion> {
@@ -565,7 +565,7 @@ impl Session for ClientSession {
         self.imp.get_peer_certificates()
     }
 
-    fn get_alpn_protocol(&self) -> Option<String> {
+    fn get_alpn_protocol(&self) -> Option<&str> {
         self.imp.get_alpn_protocol()
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -500,8 +500,8 @@ impl ServerSessionImpl {
         Some(r)
     }
 
-    pub fn get_alpn_protocol(&self) -> Option<String> {
-        self.alpn_protocol.clone()
+    pub fn get_alpn_protocol(&self) -> Option<&str> {
+        self.alpn_protocol.as_ref().map(|s| s.as_ref())
     }
 
     pub fn get_protocol_version(&self) -> Option<ProtocolVersion> {
@@ -595,7 +595,7 @@ impl Session for ServerSession {
         self.imp.get_peer_certificates()
     }
 
-    fn get_alpn_protocol(&self) -> Option<String> {
+    fn get_alpn_protocol(&self) -> Option<&str> {
         self.imp.get_alpn_protocol()
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -90,7 +90,7 @@ pub trait Session: Read + Write + Send {
     /// A return value of None after handshake completion
     /// means no protocol was agreed (because no protocols
     /// were offered or accepted by the peer).
-    fn get_alpn_protocol(&self) -> Option<String>;
+    fn get_alpn_protocol(&self) -> Option<&str>;
 
     /// Retrieves the protocol version agreed with the peer.
     ///

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -100,7 +100,7 @@ fn do_handshake_until_error(client: &mut ClientSession,
     Ok(())
 }
 
-fn alpn_test(server_protos: Vec<String>, client_protos: Vec<String>, agreed: Option<String>) {
+fn alpn_test(server_protos: Vec<String>, client_protos: Vec<String>, agreed: Option<&str>) {
     let mut client_config = make_client_config();
     let mut server_config = make_server_config();
 
@@ -137,7 +137,7 @@ fn alpn() {
     // server chooses preference
     alpn_test(vec!["server-proto".to_string(), "client-proto".to_string()],
               vec!["client-proto".to_string(), "server-proto".to_string()],
-              Some("server-proto".to_string()));
+              Some("server-proto"));
 
     // case sensitive
     alpn_test(vec!["PROTO".to_string()], vec!["proto".to_string()], None);


### PR DESCRIPTION
The caller can clone it if it wants to.