### PR TITLE
Move HandshakeHash into SessionCommon

### DIFF
--- a/src/client/common.rs
+++ b/src/client/common.rs
@@ -8,7 +8,6 @@ use msgs::persist;
 use msgs::enums::ExtensionType;
 use msgs::enums::NamedGroup;
 use session::SessionRandoms;
-use hash_hs;
 use sign;
 use suites;
 use webpki;
@@ -50,7 +49,6 @@ impl ServerKXDetails {
 }
 
 pub struct HandshakeDetails {
-    pub transcript: hash_hs::HandshakeHash,
     pub resuming_session: Option<persist::ClientSessionValue>,
     pub hash_at_client_recvd_server_hello: Vec<u8>,
     pub randoms: SessionRandoms,
@@ -64,7 +62,6 @@ pub struct HandshakeDetails {
 impl HandshakeDetails {
     pub fn new(host_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> HandshakeDetails {
         HandshakeDetails {
-            transcript: hash_hs::HandshakeHash::new(),
             hash_at_client_recvd_server_hello: Vec::new(),
             resuming_session: None,
             randoms: SessionRandoms::for_client(),

--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -145,7 +145,7 @@ pub fn fill_in_psk_binder(sess: &mut ClientSessionImpl,
     // length, or the length of its container.
     let binder_plaintext = hmp.get_encoding_for_binder_signing();
     let handshake_hash =
-        handshake.transcript.get_hash_given(suite_hash, &binder_plaintext);
+        sess.common.hs_transcript.get_hash_given(suite_hash, &binder_plaintext);
 
     let mut empty_hash_ctx = hash_hs::HandshakeHash::new();
     empty_hash_ctx.start_hash(suite_hash);
@@ -175,9 +175,9 @@ impl InitialState {
         }
     }
 
-    fn emit_initial_client_hello(mut self, sess: &mut ClientSessionImpl) -> NextState {
+    fn emit_initial_client_hello(self, sess: &mut ClientSessionImpl) -> NextState {
         if sess.config.client_auth_cert_resolver.has_certs() {
-            self.handshake.transcript.set_client_auth_enabled();
+            sess.common.hs_transcript.set_client_auth_enabled();
         }
         let hello_details = ClientHelloDetails::new();
         emit_client_hello_for_retry(sess, self.handshake, hello_details, None)
@@ -425,7 +425,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
 
     trace!("Sending ClientHello {:#?}", ch);
 
-    handshake.transcript.add_message(&ch);
+    sess.common.hs_transcript.add_message(&ch);
     sess.common.send_msg(ch, false);
 
     // Calculate the hash of ClientHello and use it to derive EarlyTrafficSecret
@@ -438,7 +438,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
             .as_ref()
             .and_then(|resume| sess.find_cipher_suite(resume.cipher_suite)).unwrap();
 
-        let client_hello_hash = handshake.transcript.get_hash_given(resuming_suite.get_hash(), &[]);
+        let client_hello_hash = sess.common.hs_transcript.get_hash_given(resuming_suite.get_hash(), &[]);
         let client_early_traffic_secret = sess.common
             .get_key_schedule()
             .derive(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash);
@@ -565,7 +565,7 @@ impl ExpectServerHello {
         check_aligned_handshake(sess)?;
 
         self.handshake.hash_at_client_recvd_server_hello =
-            self.handshake.transcript.get_current_hash();;
+            sess.common.hs_transcript.get_current_hash();
 
         if !sess.early_data.is_enabled() {
             // Set the client encryption key for handshakes if early data is not used
@@ -732,8 +732,9 @@ impl State for ExpectServerHello {
         }
 
         // Start our handshake hash, and input the server-hello.
-        self.handshake.transcript.start_hash(sess.common.get_suite_assert().get_hash());
-        self.handshake.transcript.add_message(&m);
+        let starting_hash = sess.common.get_suite_assert().get_hash();
+        sess.common.hs_transcript.start_hash(starting_hash);
+        sess.common.hs_transcript.add_message(&m);
 
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
@@ -838,7 +839,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         Box::new(self.0)
     }
 
-    fn handle_hello_retry_request(mut self, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle_hello_retry_request(self, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         check_handshake_message(&m, &[HandshakeType::HelloRetryRequest])?;
 
         let hrr = extract_handshake!(m, HandshakePayload::HelloRetryRequest).unwrap();
@@ -905,9 +906,9 @@ impl ExpectServerHelloOrHelloRetryRequest {
         sess.common.set_suite(cs);
 
         // This is the draft19 change where the transcript became a tree
-        self.0.handshake.transcript.start_hash(cs.get_hash());
-        self.0.handshake.transcript.rollup_for_hrr();
-        self.0.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.start_hash(cs.get_hash());
+        sess.common.hs_transcript.rollup_for_hrr();
+        sess.common.hs_transcript.add_message(&m);
 
         // Early data is not alllowed after HelloRetryrequest
         if sess.early_data.is_enabled() {
@@ -995,10 +996,10 @@ impl State for ExpectTLS13EncryptedExtensions {
         check_handshake_message(m, &[HandshakeType::EncryptedExtensions])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let exts = extract_handshake!(m, HandshakePayload::EncryptedExtensions).unwrap();
         debug!("TLS1.3 encrypted extensions: {:?}", exts);
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         validate_encrypted_extensions(sess, &self.hello, exts)?;
         process_alpn_protocol(sess, exts.get_alpn_protocol())?;
@@ -1074,7 +1075,7 @@ impl State for ExpectTLS13Certificate {
 
     fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let cert_chain = extract_handshake!(m, HandshakePayload::CertificateTLS13).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         // This is only non-empty for client auth.
         if !cert_chain.context.0.is_empty() {
@@ -1140,9 +1141,9 @@ impl State for ExpectTLS12Certificate {
         check_handshake_message(m, &[HandshakeType::Certificate])
     }
 
-    fn handle(mut self: Box<Self>, _sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let cert_chain = extract_handshake!(m, HandshakePayload::Certificate).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         self.server_cert.cert_chain = cert_chain.clone();
 
@@ -1175,8 +1176,8 @@ impl State for ExpectTLS12CertificateStatus {
         check_handshake_message(m, &[HandshakeType::CertificateStatus])
     }
 
-    fn handle(mut self: Box<Self>, _sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
-        self.handshake.transcript.add_message(&m);
+    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+        sess.common.hs_transcript.add_message(&m);
         let mut status = extract_handshake_mut!(m, HandshakePayload::CertificateStatus).unwrap();
 
         self.server_cert.ocsp_response = status.take_ocsp_response();
@@ -1285,10 +1286,10 @@ impl State for ExpectTLS12ServerKX {
         check_handshake_message(m, &[HandshakeType::ServerKeyExchange])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let opaque_kx = extract_handshake!(m, HandshakePayload::ServerKeyExchange).unwrap();
         let maybe_decoded_kx = opaque_kx.unwrap_given_kxa(&sess.common.get_suite_assert().kx);
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         if maybe_decoded_kx.is_none() {
             sess.common.send_fatal_alert(AlertDescription::DecodeError);
@@ -1370,7 +1371,7 @@ impl State for ExpectTLS13CertificateVerify {
             .map_err(|err| send_cert_error_alert(sess, err))?;
 
         // 2. Verify their signature on the handshake.
-        let handshake_hash = self.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let sigv = verify::verify_tls13(&self.server_cert.cert_chain[0],
                                         cert_verify,
                                         &handshake_hash,
@@ -1388,14 +1389,13 @@ impl State for ExpectTLS13CertificateVerify {
         }
 
         sess.server_cert_chain = self.server_cert.take_chain();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         Ok(self.into_expect_tls13_finished(certv, sigv))
     }
 }
 
-fn emit_certificate(handshake: &mut HandshakeDetails,
-                    client_auth: &mut ClientAuthDetails,
+fn emit_certificate(client_auth: &mut ClientAuthDetails,
                     sess: &mut ClientSessionImpl) {
     let chosen_cert = client_auth.cert.take();
 
@@ -1408,12 +1408,11 @@ fn emit_certificate(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&cert);
+    sess.common.hs_transcript.add_message(&cert);
     sess.common.send_msg(cert, false);
 }
 
-fn emit_clientkx(handshake: &mut HandshakeDetails,
-                 sess: &mut ClientSessionImpl,
+fn emit_clientkx(sess: &mut ClientSessionImpl,
                  kxd: &suites::KeyExchangeResult) {
     let mut buf = Vec::new();
     let ecpoint = PayloadU8::new(kxd.pubkey.clone());
@@ -1429,20 +1428,19 @@ fn emit_clientkx(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&ckx);
+    sess.common.hs_transcript.add_message(&ckx);
     sess.common.send_msg(ckx, false);
 }
 
-fn emit_certverify(handshake: &mut HandshakeDetails,
-                   client_auth: &mut ClientAuthDetails,
+fn emit_certverify(client_auth: &mut ClientAuthDetails,
                    sess: &mut ClientSessionImpl) -> Result<(), TLSError> {
     if client_auth.signer.is_none() {
         trace!("Not sending CertificateVerify, no key");
-        handshake.transcript.abandon_client_auth();
+        sess.common.hs_transcript.abandon_client_auth();
         return Ok(());
     }
 
-    let message = handshake.transcript.take_handshake_buf();
+    let message = sess.common.hs_transcript.take_handshake_buf();
     let signer = client_auth.signer.take().unwrap();
     let scheme = signer.get_scheme();
     let sig = signer.sign(&message)?;
@@ -1457,7 +1455,7 @@ fn emit_certverify(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, false);
     Ok(())
 }
@@ -1473,9 +1471,8 @@ fn emit_ccs(sess: &mut ClientSessionImpl) {
     sess.common.we_now_encrypting();
 }
 
-fn emit_finished(handshake: &mut HandshakeDetails,
-                 sess: &mut ClientSessionImpl) {
-    let vh = handshake.transcript.get_current_hash();
+fn emit_finished(sess: &mut ClientSessionImpl) {
+    let vh = sess.common.hs_transcript.get_current_hash();
     let verify_data = sess.common.secrets
         .as_ref()
         .unwrap()
@@ -1491,7 +1488,7 @@ fn emit_finished(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&f);
+    sess.common.hs_transcript.add_message(&f);
     sess.common.send_msg(f, true);
 }
 
@@ -1522,9 +1519,9 @@ impl State for ExpectTLS12CertificateRequest {
         check_handshake_message(m, &[HandshakeType::CertificateRequest])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let certreq = extract_handshake!(m, HandshakePayload::CertificateRequest).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         debug!("Got CertificateRequest {:?}", certreq);
 
         let mut client_auth = ClientAuthDetails::new();
@@ -1581,9 +1578,9 @@ impl State for ExpectTLS13CertificateRequest {
         check_handshake_message(m, &[HandshakeType::CertificateRequest])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let certreq = &extract_handshake!(m, HandshakePayload::CertificateRequestTLS13).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         debug!("Got CertificateRequest {:?}", certreq);
 
         // Fortunately the problems here in TLS1.2 and prior are corrected in
@@ -1669,11 +1666,11 @@ impl State for ExpectTLS12ServerDoneOrCertReq {
                                   HandshakeType::ServerHelloDone])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         if extract_handshake!(m, HandshakePayload::CertificateRequest).is_some() {
             self.into_expect_tls12_certificate_req().handle(sess, m)
         } else {
-            self.handshake.transcript.abandon_client_auth();
+            sess.common.hs_transcript.abandon_client_auth();
             self.into_expect_tls12_server_done().handle(sess, m)
         }
     }
@@ -1720,7 +1717,7 @@ impl State for ExpectTLS12ServerDone {
 
     fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let mut st = *self;
-        st.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         debug!("Server cert is {:?}", st.server_cert.cert_chain);
         debug!("Server DNS name is {:?}", st.handshake.dns_name);
@@ -1788,8 +1785,7 @@ impl State for ExpectTLS12ServerDone {
 
         // 4.
         if st.client_auth.is_some() {
-            emit_certificate(&mut st.handshake,
-                             st.client_auth.as_mut().unwrap(),
+            emit_certificate(st.client_auth.as_mut().unwrap(),
                              sess);
         }
 
@@ -1799,14 +1795,13 @@ impl State for ExpectTLS12ServerDone {
             .ok_or_else(|| TLSError::PeerMisbehavedError("key exchange failed".to_string()))?;
 
         // 5b.
-        emit_clientkx(&mut st.handshake, sess, &kxd);
+        emit_clientkx(sess, &kxd);
         // nb. EMS handshake hash only runs up to ClientKeyExchange.
-        let handshake_hash = st.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
 
         // 5c.
         if st.client_auth.is_some() {
-            emit_certverify(&mut st.handshake,
-                            st.client_auth.as_mut().unwrap(),
+            emit_certverify(st.client_auth.as_mut().unwrap(),
                             sess)?;
         }
 
@@ -1831,7 +1826,7 @@ impl State for ExpectTLS12ServerDone {
         sess.common.start_encryption_tls12(secrets);
 
         // 6.
-        emit_finished(&mut st.handshake, sess);
+        emit_finished(sess);
 
         if st.must_issue_new_ticket {
             Ok(st.into_expect_tls12_new_ticket(certv, sigv))
@@ -1909,8 +1904,8 @@ impl State for ExpectTLS12NewTicket {
         check_handshake_message(m, &[HandshakeType::NewSessionTicket])
     }
 
-    fn handle(mut self: Box<Self>, _sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
-        self.handshake.transcript.add_message(&m);
+    fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
+        sess.common.hs_transcript.add_message(&m);
 
         let nst = extract_handshake_mut!(m, HandshakePayload::NewSessionTicket).unwrap();
         let recvd = ReceivedTicketDetails::from(nst.ticket.0, nst.lifetime_hint);
@@ -1961,8 +1956,7 @@ fn save_session(handshake: &mut HandshakeDetails,
     }
 }
 
-fn emit_certificate_tls13(handshake: &mut HandshakeDetails,
-                          client_auth: &mut ClientAuthDetails,
+fn emit_certificate_tls13(client_auth: &mut ClientAuthDetails,
                           sess: &mut ClientSessionImpl) {
     let context = client_auth.auth_context
         .take()
@@ -1987,12 +1981,11 @@ fn emit_certificate_tls13(handshake: &mut HandshakeDetails,
             payload: HandshakePayload::CertificateTLS13(cert_payload),
         }),
     };
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, true);
 }
 
-fn emit_certverify_tls13(handshake: &mut HandshakeDetails,
-                         client_auth: &mut ClientAuthDetails,
+fn emit_certverify_tls13(client_auth: &mut ClientAuthDetails,
                          sess: &mut ClientSessionImpl) -> Result<(), TLSError> {
     if client_auth.signer.is_none() {
         debug!("Skipping certverify message (no client scheme/key)");
@@ -2002,7 +1995,7 @@ fn emit_certverify_tls13(handshake: &mut HandshakeDetails,
     let mut message = Vec::new();
     message.resize(64, 0x20u8);
     message.extend_from_slice(b"TLS 1.3, client CertificateVerify\x00");
-    message.extend_from_slice(&handshake.transcript.get_current_hash());
+    message.extend_from_slice(&sess.common.hs_transcript.get_current_hash());
 
     let signer = client_auth.signer.take().unwrap();
     let scheme = signer.get_scheme();
@@ -2018,14 +2011,13 @@ fn emit_certverify_tls13(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, true);
     Ok(())
 }
 
-fn emit_finished_tls13(handshake: &mut HandshakeDetails,
-                       sess: &mut ClientSessionImpl) {
-    let handshake_hash = handshake.transcript.get_current_hash();
+fn emit_finished_tls13(sess: &mut ClientSessionImpl) {
+    let handshake_hash = sess.common.hs_transcript.get_current_hash();
     let verify_data = sess.common
         .get_key_schedule()
         .sign_finish(SecretKind::ClientHandshakeTrafficSecret, &handshake_hash);
@@ -2040,12 +2032,11 @@ fn emit_finished_tls13(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, true);
 }
 
-fn emit_end_of_early_data_tls13(handshake: &mut HandshakeDetails,
-                                sess: &mut ClientSessionImpl) {
+fn emit_end_of_early_data_tls13(sess: &mut ClientSessionImpl) {
     let m = Message {
         typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_3,
@@ -2055,7 +2046,7 @@ fn emit_end_of_early_data_tls13(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, true);
 }
 
@@ -2087,7 +2078,7 @@ impl State for ExpectTLS13Finished {
         let mut st = *self;
         let finished = extract_handshake!(m, HandshakePayload::Finished).unwrap();
 
-        let handshake_hash = st.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let expect_verify_data = sess.common
             .get_key_schedule()
             .sign_finish(SecretKind::ServerHandshakeTrafficSecret, &handshake_hash);
@@ -2111,13 +2102,13 @@ impl State for ExpectTLS13Finished {
             None
         };
 
-        st.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         /* Transition to application data */
         sess.common.get_mut_key_schedule().input_empty();
 
         /* Traffic from server is now decrypted with application data keys. */
-        let handshake_hash = st.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let read_key = sess.common
             .get_key_schedule()
             .derive(SecretKind::ServerApplicationTrafficSecret, &handshake_hash);
@@ -2140,7 +2131,7 @@ impl State for ExpectTLS13Finished {
         /* The EndOfEarlyData message to server is still encrypted with early data keys,
          * but appears in the transcript after the server Finished. */
         if let Some(write_key) = maybe_write_key {
-            emit_end_of_early_data_tls13(&mut st.handshake, sess);
+            emit_end_of_early_data_tls13(sess);
             sess.common.early_traffic = false;
             sess.early_data.finished();
             sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
@@ -2153,16 +2144,13 @@ impl State for ExpectTLS13Finished {
         /* Send our authentication/finished messages.  These are still encrypted
          * with our handshake keys. */
         if st.client_auth.is_some() {
-            emit_certificate_tls13(&mut st.handshake,
-                                   st.client_auth.as_mut().unwrap(),
+            emit_certificate_tls13(st.client_auth.as_mut().unwrap(),
                                    sess);
-            emit_certverify_tls13(&mut st.handshake,
-                                  st.client_auth.as_mut().unwrap(),
+            emit_certverify_tls13(st.client_auth.as_mut().unwrap(),
                                   sess)?;
         }
 
-        emit_finished_tls13(&mut st.handshake,
-                            sess);
+        emit_finished_tls13(sess);
 
         /* Now move to our application traffic keys. */
         check_aligned_handshake(sess)?;
@@ -2212,7 +2200,7 @@ impl State for ExpectTLS12Finished {
         let finished = extract_handshake!(m, HandshakePayload::Finished).unwrap();
 
         // Work out what verify_data we expect.
-        let vh = st.handshake.transcript.get_current_hash();
+        let vh = sess.common.hs_transcript.get_current_hash();
         let expect_verify_data = sess.common.secrets
             .as_ref()
             .unwrap()
@@ -2228,7 +2216,7 @@ impl State for ExpectTLS12Finished {
             .map(|_| verify::FinishedMessageVerified::assertion())?;
 
         // Hash this message too.
-        st.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         save_session(&mut st.handshake,
                      &mut st.ticket,
@@ -2236,7 +2224,7 @@ impl State for ExpectTLS12Finished {
 
         if st.resuming {
             emit_ccs(sess);
-            emit_finished(&mut st.handshake, sess);
+            emit_finished(sess);
         }
 
         sess.common.we_now_encrypting();
@@ -2276,7 +2264,7 @@ struct ExpectTLS13Traffic {
 impl ExpectTLS13Traffic {
     fn handle_new_ticket_tls13(&mut self, sess: &mut ClientSessionImpl, m: Message) -> Result<(), TLSError> {
         let nst = extract_handshake!(m, HandshakePayload::NewSessionTicketTLS13).unwrap();
-        let handshake_hash = self.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let resumption_master_secret = sess.common
             .get_key_schedule()
             .derive(SecretKind::ResumptionMasterSecret, &handshake_hash);

--- a/src/server/common.rs
+++ b/src/server/common.rs
@@ -1,13 +1,11 @@
 use session::SessionRandoms;
 use msgs::handshake::{ServerExtension, SessionID};
-use hash_hs;
 use suites;
 use key;
 
 use std::mem;
 
 pub struct HandshakeDetails {
-    pub transcript: hash_hs::HandshakeHash,
     pub hash_at_server_fin: Vec<u8>,
     pub session_id: SessionID,
     pub randoms: SessionRandoms,
@@ -18,7 +16,6 @@ pub struct HandshakeDetails {
 impl HandshakeDetails {
     pub fn new(extra_exts: Vec<ServerExtension>) -> HandshakeDetails {
         HandshakeDetails {
-            transcript: hash_hs::HandshakeHash::new(),
             hash_at_server_fin: Vec::new(),
             session_id: SessionID::empty(),
             randoms: SessionRandoms::for_server(),

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -131,20 +131,14 @@ pub struct ExpectClientHello {
 }
 
 impl ExpectClientHello {
-    pub fn new(perhaps_client_auth: bool, extra_exts: Vec<ServerExtension>) -> ExpectClientHello {
-        let mut ret = ExpectClientHello {
+    pub fn new(extra_exts: Vec<ServerExtension>) -> ExpectClientHello {
+        ExpectClientHello {
             handshake: HandshakeDetails::new(extra_exts),
             done_retry: false,
             send_cert_status: false,
             send_sct: false,
             send_ticket: false,
-        };
-
-        if perhaps_client_auth {
-            ret.handshake.transcript.set_client_auth_enabled();
         }
-
-        ret
     }
 
     fn into_expect_tls12_ccs(self) -> NextState {
@@ -306,7 +300,7 @@ impl ExpectClientHello {
         };
 
         let suite_hash = sess.common.get_suite_assert().get_hash();
-        let handshake_hash = self.handshake.transcript.get_hash_given(suite_hash, &binder_plaintext);
+        let handshake_hash = sess.common.hs_transcript.get_hash_given(suite_hash, &binder_plaintext);
 
         let mut key_schedule = KeySchedule::new(suite_hash);
         key_schedule.input_secret(psk);
@@ -358,7 +352,7 @@ impl ExpectClientHello {
         check_aligned_handshake(sess)?;
 
         trace!("sending server hello {:?}", sh);
-        self.handshake.transcript.add_message(&sh);
+        sess.common.hs_transcript.add_message(&sh);
         sess.common.send_msg(sh, false);
 
         // Start key schedule
@@ -371,7 +365,7 @@ impl ExpectClientHello {
         }
         key_schedule.input_secret(&kxr.premaster_secret);
 
-        let handshake_hash = self.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let write_key = key_schedule.derive(SecretKind::ServerHandshakeTrafficSecret, &handshake_hash);
         let read_key = key_schedule.derive(SecretKind::ClientHandshakeTrafficSecret, &handshake_hash);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
@@ -422,8 +416,8 @@ impl ExpectClientHello {
         };
 
         trace!("Requesting retry {:?}", m);
-        self.handshake.transcript.rollup_for_hrr();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.rollup_for_hrr();
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, false);
     }
 
@@ -444,7 +438,7 @@ impl ExpectClientHello {
         };
 
         trace!("sending encrypted extensions {:?}", ee);
-        self.handshake.transcript.add_message(&ee);
+        sess.common.hs_transcript.add_message(&ee);
         sess.common.send_msg(ee, true);
         Ok(())
     }
@@ -477,7 +471,7 @@ impl ExpectClientHello {
         };
 
         trace!("Sending CertificateRequest {:?}", m);
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, true);
         true
     }
@@ -524,7 +518,7 @@ impl ExpectClientHello {
         };
 
         trace!("sending certificate {:?}", c);
-        self.handshake.transcript.add_message(&c);
+        sess.common.hs_transcript.add_message(&c);
         sess.common.send_msg(c, true);
     }
 
@@ -536,7 +530,7 @@ impl ExpectClientHello {
         let mut message = Vec::new();
         message.resize(64, 0x20u8);
         message.extend_from_slice(b"TLS 1.3, server CertificateVerify\x00");
-        message.extend_from_slice(&self.handshake.transcript.get_current_hash());
+        message.extend_from_slice(&sess.common.hs_transcript.get_current_hash());
 
         let signing_key = &server_key.key;
         let signer = signing_key.choose_scheme(schemes)
@@ -557,13 +551,13 @@ impl ExpectClientHello {
         };
 
         trace!("sending certificate-verify {:?}", m);
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, true);
         Ok(())
     }
 
     fn emit_finished_tls13(&mut self, sess: &mut ServerSessionImpl) {
-        let handshake_hash = self.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let verify_data = sess.common
             .get_key_schedule()
             .sign_finish(SecretKind::ServerHandshakeTrafficSecret, &handshake_hash);
@@ -579,8 +573,8 @@ impl ExpectClientHello {
         };
 
         trace!("sending finished {:?}", m);
-        self.handshake.transcript.add_message(&m);
-        self.handshake.hash_at_server_fin = self.handshake.transcript.get_current_hash();
+        sess.common.hs_transcript.add_message(&m);
+        self.handshake.hash_at_server_fin = sess.common.hs_transcript.get_current_hash();
         sess.common.send_msg(m, true);
 
         // Now move to application data keys.
@@ -635,7 +629,7 @@ impl ExpectClientHello {
         };
 
         trace!("sending server hello {:?}", sh);
-        self.handshake.transcript.add_message(&sh);
+        sess.common.hs_transcript.add_message(&sh);
         sess.common.send_msg(sh, false);
         Ok(())
     }
@@ -654,7 +648,7 @@ impl ExpectClientHello {
             }),
         };
 
-        self.handshake.transcript.add_message(&c);
+        sess.common.hs_transcript.add_message(&c);
         sess.common.send_msg(c, false);
     }
 
@@ -678,7 +672,7 @@ impl ExpectClientHello {
             }),
         };
 
-        self.handshake.transcript.add_message(&c);
+        sess.common.hs_transcript.add_message(&c);
         sess.common.send_msg(c, false);
     }
 
@@ -718,7 +712,7 @@ impl ExpectClientHello {
             }),
         };
 
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, false);
         Ok(kx)
     }
@@ -749,7 +743,7 @@ impl ExpectClientHello {
         };
 
         trace!("Sending CertificateRequest {:?}", m);
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, false);
         true
     }
@@ -764,7 +758,7 @@ impl ExpectClientHello {
             }),
         };
 
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, false);
     }
 
@@ -814,7 +808,7 @@ impl ExpectClientHello {
             emit_ticket(&mut self.handshake, sess);
         }
         emit_ccs(sess);
-        emit_finished(&mut self.handshake, sess);
+        emit_finished(sess);
 
         assert!(same_dns_name_or_both_none(sni, sess.get_sni()));
 
@@ -859,7 +853,7 @@ impl ExpectClientHello {
             // We don't have a suitable key share.  Choose a suitable group and
             // send a HelloRetryRequest.
             let retry_group_maybe = util::first_in_both(&NamedGroups::supported(), groups_ext);
-            self.handshake.transcript.add_message(chm);
+            sess.common.hs_transcript.add_message(chm);
 
             if let Some(group) = retry_group_maybe {
                 if self.done_retry {
@@ -926,7 +920,7 @@ impl ExpectClientHello {
         }
 
         let full_handshake = resuming_psk.is_none();
-        self.handshake.transcript.add_message(chm);
+        sess.common.hs_transcript.add_message(chm);
         self.emit_server_hello_tls13(sess, &client_hello.session_id,
                                      chosen_share, chosen_psk_index, resuming_psk)?;
         if !self.done_retry {
@@ -1064,7 +1058,8 @@ impl State for ExpectClientHello {
         sess.common.set_suite(maybe_ciphersuite.unwrap());
 
         // Start handshake hash.
-        if !self.handshake.transcript.start_hash(sess.common.get_suite_assert().get_hash()) {
+        let starting_hash = sess.common.get_suite_assert().get_hash();
+        if !sess.common.hs_transcript.start_hash(starting_hash) {
             sess.common.send_fatal_alert(AlertDescription::IllegalParameter);
             return Err(TLSError::PeerIncompatibleError("hash differed on retry"
                 .to_string()));
@@ -1079,7 +1074,7 @@ impl State for ExpectClientHello {
 
         // -- TLS1.2 only from hereon in --
         self.save_sni(sess, sni.clone());
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         if client_hello.ems_support_offered() {
             self.handshake.using_ems = true;
@@ -1218,14 +1213,14 @@ impl State for ExpectTLS12Certificate {
         check_handshake_message(m, &[HandshakeType::Certificate])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let cert_chain = extract_handshake!(m, HandshakePayload::Certificate).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         if cert_chain.is_empty() &&
            !sess.config.verifier.client_auth_mandatory() {
             debug!("client auth requested but no certificate supplied");
-            self.handshake.transcript.abandon_client_auth();
+            sess.common.hs_transcript.abandon_client_auth();
             return Ok(self.into_expect_tls12_client_kx(None));
         }
 
@@ -1270,9 +1265,9 @@ impl State for ExpectTLS13Certificate {
         check_handshake_message(m, &[HandshakeType::Certificate])
     }
 
-    fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
+    fn handle(self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let certp = extract_handshake!(m, HandshakePayload::CertificateTLS13).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         // We don't send any CertificateRequest extensions, so any extensions
         // here are illegal.
@@ -1286,7 +1281,7 @@ impl State for ExpectTLS13Certificate {
         if cert_chain.is_empty() {
             if !sess.config.verifier.client_auth_mandatory() {
                 debug!("client auth requested but no certificate supplied");
-                self.handshake.transcript.abandon_client_auth();
+                sess.common.hs_transcript.abandon_client_auth();
                 return Ok(self.into_expect_tls13_finished());
             }
 
@@ -1338,7 +1333,7 @@ impl State for ExpectTLS12ClientKX {
 
     fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let client_kx = extract_handshake!(m, HandshakePayload::ClientKeyExchange).unwrap();
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         // Complete key agreement, and set up encryption with the
         // resulting premaster secret.
@@ -1354,7 +1349,7 @@ impl State for ExpectTLS12ClientKX {
 
         let hashalg = sess.common.get_suite_assert().get_hash();
         let secrets = if self.handshake.using_ems {
-            let handshake_hash = self.handshake.transcript.get_current_hash();
+            let handshake_hash = sess.common.hs_transcript.get_current_hash();
             SessionSecrets::new_ems(&self.handshake.randoms,
                                     &handshake_hash,
                                     hashalg,
@@ -1402,7 +1397,7 @@ impl State for ExpectTLS12CertificateVerify {
     fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let rc = {
             let sig = extract_handshake!(m, HandshakePayload::CertificateVerify).unwrap();
-            let handshake_msgs = self.handshake.transcript.take_handshake_buf();
+            let handshake_msgs = sess.common.hs_transcript.take_handshake_buf();
             let certs = &self.client_cert.cert_chain;
 
             verify::verify_signed_struct(&handshake_msgs, &certs[0], sig)
@@ -1416,7 +1411,7 @@ impl State for ExpectTLS12CertificateVerify {
         trace!("client CertificateVerify OK");
         sess.client_cert_chain = Some(self.client_cert.take_chain());
 
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         Ok(self.into_expect_tls12_ccs())
     }
 }
@@ -1444,8 +1439,8 @@ impl State for ExpectTLS13CertificateVerify {
     fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let rc = {
             let sig = extract_handshake!(m, HandshakePayload::CertificateVerify).unwrap();
-            let handshake_hash = self.handshake.transcript.get_current_hash();
-            self.handshake.transcript.abandon_client_auth();
+            let handshake_hash = sess.common.hs_transcript.get_current_hash();
+            sess.common.hs_transcript.abandon_client_auth();
             let certs = &self.client_cert.cert_chain;
 
             verify::verify_tls13(&certs[0],
@@ -1462,7 +1457,7 @@ impl State for ExpectTLS13CertificateVerify {
         trace!("client CertificateVerify OK");
         sess.client_cert_chain = Some(self.client_cert.take_chain());
 
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         Ok(self.into_expect_tls13_finished())
     }
 }
@@ -1526,14 +1521,13 @@ fn get_server_session_value_tls12(handshake: &HandshakeDetails,
     v
 }
 
-fn get_server_session_value_tls13(handshake: &HandshakeDetails,
-                                  sess: &ServerSessionImpl,
+fn get_server_session_value_tls13(sess: &ServerSessionImpl,
                                   nonce: &[u8]) -> persist::ServerSessionValue {
     let scs = sess.common.get_suite_assert();
     let version = ProtocolVersion::TLSv1_3;
 
-    let handshake_hash = handshake
-        .transcript
+    let handshake_hash = sess.common
+        .hs_transcript
         .get_current_hash();
     let resumption_master_secret = sess.common
         .get_key_schedule()
@@ -1570,7 +1564,7 @@ fn emit_ticket(handshake: &mut HandshakeDetails,
         }),
     };
 
-    handshake.transcript.add_message(&m);
+    sess.common.hs_transcript.add_message(&m);
     sess.common.send_msg(m, false);
 }
 
@@ -1585,8 +1579,8 @@ fn emit_ccs(sess: &mut ServerSessionImpl) {
     sess.common.we_now_encrypting();
 }
 
-fn emit_finished(handshake: &mut HandshakeDetails, sess: &mut ServerSessionImpl) {
-    let vh = handshake.transcript.get_current_hash();
+fn emit_finished(sess: &mut ServerSessionImpl) {
+    let vh = sess.common.hs_transcript.get_current_hash();
     let verify_data = sess.common.secrets
         .as_ref()
         .unwrap()
@@ -1602,7 +1596,7 @@ fn emit_finished(handshake: &mut HandshakeDetails, sess: &mut ServerSessionImpl)
         }),
     };
 
-    handshake.transcript.add_message(&f);
+    sess.common.hs_transcript.add_message(&f);
     sess.common.send_msg(f, true);
 }
 
@@ -1628,7 +1622,7 @@ impl State for ExpectTLS12Finished {
     fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let finished = extract_handshake!(m, HandshakePayload::Finished).unwrap();
 
-        let vh = self.handshake.transcript.get_current_hash();
+        let vh = sess.common.hs_transcript.get_current_hash();
         let expect_verify_data = sess.common.secrets
             .as_ref()
             .unwrap()
@@ -1655,15 +1649,14 @@ impl State for ExpectTLS12Finished {
         }
 
         // Send our CCS and Finished.
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
         if !self.resuming {
             if self.send_ticket {
                 emit_ticket(&mut self.handshake,
                             sess);
             }
             emit_ccs(sess);
-            emit_finished(&mut self.handshake,
-                          sess);
+            emit_finished(sess);
         }
 
         sess.common.we_now_encrypting();
@@ -1687,7 +1680,7 @@ impl ExpectTLS13Finished {
     fn emit_stateless_ticket_tls13(&mut self, sess: &mut ServerSessionImpl) {
         debug_assert!(self.send_ticket);
         let nonce = rand::random_vec(32);
-        let plain = get_server_session_value_tls13(&self.handshake, sess, &nonce)
+        let plain = get_server_session_value_tls13(sess, &nonce)
             .get_encoding();
         let maybe_ticket = sess.config
             .ticketer
@@ -1710,8 +1703,8 @@ impl ExpectTLS13Finished {
             }),
         };
 
-        trace!("sending new stateless ticket {:?}", m);
-        self.handshake.transcript.add_message(&m);
+        trace!("sending new ticket {:?}", m);
+        sess.common.hs_transcript.add_message(&m);
         sess.common.send_msg(m, true);
     }
 
@@ -1719,7 +1712,7 @@ impl ExpectTLS13Finished {
         debug_assert!(self.send_ticket);
         let nonce = rand::random_vec(32);
         let id = rand::random_vec(32);
-        let plain = get_server_session_value_tls13(&self.handshake, sess, &nonce)
+        let plain = get_server_session_value_tls13(sess, &nonce)
             .get_encoding();
 
         if sess.config.session_storage.put(id.clone(), plain) {
@@ -1736,7 +1729,7 @@ impl ExpectTLS13Finished {
             };
 
             trace!("sending new stateful ticket {:?}", m);
-            self.handshake.transcript.add_message(&m);
+            sess.common.hs_transcript.add_message(&m);
             sess.common.send_msg(m, true);
         } else {
             trace!("resumption not available; not issuing ticket");
@@ -1752,7 +1745,7 @@ impl State for ExpectTLS13Finished {
     fn handle(mut self: Box<Self>, sess: &mut ServerSessionImpl, m: Message) -> NextStateOrError {
         let finished = extract_handshake!(m, HandshakePayload::Finished).unwrap();
 
-        let handshake_hash = self.handshake.transcript.get_current_hash();
+        let handshake_hash = sess.common.hs_transcript.get_current_hash();
         let expect_verify_data = sess.common
             .get_key_schedule()
             .sign_finish(SecretKind::ClientHandshakeTrafficSecret, &handshake_hash);
@@ -1767,7 +1760,7 @@ impl State for ExpectTLS13Finished {
 
         // nb. future derivations include Client Finished, but not the
         // main application data keying.
-        self.handshake.transcript.add_message(&m);
+        sess.common.hs_transcript.add_message(&m);
 
         // Now move to using application data keys for client traffic.
         // Server traffic is already done.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -266,16 +266,19 @@ impl fmt::Debug for ServerSessionImpl {
 impl ServerSessionImpl {
     pub fn new(server_config: &Arc<ServerConfig>, extra_exts: Vec<ServerExtension>)
                -> ServerSessionImpl {
-        let perhaps_client_auth = server_config.verifier.offer_client_auth();
+        let mut common = SessionCommon::new(server_config.mtu, false);
+        if server_config.verifier.offer_client_auth() {
+            common.hs_transcript.set_client_auth_enabled();
+        }
 
         ServerSessionImpl {
             config: server_config.clone(),
-            common: SessionCommon::new(server_config.mtu, false),
+            common,
             sni: None,
             alpn_protocol: None,
             quic_params: None,
             error: None,
-            state: Some(Box::new(hs::ExpectClientHello::new(perhaps_client_auth, extra_exts))),
+            state: Some(Box::new(hs::ExpectClientHello::new(extra_exts))),
             client_cert_chain: None,
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,6 +17,7 @@ use key_schedule::{SecretKind, KeySchedule};
 use prf;
 use rand;
 use quic;
+use hash_hs;
 
 use std::io;
 use std::collections::VecDeque;
@@ -410,6 +411,7 @@ pub struct SessionCommon {
     received_plaintext: ChunkVecBuffer,
     sendable_plaintext: ChunkVecBuffer,
     pub sendable_tls: ChunkVecBuffer,
+    pub hs_transcript: hash_hs::HandshakeHash,
 }
 
 impl SessionCommon {
@@ -436,6 +438,7 @@ impl SessionCommon {
             received_plaintext: ChunkVecBuffer::new(),
             sendable_plaintext: ChunkVecBuffer::new(),
             sendable_tls: ChunkVecBuffer::new(),
+            hs_transcript: hash_hs::HandshakeHash::new(),
         }
     }
 


### PR DESCRIPTION
This allows for easy access from the QUIC interface for key derivation, reduces some duplication between client/server data structures, and should not have any semantic impact. Merging this separately will drastically reduce the difficulty of keeping #187 rebased as development on master continues.