### PR TITLE
Add Session::get_negotiated_ciphersuite()

### DIFF
--- a/examples/simpleclient.rs
+++ b/examples/simpleclient.rs
@@ -7,6 +7,8 @@ extern crate rustls;
 extern crate webpki;
 extern crate webpki_roots;
 
+use rustls::Session;
+
 fn main() {
     let mut config = rustls::ClientConfig::new();
     config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
@@ -22,7 +24,8 @@ fn main() {
                       "\r\n")
               .as_bytes())
         .unwrap();
-
+    let ciphersuite = tls.sess.get_negotiated_ciphersuite().unwrap();
+    writeln!(&mut std::io::stderr(), "Current ciphersuite: {:?}", ciphersuite.suite).unwrap();
     let mut plaintext = Vec::new();
     tls.read_to_end(&mut plaintext).unwrap();
     stdout().write_all(&plaintext).unwrap();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -419,6 +419,10 @@ impl ClientSessionImpl {
     pub fn get_protocol_version(&self) -> Option<ProtocolVersion> {
         self.common.negotiated_version
     }
+
+    pub fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
+        Some(self.common.get_suite())
+    }
 }
 
 /// This represents a single TLS client session.
@@ -481,6 +485,10 @@ impl Session for ClientSession {
 
     fn get_protocol_version(&self) -> Option<ProtocolVersion> {
         self.imp.get_protocol_version()
+    }
+
+    fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
+        self.imp.get_negotiated_ciphersuite()
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -373,6 +373,10 @@ impl ServerSessionImpl {
         self.common.negotiated_version
     }
 
+    pub fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
+        Some(self.common.get_suite())
+    }
+
     pub fn get_sni(&self)-> Option<&webpki::DNSName> {
         self.sni.as_ref()
     }
@@ -466,6 +470,10 @@ impl Session for ServerSession {
 
     fn get_protocol_version(&self) -> Option<ProtocolVersion> {
         self.imp.get_protocol_version()
+    }
+
+    fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
+        self.imp.get_negotiated_ciphersuite()
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -97,6 +97,11 @@ pub trait Session: Read + Write + Send + Sync {
     /// This returns None until the version is agreed.
     fn get_protocol_version(&self) -> Option<ProtocolVersion>;
 
+    /// Retrives the ciphersuite agreed with the peer.
+    ///
+    /// This returns None until the ciphersuite is agreed.
+    fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite>;
+
     /// This function uses `io` to complete any outstanding IO for
     /// this session.
     ///


### PR DESCRIPTION
rustls::SessionCommon already has a public get_suite().This PR adds a new API get_negotiated_ciphersuite() for ClientSession and ServerSession to access negotiated ciphersuite. 

This API panics if called prior to TLS negotiation, because SessionCommon:suite is None and SessionCommon::get_suite() unwraps it (see src/session.rs:375). 

The simpleclient example is modified to print the ciphersuite.