### PR TITLE
Lower logging priority

### DIFF
--- a/examples/tlsserver.rs
+++ b/examples/tlsserver.rs
@@ -64,7 +64,7 @@ impl TlsServer {
     fn accept(&mut self, poll: &mut mio::Poll) -> bool {
         match self.server.accept() {
             Ok((socket, addr)) => {
-                info!("Accepting new connection from {:?}", addr);
+                debug!("Accepting new connection from {:?}", addr);
 
                 let tls_session = rustls::ServerSession::new(&self.tls_config);
                 let mode = self.mode.clone();
@@ -207,7 +207,7 @@ impl Connection {
         }
 
         if rc.unwrap() == 0 {
-            info!("eof");
+            debug!("eof");
             self.closing = true;
             return;
         }
@@ -233,7 +233,7 @@ impl Connection {
         }
 
         if !buf.is_empty() {
-            info!("plaintext read {:?}", buf.len());
+            debug!("plaintext read {:?}", buf.len());
             self.incoming_plaintext(&buf);
         }
     }
@@ -260,7 +260,7 @@ impl Connection {
         // Otherwise, we shove the data into the TLS session.
         match maybe_len {
             Some(len) if len == 0 => {
-                info!("back eof");
+                debug!("back eof");
                 self.closing = true;
             }
             Some(len) => {

--- a/src/anchors.rs
+++ b/src/anchors.rs
@@ -114,14 +114,14 @@ impl RootCertStore {
             match self.add(&der) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
-                    debug!("invalid cert der {:?}", der);
-                    info!("certificate parsing failed: {:?}", err);
+                    trace!("invalid cert der {:?}", der);
+                    debug!("certificate parsing failed: {:?}", err);
                     invalid_count += 1
                 }
             }
         }
 
-        info!("add_pem_file processed {} valid and {} invalid certs",
+        debug!("add_pem_file processed {} valid and {} invalid certs",
               valid_count,
               invalid_count);
 

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -114,7 +114,7 @@ impl ClientHelloDetails {
         for ext in received_exts {
             let ext_type = ext.get_type();
             if !self.sent_extensions.contains(&ext_type) && !allowed_unsolicited.contains(&ext_type) {
-                debug!("Unsolicited extension {:?}", ext_type);
+                trace!("Unsolicited extension {:?}", ext_type);
                 return true;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@
 //! they mean.
 //!
 //! - `logging`: this makes the rustls crate depend on the `log` crate.
-//!   rustls outputs interesting protocol-level messages at `debug!` and `info!`
+//!   rustls outputs interesting protocol-level messages at `trace!` and `debug!`
 //!   level, and protocol-level errors at `warn!` and `error!` level.  The log
 //!   messages do not contain secret key data, and so are safe to archive without
 //!   affecting session security.  This feature is in the default set.

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -107,7 +107,7 @@ impl ServerCertVerifier for WebPKIVerifier {
             .map(|_| cert)?;
 
         if !ocsp_response.is_empty() {
-            info!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
+            debug!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
         }
 
         cert.verify_is_valid_for_dns_name(dns_name)
@@ -362,7 +362,7 @@ pub fn verify_scts(cert: &Certificate,
     for sct in scts {
         match sct::verify_sct(&cert.0, &sct.0, now, logs) {
             Ok(index) => {
-                info!("Valid SCT signed by {} on {}",
+                debug!("Valid SCT signed by {} on {}",
                       logs[index].operated_by, logs[index].description);
                 valid_scts += 1;
             }
@@ -370,7 +370,7 @@ pub fn verify_scts(cert: &Certificate,
                 if e.should_be_fatal() {
                     return Err(TLSError::InvalidSCT(e));
                 }
-                info!("SCT ignored because {:?}", e);
+                debug!("SCT ignored because {:?}", e);
                 last_sct_error = Some(e);
             }
         }


### PR DESCRIPTION
This lowers the logging priority of debug messages to trace and info
messages to debug. This is done to allow consuming programs to log at
the info level without having to see messages from this library. Since
this library didn't previously use the trace level, these new priorities
are mapped one to one.