### PR TITLE
Reexport `WriteEarlyData`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ pub use stream::{Stream, StreamOwned};
 pub use anchors::{DistinguishedNames, RootCertStore};
 pub use client::StoresClientSessions;
 pub use client::handy::{NoClientSessionStorage, ClientSessionMemoryCache};
-pub use client::{ClientConfig, ClientSession};
+pub use client::{ClientConfig, ClientSession, WriteEarlyData};
 pub use client::ResolvesClientCert;
 pub use server::StoresServerSessions;
 pub use server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};


### PR DESCRIPTION
Otherwise, the struct can't be named and doesn't show up in generated docs,
which makes the `bytes_left` method very hard to discover.