### PR TITLE
Add "dangerous" option to disable hostname verification

### DIFF
--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -1147,7 +1147,11 @@ impl State for ExpectTLS13CertificateVerify {
             .get_verifier()
             .verify_server_cert(&sess.config.root_store,
                                 &self.server_cert.cert_chain,
-                                self.handshake.dns_name.as_ref(),
+                                if sess.config.verify_hostname {
+                                    Some(self.handshake.dns_name.as_ref())
+                                } else {
+                                    None
+                                },
                                 &self.server_cert.ocsp_response)?;
 
         // 2. Verify their signature on the handshake.
@@ -1519,7 +1523,11 @@ impl State for ExpectTLS12ServerDone {
             .get_verifier()
             .verify_server_cert(&sess.config.root_store,
                                 &st.server_cert.cert_chain,
-                                st.handshake.dns_name.as_ref(),
+                                if sess.config.verify_hostname {
+                                    Some(st.handshake.dns_name.as_ref())
+                                } else {
+                                    None
+                                },
                                 &st.server_cert.ocsp_response)?;
 
         // 2. Verify any included SCTs.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -117,6 +117,11 @@ pub struct ClientConfig {
 
     /// How to verify the server certificate chain.
     verifier: Arc<verify::ServerCertVerifier>,
+
+    /// Whether to verify server certificate against given hostname.
+    ///
+    /// The defauls is true.
+    verify_hostname: bool,
 }
 
 impl ClientConfig {
@@ -135,7 +140,8 @@ impl ClientConfig {
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             ct_logs: None,
             enable_sni: true,
-            verifier: Arc::new(verify::WebPKIVerifier::new())
+            verifier: Arc::new(verify::WebPKIVerifier::new()),
+            verify_hostname: true,
         }
     }
 
@@ -214,6 +220,11 @@ pub mod danger {
         pub fn set_certificate_verifier(&mut self,
                                         verifier: Arc<ServerCertVerifier>) {
             self.cfg.verifier = verifier;
+        }
+
+        /// Hostname verification is enabled by default. Pass `false` to disable.
+        pub fn set_verify_hostname(&mut self, verify: bool) {
+            self.cfg.verify_hostname = verify;
         }
     }
 }

--- a/src/verifybench.rs
+++ b/src/verifybench.rs
@@ -57,7 +57,7 @@ fn test_reddit_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("reddit.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -73,7 +73,7 @@ fn test_github_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("github.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -90,7 +90,7 @@ fn test_arstechnica_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("arstechnica.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -107,7 +107,7 @@ fn test_servo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("servo.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -123,7 +123,7 @@ fn test_twitter_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("twitter.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap(); });
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap(); });
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn test_wikipedia_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("wikipedia.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -155,7 +155,7 @@ fn test_google_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.google.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -172,7 +172,7 @@ fn test_hn_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("news.ycombinator.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -188,7 +188,7 @@ fn test_stackoverflow_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("stackoverflow.com")
           .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -204,7 +204,7 @@ fn test_duckduckgo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("duckduckgo.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -221,7 +221,7 @@ fn test_rustlang_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.rust-lang.org")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 
@@ -238,7 +238,7 @@ fn test_wapo_cert() {
           |_| {
         let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.washingtonpost.com")
             .unwrap();
-        V.verify_server_cert(&anchors, &chain[..], dns_name, &[]).unwrap();
+        V.verify_server_cert(&anchors, &chain[..], Some(dns_name), &[]).unwrap();
     });
 }
 


### PR DESCRIPTION
TLS transactions in non-Internet contexts often don't use hostnames. Support these usage scenarios by making the hostname verification of the server certificate optional if the dangerous_configuration feature is enabled.