### PR TITLE
Raw handshake I/O for QUIC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 script:
   - cargo build
   - RUST_BACKTRACE=1 cargo test
-  - RUST_BACKTRACE=1 cargo test --features dangerous_configuration danger
+  - RUST_BACKTRACE=1 cargo test --all-features
   - cargo test --release --no-run
   - ./target/release/examples/bench
 #  - ( cd trytls && ./runme )

--- a/bogo/config.json
+++ b/bogo/config.json
@@ -88,7 +88,8 @@
     "ALPN*SelectEmpty-*": "",
     "Draft-Downgrade-Server": "not implemented; TODO",
     "EarlyData-*ALPN*-*": "no alpn change in resumed sessions",
-    "*EarlyKeyingMaterial-Client-*": "early exporter NYI"
+    "*EarlyKeyingMaterial-Client-*": "early exporter NYI",
+    "QUICTransportParams-*-TLS12": "QUIC support requires TLS >= 1.3"
   },
   "ErrorMap": {
     ":HTTP_REQUEST:": ":GARBAGE:",
@@ -281,8 +282,6 @@
     "CurveTest-Server-Compressed-P-384-TLS12": ":PEER_MISBEHAVIOUR:",
     "CurveTest-Client-Compressed-P-384-TLS13": ":PEER_MISBEHAVIOUR:",
     "CurveTest-Server-Compressed-P-384-TLS13": ":PEER_MISBEHAVIOUR:",
-    "QUICTransportParams-Client-Rejected-TLS12": ":PEER_MISBEHAVIOUR:",
-    "QUICTransportParams-Server-Rejected-TLS12": "missing peer quic transport params",
     "ExtendedMasterSecret-NoToYes-Client": ":PEER_MISBEHAVIOUR:",
     "ExtendedMasterSecret-YesToNo-Server": ":PEER_MISBEHAVIOUR:",
     "ExtendedMasterSecret-YesToNo-Client": ":PEER_MISBEHAVIOUR:",

--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -337,6 +337,8 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
         )));
     }
 
+    // Extra extensions must be placed before the PSK extension
+    exts.extend(handshake.extra_exts.iter().cloned());
 
     let fill_in_binder = if support_tls13 && sess.config.enable_tickets &&
                             resume_version == ProtocolVersion::TLSv1_3 &&
@@ -390,8 +392,6 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
     } else {
         false
     };
-
-    exts.extend(handshake.extra_exts.iter().cloned());
 
     // Note what extensions we sent.
     hello.sent_extensions = exts.iter()

--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -2332,6 +2332,13 @@ impl ExpectTLS13Traffic {
 
         if let Some(sz) = nst.get_max_early_data_size() {
             value.set_max_early_data_size(sz);
+            #[cfg(feature = "quic")] {
+                if sess.common.protocol == Protocol::Quic {
+                    if sz != 0 && sz != 0xffff_ffff {
+                        return Err(TLSError::PeerMisbehavedError("invalid max_early_data_size".into()));
+                    }
+                }
+            }
         }
 
         let key = persist::ClientSessionKey::session_for_dns_name(self.handshake.dns_name.as_ref());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -360,7 +360,6 @@ impl<'a> io::Write for WriteEarlyData<'a> {
 pub struct ClientSessionImpl {
     pub config: Arc<ClientConfig>,
     pub alpn_protocol: Option<Vec<u8>>,
-    pub quic_params: Option<Vec<u8>>,
     pub common: SessionCommon,
     pub error: Option<TLSError>,
     pub state: Option<Box<hs::State + Send + Sync>>,
@@ -379,7 +378,6 @@ impl ClientSessionImpl {
         ClientSessionImpl {
             config: config.clone(),
             alpn_protocol: None,
-            quic_params: None,
             common: SessionCommon::new(config.mtu, true),
             error: None,
             state: None,
@@ -478,7 +476,7 @@ impl ClientSessionImpl {
         self.process_main_protocol(msg)
     }
 
-    fn process_new_handshake_messages(&mut self) -> Result<(), TLSError> {
+    pub fn process_new_handshake_messages(&mut self) -> Result<(), TLSError> {
         while let Some(msg) = self.common.handshake_joiner.frames.pop_front() {
             self.process_main_protocol(msg)?;
         }

--- a/src/msgs/base.rs
+++ b/src/msgs/base.rs
@@ -85,12 +85,16 @@ impl PayloadU16 {
     pub fn empty() -> PayloadU16 {
         PayloadU16::new(Vec::new())
     }
+
+    pub fn encode_slice(slice: &[u8], bytes: &mut Vec<u8>) {
+        (slice.len() as u16).encode(bytes);
+        bytes.extend_from_slice(slice);
+    }
 }
 
 impl Codec for PayloadU16 {
     fn encode(&self, bytes: &mut Vec<u8>) {
-        (self.0.len() as u16).encode(bytes);
-        bytes.extend_from_slice(&self.0);
+        Self::encode_slice(&self.0, bytes);
     }
 
     fn read(r: &mut Reader) -> Option<PayloadU16> {

--- a/src/msgs/persist_test.rs
+++ b/src/msgs/persist_test.rs
@@ -34,7 +34,8 @@ fn serversessionvalue_is_debug() {
                                       ProtocolVersion::TLSv1_2,
                                       CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
                                       vec![1, 2, 3],
-                                      &None);
+                                      &None,
+                                      None);
     println!("{:?}", ssv);
 }
 
@@ -45,7 +46,7 @@ fn serversessionvalue_no_sni() {
         0x03, 0x03,
         0xc0, 0x23,
         0x03, 0x01, 0x02, 0x03,
-        0x00
+        0x00, 0x00, 0x00,
     ];
     let mut rd = Reader::init(&bytes);
     let ssv = ServerSessionValue::read(&mut rd).unwrap();
@@ -60,7 +61,7 @@ fn serversessionvalue_with_cert() {
         0xc0, 0x23,
         0x03, 0x01, 0x02, 0x03,
         0x00,
-        0x00, 0x00, 0x00
+        0x00, 0x00,
     ];
     let mut rd = Reader::init(&bytes);
     let ssv = ServerSessionValue::read(&mut rd).unwrap();

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -161,6 +161,7 @@ pub trait ServerQuicExt {
     /// TLS-encoded transport parameters to send.
     fn new_quic(config: &Arc<ServerConfig>, params: Vec<u8>) -> ServerSession {
         assert!(config.versions.iter().all(|x| x.get_u16() >= ProtocolVersion::TLSv1_3.get_u16()), "QUIC requires TLS version >= 1.3");
+        assert!(config.max_early_data_size == 0 || config.max_early_data_size == 0xffff_ffff, "QUIC sessions must set a max early data of 0 or 2^32-1");
         let mut imp = ServerSessionImpl::new(config, vec![
             ServerExtension::TransportParameters(params),
         ]);

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use webpki;
 
 /// Secrets used to encrypt/decrypt traffic
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Secrets {
     /// Secret used to encrypt packets transmitted by the client
     pub client: Vec<u8>,

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -24,6 +24,9 @@ pub trait QuicExt {
     /// Return the TLS-encoded transport parameters for the session's peer.
     fn get_quic_transport_parameters(&self) -> Option<&[u8]>;
 
+    /// Return the early traffic secret, used to encrypt 0-RTT data.
+    fn get_early_secret(&self) -> Option<&[u8]>;
+
     /// Consume unencrypted TLS handshake data.
     ///
     /// Handshake data obtained from separate encryption levels should be supplied in separate calls.
@@ -49,6 +52,10 @@ impl QuicExt for ClientSession {
         self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
     }
 
+    fn get_early_secret(&self) -> Option<&[u8]> {
+        self.imp.common.quic.early_secret.as_ref().map(|x| &x[..])
+    }
+
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {
         self.imp.common
             .handshake_joiner
@@ -71,6 +78,10 @@ impl QuicExt for ClientSession {
 impl QuicExt for ServerSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
         self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
+    }
+
+    fn get_early_secret(&self) -> Option<&[u8]> {
+        self.imp.common.quic.early_secret.as_ref().map(|x| &x[..])
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -1,28 +1,125 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use client::{ClientConfig, ClientSession, ClientSessionImpl};
-use msgs::base::Payload;
-use msgs::enums::ExtensionType;
-use msgs::handshake::{ClientExtension, ServerExtension, UnknownExtension};
+use msgs::enums::{ContentType, ProtocolVersion, AlertDescription};
+use msgs::handshake::{ClientExtension, ServerExtension};
+use msgs::message::{Message, MessagePayload};
 use server::{ServerConfig, ServerSession, ServerSessionImpl};
+use error::TLSError;
+use key_schedule::{KeySchedule, SecretKind};
+use session::{SessionCommon, Protocol};
 
 use std::sync::Arc;
 use webpki;
+
+/// Secrets used to encrypt/decrypt traffic
+pub struct Secrets {
+    /// Secret used to encrypt packets transmitted by the client
+    pub client: Vec<u8>,
+    /// Secret used to encrypt packets transmitted by the server
+    pub server: Vec<u8>,
+}
 
 /// Generic methods for QUIC sessions
 pub trait QuicExt {
     /// Return the TLS-encoded transport parameters for the session's peer.
     fn get_quic_transport_parameters(&self) -> Option<&[u8]>;
+
+    /// Consume unencrypted TLS handshake data.
+    ///
+    /// Handshake data obtained from separate encryption levels should be supplied in separate calls.
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError>;
+
+    /// Emit unencrypted TLS handshake data.
+    ///
+    /// When this returns `Some(_)`, the keys used for future handshake data must be derived from
+    /// the new secrets.
+    fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Secrets>;
+
+    /// Emit the TLS description code of a fatal alert, if one has arisen.
+    ///
+    /// Check after `read_hs` returns `Err(_)`.
+    fn get_alert(&self) -> Option<AlertDescription>;
+
+    /// Compute the secrets to use following a 1-RTT key update from their previous values.
+    fn update_secrets(&self, client: &[u8], server: &[u8]) -> Secrets;
 }
 
 impl QuicExt for ClientSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp.quic_params.as_ref().map(|v| v.as_ref())
+        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
     }
+
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {
+        self.imp.common
+            .handshake_joiner
+            .take_message(Message {
+                typ: ContentType::Handshake,
+                version: ProtocolVersion::TLSv1_3,
+                payload: MessagePayload::new_opaque(plaintext.into()),
+            });
+        self.imp.process_new_handshake_messages()?;
+        Ok(())
+    }
+
+    fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Secrets> { write_hs(&mut self.imp.common, buf) }
+
+    fn get_alert(&self) -> Option<AlertDescription> { self.imp.common.quic.alert }
+
+    fn update_secrets(&self, client: &[u8], server: &[u8]) -> Secrets { update_secrets(&self.imp.common, client, server) }
 }
 
 impl QuicExt for ServerSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp.quic_params.as_ref().map(|v| v.as_ref())
+        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
+    }
+
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {
+        self.imp.common
+            .handshake_joiner
+            .take_message(Message {
+                typ: ContentType::Handshake,
+                version: ProtocolVersion::TLSv1_3,
+                payload: MessagePayload::new_opaque(plaintext.into()),
+            });
+        self.imp.process_new_handshake_messages()?;
+        Ok(())
+    }
+    
+    fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Secrets> { write_hs(&mut self.imp.common, buf) }
+
+    fn get_alert(&self) -> Option<AlertDescription> { self.imp.common.quic.alert }
+
+    fn update_secrets(&self, client: &[u8], server: &[u8]) -> Secrets { update_secrets(&self.imp.common, client, server) }
+}
+
+fn write_hs(this: &mut SessionCommon, buf: &mut Vec<u8>) -> Option<Secrets> {
+    while let Some((_, msg)) = this.quic.hs_queue.pop_front() {
+        buf.extend_from_slice(&msg);
+        if let Some(&(true, _)) = this.quic.hs_queue.front() {
+            if this.quic.hs_secrets.is_some() {
+                // Allow the caller to switch keys before proceeding.
+                break;
+            }
+        }
+    }
+    if let Some(secrets) = this.quic.hs_secrets.take() {
+        return Some(secrets);
+    }
+    if let Some(secrets) = this.quic.traffic_secrets.take() {
+        return Some(secrets);
+    }
+    None
+}
+
+fn update_secrets(this: &SessionCommon, client: &[u8], server: &[u8]) -> Secrets {
+    let suite = this.get_suite_assert();
+    // TODO: Don't clone
+    let mut key_schedule = KeySchedule::new(suite.get_hash());
+    key_schedule.current_client_traffic_secret = client.into();
+    key_schedule.current_server_traffic_secret = server.into();
+    Secrets {
+        client: key_schedule.derive_next(SecretKind::ClientApplicationTrafficSecret),
+        server: key_schedule.derive_next(SecretKind::ServerApplicationTrafficSecret),
     }
 }
 
@@ -33,12 +130,11 @@ pub trait ClientQuicExt {
     /// TLS-encoded transport parameters to send.
     fn new_quic(config: &Arc<ClientConfig>, hostname: webpki::DNSNameRef, params: Vec<u8>)
                 -> ClientSession {
+        assert!(config.versions.iter().all(|x| x.get_u16() >= ProtocolVersion::TLSv1_3.get_u16()), "QUIC requires TLS version >= 1.3");
         let mut imp = ClientSessionImpl::new(config);
+        imp.common.protocol = Protocol::Quic;
         imp.start_handshake(hostname.into(), vec![
-            ClientExtension::Unknown(UnknownExtension {
-                typ: ExtensionType::TransportParameters,
-                payload: Payload::new(params),
-            })
+            ClientExtension::TransportParameters(params),
         ]);
         ClientSession { imp }
     }
@@ -52,14 +148,12 @@ pub trait ServerQuicExt {
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
     fn new_quic(config: &Arc<ServerConfig>, params: Vec<u8>) -> ServerSession {
-        ServerSession {
-            imp: ServerSessionImpl::new(config, vec![
-                ServerExtension::Unknown(UnknownExtension {
-                    typ: ExtensionType::TransportParameters,
-                    payload: Payload::new(params),
-                }),
-            ]),
-        }
+        assert!(config.versions.iter().all(|x| x.get_u16() >= ProtocolVersion::TLSv1_3.get_u16()), "QUIC requires TLS version >= 1.3");
+        let mut imp = ServerSessionImpl::new(config, vec![
+            ServerExtension::TransportParameters(params),
+        ]);
+        imp.common.protocol = Protocol::Quic;
+        ServerSession { imp }
     }
 }
 

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -12,7 +12,7 @@ use msgs::handshake::{NamedGroups, SupportedGroups, ClientExtension};
 use msgs::handshake::{ECPointFormatList, SupportedPointFormats};
 use msgs::handshake::{ServerECDHParams, DigitallySignedStruct};
 use msgs::handshake::{ServerKeyExchangePayload, ECDHEServerKeyExchange};
-use msgs::handshake::{CertificateRequestPayload, NewSessionTicketPayload};
+use msgs::handshake::{CertificateRequestPayload, NewSessionTicketPayload, NewSessionTicketExtension};
 use msgs::handshake::{CertificateRequestPayloadTLS13, NewSessionTicketPayloadTLS13};
 use msgs::handshake::{HelloRetryRequest, HelloRetryExtension, KeyShareEntry};
 use msgs::handshake::{CertificatePayloadTLS13, CertificateEntry};
@@ -356,6 +356,8 @@ impl ExpectClientHello {
 
         check_aligned_handshake(sess)?;
 
+        let client_hello_hash = sess.common.hs_transcript.get_hash_given(sess.common.get_suite_assert().get_hash(), &[]);
+
         trace!("sending server hello {:?}", sh);
         sess.common.hs_transcript.add_message(&sh);
         sess.common.send_msg(sh, false);
@@ -365,6 +367,14 @@ impl ExpectClientHello {
         let mut key_schedule = KeySchedule::new(suite.get_hash());
         if let Some(psk) = resuming_psk {
             key_schedule.input_secret(&psk);
+
+            #[cfg(feature = "quic")] {
+                if sess.common.protocol == Protocol::Quic {
+                    let client_early_traffic_secret = key_schedule
+                        .derive(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash);
+                    sess.common.quic.early_secret = Some(client_early_traffic_secret);
+                }
+            }
         } else {
             key_schedule.input_empty();
         }
@@ -1722,7 +1732,12 @@ impl ExpectTLS13Finished {
 
         let ticket = maybe_ticket.unwrap();
         let age_add = rand::random_u32(); // nb, we don't do 0-RTT data, so whatever
-        let payload = NewSessionTicketPayloadTLS13::new(ticket_lifetime, age_add, nonce, ticket);
+        let mut payload = NewSessionTicketPayloadTLS13::new(ticket_lifetime, age_add, nonce, ticket);
+        #[cfg(feature = "quic")] {
+            if sess.config.max_early_data_size > 0 && sess.common.protocol == Protocol::Quic {
+                payload.exts.push(NewSessionTicketExtension::EarlyData(sess.config.max_early_data_size));
+            }
+        }
         let m = Message {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
@@ -1747,7 +1762,12 @@ impl ExpectTLS13Finished {
         if sess.config.session_storage.put(id.clone(), plain) {
             let stateful_lifetime = 24 * 60 * 60; // this is a bit of a punt
             let age_add = rand::random_u32();
-            let payload = NewSessionTicketPayloadTLS13::new(stateful_lifetime, age_add, nonce, id);
+            let mut payload = NewSessionTicketPayloadTLS13::new(stateful_lifetime, age_add, nonce, id);
+            #[cfg(feature = "quic")] {
+                if sess.config.max_early_data_size > 0 && sess.common.protocol == Protocol::Quic {
+                    payload.exts.push(NewSessionTicketExtension::EarlyData(sess.config.max_early_data_size));
+                }
+            }
             let m = Message {
                 typ: ContentType::Handshake,
                 version: ProtocolVersion::TLSv1_3,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -141,6 +141,11 @@ pub struct ServerConfig {
     /// How to output key material for debugging.  The default
     /// does nothing.
     pub key_log: Arc<KeyLog>,
+
+    /// Amount of early data to accept; 0 to disable.
+    #[cfg(feature = "quic")]    // TLS support unimplemented
+    #[doc(hidden)]
+    pub max_early_data_size: u32,
 }
 
 impl ServerConfig {
@@ -169,6 +174,8 @@ impl ServerConfig {
             versions: vec![ ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2 ],
             verifier: client_cert_verifier,
             key_log: Arc::new(NoKeyLog {}),
+            #[cfg(feature = "quic")]
+            max_early_data_size: 0,
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -341,7 +341,7 @@ impl ServerSessionImpl {
         self.process_main_protocol(msg)
     }
 
-    fn process_new_handshake_messages(&mut self) -> Result<(), TLSError> {
+    pub fn process_new_handshake_messages(&mut self) -> Result<(), TLSError> {
         while let Some(msg) = self.common.handshake_joiner.frames.pop_front() {
             self.process_main_protocol(msg)?;
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -904,6 +904,7 @@ pub(crate) struct Quic {
     pub params: Option<Vec<u8>>,
     pub alert: Option<AlertDescription>,
     pub hs_queue: VecDeque<(bool, Vec<u8>)>,
+    pub early_secret: Option<Vec<u8>>,
     pub hs_secrets: Option<quic::Secrets>,
     pub traffic_secrets: Option<quic::Secrets>,
 }
@@ -918,6 +919,7 @@ impl Quic {
             params: None,
             alert: None,
             hs_queue: VecDeque::new(),
+            early_secret: None,
             hs_secrets: None,
             traffic_secrets: None,
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -205,7 +205,7 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Protocol {
     Tls13,
     #[cfg(feature = "quic")]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1974,6 +1974,7 @@ fn quic_handshake() {
         ClientSession::new_quic(&client_config, dns_name("localhost"), client_params.into());
     let mut server = ServerSession::new_quic(&server_config, server_params.into());
     step(&mut client, &mut server).unwrap();
+    assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
     let client_early = client.get_early_secret().unwrap();
     let server_early = server.get_early_secret().unwrap();
     assert_eq!(client_early, server_early);


### PR DESCRIPTION
This works towards supporting [the new QUIC TLS interface](https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#rfc.section.3), wherein QUIC subsumes the TLS record layer, taking over responsibility for fragmentation, encryption/decryption, and communication of alerts.

While `read_hs` as written should handle incoming data correctly, I'm unsure how to proceed with handling outgoing handshake data and alerts. The current implementation performs encoding of alerts, encryption, and fragmentation eagerly, all of which are undesired.

Ideally I'd like to defer these operations to being performed on demand, so that the QUIC interface can easily pass the data out as-is, while the regular interface performs the transformations necessary for conventional use. This seems likely to be a more invasive change, so before I proceed I'd like feedback on the idea, and input on how to approach implementing it.

This interface will likely need to be further extended with helpers to perform [the necessary key derivation](https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#rfc.section.5.1), which uses different labels than that of TLS.