### PR TITLE
Make hostname argument optional

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -54,11 +54,11 @@ pub struct HandshakeDetails {
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub session_id: SessionID,
-    pub dns_name: webpki::DNSName,
+    pub dns_name: Option<webpki::DNSName>,
 }
 
 impl HandshakeDetails {
-    pub fn new(host_name: webpki::DNSName) -> HandshakeDetails {
+    pub fn new(host_name: Option<webpki::DNSName>) -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
             resuming_session: None,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -235,7 +235,7 @@ impl fmt::Debug for ClientSessionImpl {
 }
 
 impl ClientSessionImpl {
-    pub fn new(config: &Arc<ClientConfig>, hostname: webpki::DNSName)
+    pub fn new(config: &Arc<ClientConfig>, hostname: Option<webpki::DNSName>)
                -> ClientSessionImpl {
         let mut cs = ClientSessionImpl {
             config: config.clone(),
@@ -433,7 +433,14 @@ impl ClientSession {
     /// we behave in the TLS protocol, `hostname` is the
     /// hostname of who we want to talk to.
     pub fn new(config: &Arc<ClientConfig>, hostname: webpki::DNSNameRef) -> ClientSession {
-        ClientSession { imp: ClientSessionImpl::new(config, hostname.into()) }
+        ClientSession { imp: ClientSessionImpl::new(config, Some(hostname.into())) }
+    }
+
+    /// Make a new ClientSession. Like `new`, but no hostname
+    /// is required, no SNI extension will be sent, and no
+    /// certificate name validation will be performed.
+    pub fn new_without_hostname(config: &Arc<ClientConfig>) -> ClientSession {
+        ClientSession { imp: ClientSessionImpl::new(config, None) }
     }
 }
 

--- a/src/msgs/persist.rs
+++ b/src/msgs/persist.rs
@@ -35,16 +35,16 @@ impl Codec for ClientSessionKey {
 }
 
 impl ClientSessionKey {
-    pub fn session_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
-        let dns_name_str: &str = dns_name.into();
+    pub fn session_for_dns_name(dns_name: Option<webpki::DNSNameRef>) -> ClientSessionKey {
+        let dns_name_str: &str = dns_name.map_or("", |n| n.into());
         ClientSessionKey {
             kind: b"session",
             dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),
         }
     }
 
-    pub fn hint_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
-        let dns_name_str: &str = dns_name.into();
+    pub fn hint_for_dns_name(dns_name: Option<webpki::DNSNameRef>) -> ClientSessionKey {
+        let dns_name_str: &str = dns_name.map_or("", |n| n.into());
         ClientSessionKey {
             kind: b"kx-hint",
             dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -65,7 +65,7 @@ pub trait ServerCertVerifier : Send + Sync {
     fn verify_server_cert(&self,
                           roots: &RootCertStore,
                           presented_certs: &[Certificate],
-                          dns_name: webpki::DNSNameRef,
+                          dns_name_opt: Option<webpki::DNSNameRef>,
                           ocsp_response: &[u8]) -> Result<ServerCertVerified, TLSError>;
 }
 
@@ -97,7 +97,7 @@ impl ServerCertVerifier for WebPKIVerifier {
     fn verify_server_cert(&self,
                           roots: &RootCertStore,
                           presented_certs: &[Certificate],
-                          dns_name: webpki::DNSNameRef,
+                          dns_name_opt: Option<webpki::DNSNameRef>,
                           ocsp_response: &[u8]) -> Result<ServerCertVerified, TLSError> {
         let (cert, chain, trustroots) = prepare(roots, presented_certs)?;
         let now = (self.time)()?;
@@ -110,9 +110,13 @@ impl ServerCertVerifier for WebPKIVerifier {
             debug!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
         }
 
-        cert.verify_is_valid_for_dns_name(dns_name)
-            .map_err(TLSError::WebPKIError)
-            .map(|_| ServerCertVerified::assertion())
+        if let Some(dns_name) = dns_name_opt {
+            cert.verify_is_valid_for_dns_name(dns_name)
+                .map_err(TLSError::WebPKIError)
+                .map(|_| ServerCertVerified::assertion())
+        } else {
+            Ok(ServerCertVerified::assertion())
+        }
     }
 }
 

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -57,7 +57,7 @@ fn test_reddit_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("reddit.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -73,7 +73,7 @@ fn test_github_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("github.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -90,7 +90,7 @@ fn test_arstechnica_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("arstechnica.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -107,7 +107,7 @@ fn test_servo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("servo.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -123,7 +123,7 @@ fn test_twitter_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("twitter.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap(); });
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap(); });
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn test_wikipedia_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("wikipedia.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -155,7 +155,7 @@ fn test_google_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.google.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -172,7 +172,7 @@ fn test_hn_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("news.ycombinator.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -188,7 +188,7 @@ fn test_stackoverflow_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("stackoverflow.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -204,7 +204,7 @@ fn test_duckduckgo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("duckduckgo.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -221,7 +221,7 @@ fn test_rustlang_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.rust-lang.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -238,7 +238,7 @@ fn test_wapo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.washingtonpost.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 


### PR DESCRIPTION
TLS transactions in non-Internet contexts often don't use hostnames. Support these usage scenarios by making the hostname optional, which disables the SNI extension and disables checking for the DNS name in the server certificate.