### PR TITLE
Add `BulkAlgorithm` to the public API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ pub use server::ProducesTickets;
 pub use ticketer::Ticketer;
 pub use verify::{NoClientAuth, AllowAnyAuthenticatedClient,
                  AllowAnyAnonymousOrAuthenticatedClient};
-pub use suites::{ALL_CIPHERSUITES, SupportedCipherSuite};
+pub use suites::{ALL_CIPHERSUITES, BulkAlgorithm, SupportedCipherSuite};
 pub use key::{Certificate, PrivateKey};
 pub use keylog::{KeyLog, NoKeyLog, KeyLogFile};
 pub use vecbuf::WriteV;

--- a/src/suites.rs
+++ b/src/suites.rs
@@ -8,7 +8,7 @@ use msgs::codec::{Reader, Codec};
 use ring;
 use untrusted;
 
-#[allow(non_camel_case_types)]
+#[allow(missing_docs, non_camel_case_types)]
 #[derive(Debug, PartialEq)]
 pub enum BulkAlgorithm {
     AES_128_GCM,


### PR DESCRIPTION
Allow users of Rustls to use `BulkAlgorithm` to filter the cipher
suites in their configurations.