### PR TITLE
Don't verify SNI names match the certificate on the server side

### DIFF
--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -912,26 +912,14 @@ impl ExpectClientHello {
         })?;
 
         // Reject syntactically-invalid end-entity certificates.
-        let end_entity_cert = webpki::EndEntityCert::from(
-              untrusted::Input::from(end_entity_cert.as_ref())).map_err(|_| {
+        webpki::EndEntityCert::from(untrusted::Input::from(end_entity_cert.as_ref())).map_err(|_| {
             sess.common.send_fatal_alert(AlertDescription::InternalError);
             TLSError::General(
                 "end-entity certificate in certificate chain is syntactically invalid".to_string())
         })?;
 
         if let Some(ref sni) = sni {
-            // If SNI was offered then the certificate must be valid for
-            // that hostname. Note that this doesn't fully validate that the
-            // certificate is valid; it only validates that the name is one
-            // that the certificate is valid for, if the certificate is
-            // valid.
-            if !end_entity_cert.verify_is_valid_for_dns_name(sni.as_ref()).is_ok() {
-                sess.common.send_fatal_alert(AlertDescription::InternalError);
-                return Err(TLSError::General(
-                    "The server certificate is not valid for the given SNI name".to_string()));
-            }
-
-            // Save the SNI into the session after it's been validated.
+            // Save the SNI into the session
             sess.set_sni(sni.clone());
         }
 


### PR DESCRIPTION
I talked about this in issue #123.  @briansmith didn't seem to think this change is a good idea.  I just wanted to lay out what change I think is best, and why I think it's reasonable.

I realize that this change makes absolutely no sense to anyone doing HTTPS with normal PKI certificate verification.  But I feel that to be a generic TLS library, there must be some way to support having a server that sends whatever certificate is necessary and allow the client to verify it in whichever way it wants.

This change should make the following possible:

*  A server can send certificates without sub_alt_names (client can verify other ways)
*  A protocol that's IP based, instead of name-based (where any name that resolves works)
*  A protocol that can *optionally* use names provided by the client (or choose not to)
*  An HTTPS server may actually *want* to send an invalid certificate that causes an understandable client-side error "name doesn't match", rather than just failing the TLS negotiation.
*  `ServerConfig::set_single_cert(...)` can actually be used now to do what it was intended to do (always serve the same cert no matter what SNI says)

Downsides:

*  99% of the time, this error just indicates that a server just chose the wrong certificate, or the certificate used wasn't created correctly.  The previous code catches this case a little earlier instead of later on the client side.