### PR TITLE
Implement client support for TLS 1.3 0-RTT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ path = "examples/tlsserver.rs"
 [[example]]
 name = "simpleclient"
 path = "examples/simpleclient.rs"
+
+[[example]]
+name = "simple_0rtt_client"
+path = "examples/simple_0rtt_client.rs"
+required-features = ["logging"]

--- a/bogo/config.json
+++ b/bogo/config.json
@@ -78,7 +78,9 @@
     "SendHalfHelloRequest-*": "",
     "RetainOnlySHA256-*": "",
     "ExtendedMasterSecret-Renego-*": "",
-    "Draft-Downgrade-Server": "not implemented; TODO"
+    "Draft-Downgrade-Server": "not implemented; TODO",
+    "EarlyData-*ALPN*-*": "no alpn change in resumed sessions",
+    "*EarlyKeyingMaterial-Client-*": "early exporter NYI"
   },
   "ErrorMap": {
     ":HTTP_REQUEST:": ":GARBAGE:",
@@ -275,7 +277,11 @@
     "QUICTransportParams-Server-Rejected-TLS12": "missing peer quic transport params",
     "ExtendedMasterSecret-NoToYes-Client": ":PEER_MISBEHAVIOUR:",
     "ExtendedMasterSecret-YesToNo-Server": ":PEER_MISBEHAVIOUR:",
-    "ExtendedMasterSecret-YesToNo-Client": ":PEER_MISBEHAVIOUR:"
+    "ExtendedMasterSecret-YesToNo-Client": ":PEER_MISBEHAVIOUR:",
+    "ServerAcceptsEarlyDataOnHRR-Client-TLS13Draft23": ":PEER_MISBEHAVIOUR:",
+    "EarlyDataVersionDowngrade-Client-TLS13Draft23": ":WRONG_VERSION:",
+    "EarlyDataWithoutResume-Client-TLS13Draft23": ":PEER_MISBEHAVIOUR:",
+    "EarlyDataVersionDowngrade-Client-TLS13Draft23": ":PEER_MISBEHAVIOUR:"
   },
   "TestLocalErrorMap": {
     "SendServerHelloAsHelloRetryRequest": "remote error: error decoding message",

--- a/examples/internal/bogo_shim.rs
+++ b/examples/internal/bogo_shim.rs
@@ -64,6 +64,12 @@ struct Options {
     read_size: usize,
     quic_transport_params: Vec<u8>,
     expect_quic_transport_params: Vec<u8>,
+    enable_early_data: bool,
+    expect_ticket_supports_early_data: bool,
+    expect_accept_early_data: bool,
+    expect_reject_early_data: bool,
+    queue_data_on_resume: bool,
+    expect_version: u16,
 }
 
 impl Options {
@@ -101,6 +107,12 @@ impl Options {
             read_size: 512,
             quic_transport_params: vec![],
             expect_quic_transport_params: vec![],
+            enable_early_data: false,
+            expect_ticket_supports_early_data: false,
+            expect_accept_early_data: false,
+            expect_reject_early_data: false,
+            queue_data_on_resume: false,
+            expect_version: 0,
         }
     }
 
@@ -111,7 +123,7 @@ impl Options {
 
     fn tls13_supported(&self) -> bool {
         self.support_tls13 && (self.version_allowed(ProtocolVersion::TLSv1_3) ||
-                               self.version_allowed(ProtocolVersion::Unknown(0x7f12)))
+                               self.version_allowed(ProtocolVersion::Unknown(0x7f17)))
     }
 
     fn tls12_supported(&self) -> bool {
@@ -368,6 +380,10 @@ fn make_client_cfg(opts: &Options) -> Arc<rustls::ClientConfig> {
         cfg.versions.push(ProtocolVersion::TLSv1_3);
     }
 
+    if opts.enable_early_data {
+        cfg.enable_early_data = true;
+    }
+
     Arc::new(cfg)
 }
 
@@ -396,6 +412,7 @@ fn handle_err(err: rustls::TLSError) -> ! {
             quit(":TLSV1_ALERT_RECORD_OVERFLOW:")
         }
         TLSError::AlertReceived(AlertDescription::HandshakeFailure) => quit(":HANDSHAKE_FAILURE:"),
+        TLSError::AlertReceived(AlertDescription::ProtocolVersion) => quit(":WRONG_VERSION:"),
         TLSError::CorruptMessagePayload(ContentType::Alert) => quit(":BAD_ALERT:"),
         TLSError::CorruptMessagePayload(ContentType::ChangeCipherSpec) => {
             quit(":BAD_CHANGE_CIPHER_SPEC:")
@@ -447,10 +464,9 @@ fn flush(sess: &mut Box<rustls::Session>, conn: &mut net::TcpStream) {
     conn.flush().unwrap();
 }
 
-fn exec(opts: &Options, sess: &mut Box<rustls::Session>) {
-    if opts.queue_data {
-        sess.write_all(b"hello world")
-            .unwrap();
+fn exec(opts: &Options, sess: &mut Box<rustls::Session>, count: usize) {
+    if opts.queue_data || (opts.queue_data_on_resume && count > 0) {
+        let _ = sess.write_all(b"hello");
     }
 
     let mut conn = net::TcpStream::connect(("localhost", opts.port)).expect("cannot connect");
@@ -498,6 +514,21 @@ fn exec(opts: &Options, sess: &mut Box<rustls::Session>) {
             sess.write_all(&export)
                 .unwrap();
             sent_exporter = true;
+        }
+
+        if opts.enable_early_data && !sess.is_handshaking() && count > 0 {
+            if opts.expect_accept_early_data && !sess.is_early_data_accepted() {
+                quit_err("Early data was not accepted, but we expect the opposite");
+            } else if opts.expect_reject_early_data && sess.is_early_data_accepted() {
+                quit_err("Early data was accepted, but we expect the opposite");
+            }
+            if opts.expect_version == 0x0304 {
+                match sess.get_protocol_version() {
+                    Some(ProtocolVersion::TLSv1_3) |
+                    Some(ProtocolVersion::Unknown(0x7f17)) => (),
+                    _ => quit_err("wrong protocol version"),
+                }
+            }
         }
 
         if !sess.is_handshaking() &&
@@ -602,6 +633,9 @@ fn main() {
             "-expect-peer-signature-algorithm" |
             "-expect-advertised-alpn" |
             "-expect-alpn" |
+            "-on-initial-expect-alpn" |
+            "-on-resume-expect-alpn" |
+            "-on-retry-expect-alpn" |
             "-expect-server-name" |
             "-expect-ocsp-response" |
             "-expect-signed-cert-timestamps" |
@@ -684,6 +718,25 @@ fn main() {
             "-enable-signed-cert-timestamps" => {
                 opts.send_sct = true;
             }
+            "-enable-early-data" |
+            "-on-resume-enable-early-data" => {
+                opts.enable_early_data = true;
+            }
+            "-on-resume-shim-writes-first" => {
+                opts.queue_data_on_resume = true;
+            }
+            "-expect-ticket-supports-early-data" => {
+                opts.expect_ticket_supports_early_data = true;
+            }
+            "-expect-accept-early-data" => {
+                opts.expect_accept_early_data = true;
+            }
+            "-expect-reject-early-data" => {
+                opts.expect_reject_early_data = true;
+            }
+            "-expect-version" => {
+                opts.expect_version = args.remove(0).parse::<u16>().unwrap();
+            }
 
             // defaults:
             "-enable-all-curves" |
@@ -734,7 +787,6 @@ fn main() {
             "-enable-channel-id" |
             "-resumption-delay" |
             "-expect-early-data-info" |
-            "-enable-early-data" |
             "-expect-cipher-aes" |
             "-retain-only-sha256-client-cert-initial" |
             "-use-client-ca-list" |
@@ -747,9 +799,10 @@ fn main() {
             "-handshake-twice" |
             "-verify-prefs" |
             "-no-op-extra-handshake" |
-            "-on-resume-enable-early-data" |
             "-read-with-unfinished-write" |
-            "-expect-peer-cert-file" => {
+            "-on-resume-read-with-unfinished-write" |
+            "-expect-peer-cert-file" |
+            "-on-initial-expect-peer-cert-file" => {
                 println!("NYI option {:?}", arg);
                 process::exit(BOGO_NACK);
             }
@@ -759,6 +812,11 @@ fn main() {
                 process::exit(1);
             }
         }
+    }
+
+    if opts.enable_early_data && opts.server {
+        println!("For now we only test client-side early data");
+        process::exit(BOGO_NACK);
     }
 
     println!("opts {:?}", opts);
@@ -799,8 +857,8 @@ fn main() {
         }
     };
 
-    for _ in 0..opts.resumes + 1 {
+    for i in 0..opts.resumes + 1 {
         let mut sess = make_session();
-        exec(&opts, &mut sess);
+        exec(&opts, &mut sess, i);
     }
 }

--- a/examples/simple_0rtt_client.rs
+++ b/examples/simple_0rtt_client.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+
+extern crate rustls;
+extern crate webpki;
+extern crate webpki_roots;
+extern crate env_logger;
+
+fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
+    let dns_name = webpki::DNSNameRef::try_from_ascii_str(domain_name).unwrap();
+    let mut sess = rustls::ClientSession::new(config, dns_name);
+    let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
+    sock.set_nodelay(true).unwrap();
+    let mut stream = rustls::Stream::new(&mut sess, &mut sock);
+    let request = format!(
+        "GET / HTTP/1.1\r\n\
+         Host: {}\r\n\
+         Connection: close\r\n\
+         Accept-Encoding: identity\r\n\
+         \r\n",
+        domain_name
+    );
+
+    stream.write_all(request.as_bytes()).unwrap();
+    let mut plaintext = Vec::new();
+    stream.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}
+
+fn main() {
+    env_logger::init();
+    let mut config = rustls::ClientConfig::new();
+    config.enable_early_data = true;
+    config
+        .root_store
+        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let config = Arc::new(config);
+    start_session(&config, "mesalink.io");
+    start_session(&config, "mesalink.io");
+}

--- a/examples/simple_0rtt_client.rs
+++ b/examples/simple_0rtt_client.rs
@@ -13,7 +13,6 @@ fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
     let mut sess = rustls::ClientSession::new(config, dns_name);
     let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
     sock.set_nodelay(true).unwrap();
-    let mut stream = rustls::Stream::new(&mut sess, &mut sock);
     let request = format!(
         "GET / HTTP/1.1\r\n\
          Host: {}\r\n\
@@ -23,7 +22,26 @@ fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
         domain_name
     );
 
-    stream.write_all(request.as_bytes()).unwrap();
+    // If early data is available with this server, then early_data()
+    // will yield Some(WriteEarlyData) and WriteEarlyData implements
+    // io::Write.  Use this to send the request.
+    if let Some(mut early_data) = sess.early_data() {
+        early_data.write(request.as_bytes())
+            .unwrap();
+    }
+
+    let mut stream = rustls::Stream::new(&mut sess, &mut sock);
+
+    // Complete handshake.
+    stream.flush()
+        .unwrap();
+
+    // If we didn't send early data, or the server didn't accept it,
+    // then send the request as normal.
+    if !stream.sess.is_early_data_accepted() {
+        stream.write_all(request.as_bytes()).unwrap();
+    }
+
     let mut plaintext = Vec::new();
     stream.read_to_end(&mut plaintext).unwrap();
     stdout().write_all(&plaintext).unwrap();
@@ -32,11 +50,16 @@ fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
 fn main() {
     env_logger::init();
     let mut config = rustls::ClientConfig::new();
+
+    // Enable early data.
     config.enable_early_data = true;
     config
         .root_store
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     let config = Arc::new(config);
+
+    // Do two sessions. The first will be a normal request, the
+    // second will use early data if the server supports it.
     start_session(&config, "mesalink.io");
     start_session(&config, "mesalink.io");
 }

--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -52,6 +52,7 @@ impl ServerKXDetails {
 pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
     pub resuming_session: Option<persist::ClientSessionValue>,
+    pub hash_at_client_recvd_server_hello: Vec<u8>,
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub session_id: SessionID,
@@ -64,6 +65,7 @@ impl HandshakeDetails {
     pub fn new(host_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
+            hash_at_client_recvd_server_hello: Vec::new(),
             resuming_session: None,
             randoms: SessionRandoms::for_client(),
             using_ems: false,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -124,6 +124,12 @@ pub struct ClientConfig {
     /// How to output key material for debugging.  The default
     /// does nothing.
     pub key_log: Arc<KeyLog>,
+
+    /// Whether to send data on the first flight ("early data") in
+    /// TLS 1.3 handshakes.
+    ///
+    /// The default is false.
+    pub enable_early_data: bool,
 }
 
 impl ClientConfig {
@@ -146,6 +152,7 @@ impl ClientConfig {
             enable_sni: true,
             verifier: Arc::new(verify::WebPKIVerifier::new()),
             key_log: Arc::new(NoKeyLog {}),
+            enable_early_data: false,
         }
     }
 
@@ -513,6 +520,14 @@ impl Session for ClientSession {
 
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
         self.imp.get_negotiated_ciphersuite()
+    }
+
+    fn is_in_early_data(&self) -> bool {
+        !self.imp.common.traffic && self.imp.common.early_traffic
+    }
+
+    fn is_early_data_accepted(&self) -> bool {
+        !self.imp.common.early_traffic && self.imp.common.early_data_accepted
     }
 }
 

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -8,6 +8,7 @@ use error::TLSError;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SecretKind {
     ResumptionPSKBinderKey,
+    ClientEarlyTrafficSecret,
     ClientHandshakeTrafficSecret,
     ServerHandshakeTrafficSecret,
     ClientApplicationTrafficSecret,
@@ -21,6 +22,7 @@ impl SecretKind {
     fn to_bytes(&self) -> &'static [u8] {
         match *self {
             SecretKind::ResumptionPSKBinderKey => b"res binder",
+            SecretKind::ClientEarlyTrafficSecret => b"c e traffic",
             SecretKind::ClientHandshakeTrafficSecret => b"c hs traffic",
             SecretKind::ServerHandshakeTrafficSecret => b"s hs traffic",
             SecretKind::ClientApplicationTrafficSecret => b"c ap traffic",
@@ -102,6 +104,7 @@ impl KeySchedule {
         match kind {
             SecretKind::ServerHandshakeTrafficSecret |
             SecretKind::ServerApplicationTrafficSecret => &self.current_server_traffic_secret,
+            SecretKind::ClientEarlyTrafficSecret |
             SecretKind::ClientHandshakeTrafficSecret |
             SecretKind::ClientApplicationTrafficSecret => &self.current_client_traffic_secret,
             _ => unreachable!(),

--- a/src/msgs/persist.rs
+++ b/src/msgs/persist.rs
@@ -62,6 +62,7 @@ pub struct ClientSessionValue {
     pub lifetime: u32,
     pub age_add: u32,
     pub extended_ms: bool,
+    pub max_early_data_size: u32,
 }
 
 impl Codec for ClientSessionValue {
@@ -75,6 +76,7 @@ impl Codec for ClientSessionValue {
         self.lifetime.encode(bytes);
         self.age_add.encode(bytes);
         (if self.extended_ms { 1u8 } else { 0u8 }).encode(bytes);
+        self.max_early_data_size.encode(bytes);
     }
 
     fn read(r: &mut Reader) -> Option<ClientSessionValue> {
@@ -87,6 +89,7 @@ impl Codec for ClientSessionValue {
         let lifetime = u32::read(r)?;
         let age_add = u32::read(r)?;
         let extended_ms = u8::read(r)?;
+        let max_early_data_size = u32::read(r)?;
 
         Some(ClientSessionValue {
             version: v,
@@ -98,6 +101,7 @@ impl Codec for ClientSessionValue {
             lifetime,
             age_add,
             extended_ms: extended_ms == 1u8,
+            max_early_data_size,
         })
     }
 }
@@ -121,6 +125,7 @@ impl ClientSessionValue {
             lifetime: 0,
             age_add: 0,
             extended_ms: false,
+            max_early_data_size: 0,
         }
     }
 
@@ -149,6 +154,10 @@ impl ClientSessionValue {
         let new_ticket = PayloadU16::new(Vec::new());
         let old_ticket = mem::replace(&mut self.ticket, new_ticket);
         old_ticket.0
+    }
+
+    pub fn set_max_early_data_size(&mut self, sz: u32) {
+        self.max_early_data_size = sz;
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -178,9 +178,9 @@ impl ServerConfig {
     /// certificate and key is used for all subsequent connections,
     /// irrespective of things like SNI hostname.
     ///
-    /// Note that the end-entity certificate must have the 
-    /// [Subject Alternative Name](https://tools.ietf.org/html/rfc6125#section-4.1) 
-    /// extension to describe, e.g., the valid DNS name. The `commonName` field is 
+    /// Note that the end-entity certificate must have the
+    /// [Subject Alternative Name](https://tools.ietf.org/html/rfc6125#section-4.1)
+    /// extension to describe, e.g., the valid DNS name. The `commonName` field is
     /// disregarded.
     ///
     /// `cert_chain` is a vector of DER-encoded certificates.
@@ -507,6 +507,14 @@ impl Session for ServerSession {
 
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
         self.imp.get_negotiated_ciphersuite()
+    }
+
+    fn is_in_early_data(&self) -> bool {
+        unimplemented!()
+    }
+
+    fn is_early_data_accepted(&self) -> bool {
+        unimplemented!()
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -508,14 +508,6 @@ impl Session for ServerSession {
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
         self.imp.get_negotiated_ciphersuite()
     }
-
-    fn is_in_early_data(&self) -> bool {
-        unimplemented!()
-    }
-
-    fn is_early_data_accepted(&self) -> bool {
-        unimplemented!()
-    }
 }
 
 impl io::Read for ServerSession {

--- a/src/session.rs
+++ b/src/session.rs
@@ -698,7 +698,8 @@ impl SessionCommon {
             } else {
                 self.max_early_data_limit = 0;
                 let _ = self.send_appdata_encrypt(&data[..max_early_data_limit], limit);
-                self.sendable_plaintext.append_limited_copy(&data[max_early_data_limit..]);
+                // Push the unsent partial buffer back to the front of sendable_plaintext
+                self.sendable_plaintext.push_front_copy(&data[max_early_data_limit..]);
                 return Err(io::Error::new(io::ErrorKind::Other,
                                           "Early data exceeds max_early_data_size"));
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -136,13 +136,6 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
     /// This returns None until the ciphersuite is agreed.
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite>;
 
-    /// Returns True if the client is ready to send early data
-    fn is_in_early_data(&self) -> bool;
-
-    /// Returns True if the handshake is completed and the server intends
-    /// to process early data.
-    fn is_early_data_accepted(&self) -> bool;
-
     /// This function uses `io` to complete any outstanding IO for
     /// this session.
     ///
@@ -392,10 +385,7 @@ pub struct SessionCommon {
     pub peer_encrypting: bool,
     pub we_encrypting: bool,
     pub traffic: bool,
-    pub use_early_data: bool,
     pub early_traffic: bool,
-    pub early_data_accepted: bool,
-    pub max_early_data_limit: u32,
     pub want_write_key_update: bool,
     pub message_deframer: MessageDeframer,
     pub handshake_joiner: HandshakeJoiner,
@@ -421,10 +411,7 @@ impl SessionCommon {
             peer_encrypting: false,
             we_encrypting: false,
             traffic: false,
-            use_early_data: false,
             early_traffic: false,
-            early_data_accepted: false,
-            max_early_data_limit: 0,
             want_write_key_update: false,
             message_deframer: MessageDeframer::new(),
             handshake_joiner: HandshakeJoiner::new(),
@@ -671,9 +658,20 @@ impl SessionCommon {
         self.send_plain(data, Limit::Yes)
     }
 
+    pub fn send_early_plaintext(&mut self, data: &[u8]) -> io::Result<usize> {
+        debug_assert!(self.early_traffic);
+        debug_assert!(self.we_encrypting);
+
+        if data.is_empty() {
+            // Don't send empty fragments.
+            return Ok(0);
+        }
+
+        Ok(self.send_appdata_encrypt(data, Limit::Yes))
+    }
 
     fn send_plain(&mut self, data: &[u8], limit: Limit) -> io::Result<usize> {
-        if !self.traffic && !self.early_traffic {
+        if !self.traffic {
             // If we haven't completed handshaking, buffer
             // plaintext to send once we do.
             let len = match limit {
@@ -690,20 +688,6 @@ impl SessionCommon {
             return Ok(0);
         }
 
-        if self.early_traffic {
-            // Check if the plaintext exceeds max_early_data_size
-            let max_early_data_limit = self.max_early_data_limit as usize;
-            if data.len() <= max_early_data_limit {
-                self.max_early_data_limit -= data.len() as u32;
-            } else {
-                self.max_early_data_limit = 0;
-                let _ = self.send_appdata_encrypt(&data[..max_early_data_limit], limit);
-                // Push the unsent partial buffer back to the front of sendable_plaintext
-                self.sendable_plaintext.push_front_copy(&data[max_early_data_limit..]);
-                return Err(io::Error::new(io::ErrorKind::Other,
-                                          "Early data exceeds max_early_data_size"));
-            }
-        }
         Ok(self.send_appdata_encrypt(data, limit))
     }
 
@@ -715,7 +699,7 @@ impl SessionCommon {
     /// Send any buffered plaintext.  Plaintext is buffered if
     /// written during handshake.
     pub fn flush_plaintext(&mut self) {
-        if !self.traffic && !self.early_traffic {
+        if !self.traffic {
             return;
         }
 

--- a/src/vecbuf.rs
+++ b/src/vecbuf.rs
@@ -92,17 +92,6 @@ impl ChunkVecBuffer {
         len
     }
 
-    /// Take and push the given `bytes` at the beginning.
-    pub fn push_front_copy(&mut self, bytes: &[u8]) -> usize {
-        let len = bytes.len();
-
-        if !bytes.is_empty() {
-            self.chunks.push_front(bytes.to_vec());
-        }
-
-        len
-    }
-
     /// Take one of the chunks from this object.  This
     /// function panics if the object `is_empty`.
     pub fn take_one(&mut self) -> Vec<u8> {

--- a/src/vecbuf.rs
+++ b/src/vecbuf.rs
@@ -92,6 +92,17 @@ impl ChunkVecBuffer {
         len
     }
 
+    /// Take and push the given `bytes` at the beginning.
+    pub fn push_front_copy(&mut self, bytes: &[u8]) -> usize {
+        let len = bytes.len();
+
+        if !bytes.is_empty() {
+            self.chunks.push_front(bytes.to_vec());
+        }
+
+        len
+    }
+
     /// Take one of the chunks from this object.  This
     /// function panics if the object `is_empty`.
     pub fn take_one(&mut self) -> Vec<u8> {


### PR DESCRIPTION
Here's my take at implementing TLS 1.3 0-RTT for resumed client sessions. It passes BOGO and works with Cloudflare's TLS 1.3 0-RTT implementation. 

Both Issue [#84](https://github.com/ctz/rustls/issues/84) and the TLS 1.3 draft discuss about the risk of using 0-rtt data. So 0-RTT is by default disabled. A user who wishes to send 0-RTT data to HAProxy or Cloudflare should set `ClientConfig.enable_early_data` and call `ClientSession::write_all()` before the handshake starts. 

Two new Session APIs, `is_in_early_data` and `is_early_data_accepted` are added. `is_in_early_data` returns `true` if any early data is in flight or ready to be sent. This implies a handshake is in process and `is_handshaking()` must be `true`. `is_early_data_accepted` returns `true` if the server has processed the 0-RTT data and the client has sent `EndOfEarlyData`. This API should be called after the handshake is completed.

A `max_early_data_size` field is added to `persist::ClientSessionValue` to indicate the maximum bytes of plaintext that can be sent as early data. This limit is enforced in `Session::send_plain()`. 

The following BOGO test cases are turned on and passed.
PASSED (TLS13-SendTicketEarlyDataInfo)
PASSED (TLS13-SendTicketEarlyDataInfo-Disabled)
PASSED (TLS13-EarlyData-TooMuchData-Client-Sync)
PASSED (TLS13-EarlyData-TooMuchData-Client-Sync-ImplicitHandshake)
PASSED (TLS13-EarlyData-TooMuchData-Client-Sync-SplitHandshakeRecords)
PASSED (TLS13-EarlyData-TooMuchData-Client-Sync-PackHandshake)
PASSED (TLS13-EarlyData-TooMuchData-Client-Async)
PASSED (TLS13-EarlyData-TooMuchData-Client-Async-ImplicitHandshake)
PASSED (TLS13-EarlyData-TooMuchData-Client-Async-SplitHandshakeRecords)
PASSED (TLS13-EarlyData-TooMuchData-Client-Async-PackHandshake)
PASSED (EarlyData-Client-TLS13Draft23)
PASSED (EarlyData-Reject-Client-TLS13Draft23)
PASSED (EarlyData-HRR-Client-TLS13Draft23)
PASSED (EarlyDataWithoutResume-Client-TLS13Draft23)
PASSED (EarlyDataVersionDowngrade-Client-TLS13Draft23)
PASSED (ServerAcceptsEarlyDataOnHRR-Client-TLS13Draft23)
PASSED (EarlyData-Client-VersionAPI-TLS13Draft23)
PASSED (EarlyData-Client-BadFinished-TLS13Draft23)
