### PR TITLE
KTLS Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = ["logging"]
 logging = ["log"]
 dangerous_configuration = []
 quic = []
+pub-secrets = []
 
 [dev-dependencies]
 log = "0.4"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 use msgs::enums::CipherSuite;
 use msgs::enums::{AlertDescription, HandshakeType};
-use session::{Session, SessionCommon};
+use session::{Session, SessionCommon, SessionSecrets};
 use keylog::{KeyLog, NoKeyLog};
 use suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use msgs::handshake::CertificatePayload;
@@ -628,6 +628,14 @@ impl ClientSession {
 }
 
 impl Session for ClientSession {
+    fn get_secrets(&self) -> Option<&SessionSecrets> {
+        self.imp.common.secrets.as_ref()
+    }
+
+    fn get_seq(&self) -> (u64, u64) {
+        (self.imp.common.read_seq, self.imp.common.write_seq)
+    }
+
     fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
         self.imp.common.read_tls(rd)
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -628,10 +628,12 @@ impl ClientSession {
 }
 
 impl Session for ClientSession {
+    #[cfg(feature = "pub-secrets")]
     fn get_secrets(&self) -> Option<&SessionSecrets> {
         self.imp.common.secrets.as_ref()
     }
 
+    #[cfg(feature = "pub-secrets")]
     fn get_seq(&self) -> (u64, u64) {
         (self.imp.common.read_seq, self.imp.common.write_seq)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,4 @@
-use session::{Session, SessionCommon};
+use session::{Session, SessionCommon, SessionSecrets};
 use keylog::{KeyLog, NoKeyLog};
 use suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use msgs::enums::{ContentType, SignatureScheme};
@@ -457,6 +457,14 @@ impl ServerSession {
 }
 
 impl Session for ServerSession {
+    fn get_secrets(&self) -> Option<&SessionSecrets> {
+        self.imp.common.secrets.as_ref()
+    }
+
+    fn get_seq(&self) -> (u64, u64) {
+        (self.imp.common.read_seq, self.imp.common.write_seq)
+    }
+
     fn read_tls(&mut self, rd: &mut io::Read) -> io::Result<usize> {
         self.imp.common.read_tls(rd)
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -457,10 +457,12 @@ impl ServerSession {
 }
 
 impl Session for ServerSession {
+    #[cfg(feature = "pub-secrets")]
     fn get_secrets(&self) -> Option<&SessionSecrets> {
         self.imp.common.secrets.as_ref()
     }
 
+    #[cfg(feature = "pub-secrets")]
     fn get_seq(&self) -> (u64, u64) {
         (self.imp.common.read_seq, self.imp.common.write_seq)
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,12 @@ use std::collections::VecDeque;
 
 /// Generalises `ClientSession` and `ServerSession`
 pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
+    /// TODO
+    fn get_secrets(&self) -> Option<&SessionSecrets>;
+
+    /// TODO
+    fn get_seq(&self) -> (u64, u64);
+
     /// Read TLS content from `rd`.  This method does internal
     /// buffering, so `rd` can supply TLS messages in arbitrary-
     /// sized chunks (like a socket or pipe might).
@@ -396,8 +402,8 @@ pub struct SessionCommon {
     pub secrets: Option<SessionSecrets>,
     key_schedule: Option<KeySchedule>,
     suite: Option<&'static SupportedCipherSuite>,
-    write_seq: u64,
-    read_seq: u64,
+    pub write_seq: u64,
+    pub read_seq: u64,
     peer_eof: bool,
     pub peer_encrypting: bool,
     pub we_encrypting: bool,

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,12 +23,6 @@ use std::collections::VecDeque;
 
 /// Generalises `ClientSession` and `ServerSession`
 pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
-    /// TODO
-    fn get_secrets(&self) -> Option<&SessionSecrets>;
-
-    /// TODO
-    fn get_seq(&self) -> (u64, u64);
-
     /// Read TLS content from `rd`.  This method does internal
     /// buffering, so `rd` can supply TLS messages in arbitrary-
     /// sized chunks (like a socket or pipe might).
@@ -141,6 +135,14 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
     ///
     /// This returns None until the ciphersuite is agreed.
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite>;
+
+    /// Get session secrets.
+    ///
+    /// The return value is None until handshake completion.
+    fn get_secrets(&self) -> Option<&SessionSecrets>;
+
+    /// Get read and write sequence number.
+    fn get_seq(&self) -> (u64, u64);
 
     /// This function uses `io` to complete any outstanding IO for
     /// this session.

--- a/src/session.rs
+++ b/src/session.rs
@@ -138,10 +138,14 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
 
     /// Get session secrets.
     ///
+    /// This allows you to use Rustls as handshake and then use KTLS or
+    /// other implementations for encryption.
     /// The return value is None until handshake completion.
+    #[cfg(feature = "pub-secrets")]
     fn get_secrets(&self) -> Option<&SessionSecrets>;
 
     /// Get read and write sequence number.
+    #[cfg(feature = "pub-secrets")]
     fn get_seq(&self) -> (u64, u64);
 
     /// This function uses `io` to complete any outstanding IO for


### PR DESCRIPTION
This PR allows the we to get session secrets and sequence numbers, in order to use rustls as a handshake for KTLS.