### PR TITLE
Use safer type ascription workaround in bogo_shim.rs.

### DIFF
--- a/examples/internal/bogo_shim.rs
+++ b/examples/internal/bogo_shim.rs
@@ -539,14 +539,16 @@ fn main() {
 
     let make_session = || {
         if opts.server {
-            let s = Box::new(rustls::ServerSession::new(server_cfg.as_ref().unwrap()));
-            s as Box<rustls::Session>
+            let s: Box<rustls::Session> =
+                Box::new(rustls::ServerSession::new(server_cfg.as_ref().unwrap()));
+            s
         } else {
             let dns_name =
                 webpki::DNSNameRef::try_from_ascii_str(&opts.host_name).unwrap();
-            let s = Box::new(rustls::ClientSession::new(client_cfg.as_ref().unwrap(),
-                                                        dns_name));
-            s as Box<rustls::Session>
+            let s: Box<rustls::Session> =
+                Box::new(rustls::ClientSession::new(client_cfg.as_ref().unwrap(),
+                                                    dns_name));
+            s
         }
     };
 


### PR DESCRIPTION
Avoid using `as` for type ascription, as `as` should be used only as a
last resort for potentially-dangerous casts.