### PR TITLE
Implement support for the QUIC TransportParameters extension

### DIFF
--- a/src/msgs/enums.rs
+++ b/src/msgs/enums.rs
@@ -223,7 +223,8 @@ enum_builder! {@U16
         KeyShare => 0x0033,
         NextProtocolNegotiation => 0x3374,
         ChannelId => 0x754f,
-        RenegotiationInfo => 0xff01
+        RenegotiationInfo => 0xff01,
+        TransportParameters => 0x001a
     }
 }
 

--- a/src/msgs/handshake.rs
+++ b/src/msgs/handshake.rs
@@ -8,6 +8,7 @@ use msgs::enums::PSKKeyExchangeMode;
 use msgs::base::{Payload, PayloadU8, PayloadU16, PayloadU24};
 use msgs::codec;
 use msgs::codec::{Codec, Reader};
+use msgs::quic::{ClientTransportParameters, ServerTransportParameters};
 use std;
 use std::fmt;
 use std::io::Write;
@@ -602,6 +603,7 @@ pub enum ClientExtension {
     ExtendedMasterSecretRequest,
     CertificateStatusRequest(CertificateStatusRequest),
     SignedCertificateTimestampRequest,
+    TransportParameters(ClientTransportParameters),
     Unknown(UnknownExtension),
 }
 
@@ -623,6 +625,7 @@ impl ClientExtension {
             ClientExtension::ExtendedMasterSecretRequest => ExtensionType::ExtendedMasterSecret,
             ClientExtension::CertificateStatusRequest(_) => ExtensionType::StatusRequest,
             ClientExtension::SignedCertificateTimestampRequest => ExtensionType::SCT,
+            ClientExtension::TransportParameters(_) => ExtensionType::TransportParameters,
             ClientExtension::Unknown(ref r) => r.typ,
         }
     }
@@ -649,6 +652,7 @@ impl Codec for ClientExtension {
             ClientExtension::PresharedKey(ref r) => r.encode(&mut sub),
             ClientExtension::Cookie(ref r) => r.encode(&mut sub),
             ClientExtension::CertificateStatusRequest(ref r) => r.encode(&mut sub),
+            ClientExtension::TransportParameters(ref r) => r.encode(&mut sub),
             ClientExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 
@@ -738,6 +742,7 @@ pub enum ServerExtension {
     CertificateStatusAck,
     SignedCertificateTimestamp(SCTList),
     SupportedVersions(ProtocolVersion),
+    TransportParameters(ServerTransportParameters),
     Unknown(UnknownExtension),
 }
 
@@ -755,6 +760,7 @@ impl ServerExtension {
             ServerExtension::CertificateStatusAck => ExtensionType::StatusRequest,
             ServerExtension::SignedCertificateTimestamp(_) => ExtensionType::SCT,
             ServerExtension::SupportedVersions(_) => ExtensionType::SupportedVersions,
+            ServerExtension::TransportParameters(_) => ExtensionType::TransportParameters,
             ServerExtension::Unknown(ref r) => r.typ,
         }
     }
@@ -777,6 +783,7 @@ impl Codec for ServerExtension {
             ServerExtension::PresharedKey(r) => codec::encode_u16(r, &mut sub),
             ServerExtension::SignedCertificateTimestamp(ref r) => r.encode(&mut sub),
             ServerExtension::SupportedVersions(ref r) => r.encode(&mut sub),
+            ServerExtension::TransportParameters(ref r) => r.encode(&mut sub),
             ServerExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 

--- a/src/msgs/mod.rs
+++ b/src/msgs/mod.rs
@@ -14,6 +14,7 @@ pub mod persist;
 pub mod deframer;
 pub mod fragmenter;
 pub mod hsjoiner;
+pub mod quic;
 
 #[cfg(test)]
 mod handshake_test;

--- a/src/msgs/quic.rs
+++ b/src/msgs/quic.rs
@@ -1,0 +1,111 @@
+use super::codec;
+use super::base::PayloadU16;
+
+#[derive(Debug, PartialEq)]
+pub struct ClientTransportParameters {
+    initial_version: u32,
+    parameters: Vec<Parameter>,
+}
+
+impl codec::Codec for ClientTransportParameters {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        codec::encode_u32(self.initial_version, bytes);
+        codec::encode_vec_u16(bytes, &self.parameters);
+    }
+
+    fn read(r: &mut codec::Reader) -> Option<Self> {
+        Some(ClientTransportParameters {
+            initial_version: try_ret!(codec::read_u32(r)),
+            parameters: try_ret!(codec::read_vec_u16(r)),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ServerTransportParameters {
+    negotiated_version: u32,
+    supported_versions: Vec<u32>,
+    parameters: Vec<Parameter>,
+}
+
+impl codec::Codec for ServerTransportParameters {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        codec::encode_u32(self.negotiated_version, bytes);
+        debug_assert!(self.supported_versions.len() * 4 <= 0xff);
+        codec::encode_u8((self.supported_versions.len() * 4) as u8, bytes);
+        for version in self.supported_versions.iter() {
+            codec::encode_u32(*version, bytes);
+        }
+        codec::encode_vec_u16(bytes, &self.parameters);
+    }
+
+    fn read(r: &mut codec::Reader) -> Option<Self> {
+        Some(ServerTransportParameters {
+            negotiated_version: try_ret!(codec::read_u32(r)),
+            supported_versions: {
+                let len = try_ret!(codec::read_u8(r)) as usize;
+                let mut sub = try_ret!(r.sub(len));
+                let mut ret = Vec::new();
+                while sub.any_left() {
+                    ret.push(try_ret!(codec::read_u32(&mut sub)));
+                }
+                ret
+            },
+            parameters: try_ret!(codec::read_vec_u16(r)),
+        })
+    }
+}
+
+type Parameter = (u16, PayloadU16);
+
+impl codec::Codec for Parameter {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        codec::encode_u16(self.0, bytes);
+        self.1.encode(bytes);
+    }
+
+    fn read(r: &mut codec::Reader) -> Option<Self> {
+        Some((try_ret!(codec::read_u16(r)), try_ret!(PayloadU16::read(r))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClientTransportParameters, ServerTransportParameters};
+    use msgs::base::PayloadU16;
+    use msgs::codec::{self, Codec};
+
+    fn round_trip<T: Codec + PartialEq>(t: T) {
+        let buf = {
+            let mut ret = Vec::new();
+            t.encode(&mut ret);
+            ret
+        };
+        println!("{:?}", buf);
+        let mut r = codec::Reader::init(&buf);
+        assert_eq!(Some(t), T::read(&mut r));
+    }
+
+    #[test]
+    fn test_client_transport_parameters() {
+        round_trip(ClientTransportParameters {
+            initial_version: 1,
+            parameters: vec![
+                (0, PayloadU16::new(b"\0\0\0\0".to_vec())),
+                (1, PayloadU16::new(b"abcd".to_vec())),
+                (3, PayloadU16::new(b"ab".to_vec())),
+            ],
+        });
+    }
+
+    #[test]
+    fn test_server_transport_parameters() {
+        round_trip(ServerTransportParameters {
+            negotiated_version: 1,
+            supported_versions: vec![1, 2, 3],
+            parameters: vec![
+                (6, PayloadU16::new(b"0123456789abcdef".to_vec())),
+            ],
+        });
+    }
+}


### PR DESCRIPTION
See #161. Here's my initial take at implementing basic support for TransportParameters.