### PR TITLE
Use QUIC key logging labels when appropriate

### DIFF
--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -399,6 +399,9 @@ impl ExpectClientHello {
                 if sess.common.protocol == Protocol::Quic {
                     let client_early_traffic_secret = key_schedule
                         .derive(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash);
+                    sess.config.key_log.log(sess.common.protocol.labels().client_early_traffic_secret,
+                                &self.handshake.randoms.client,
+                                &client_early_traffic_secret);
                     // If 0-RTT should be rejected, this will be clobbered by process_extensions
                     // before the application can see.
                     sess.common.quic.early_secret = Some(client_early_traffic_secret);
@@ -414,10 +417,10 @@ impl ExpectClientHello {
         let read_key = key_schedule.derive(SecretKind::ClientHandshakeTrafficSecret, &handshake_hash);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
-        sess.config.key_log.log("SERVER_HANDSHAKE_TRAFFIC_SECRET",
+        sess.config.key_log.log(sess.common.protocol.labels().server_handshake_traffic_secret,
                                 &self.handshake.randoms.client,
                                 &write_key);
-        sess.config.key_log.log("CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+        sess.config.key_log.log(sess.common.protocol.labels().client_handshake_traffic_secret,
                                 &self.handshake.randoms.client,
                                 &read_key);
 
@@ -640,7 +643,7 @@ impl ExpectClientHello {
                     &self.handshake.hash_at_server_fin);
         let suite = sess.common.get_suite_assert();
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
-        sess.config.key_log.log("SERVER_TRAFFIC_SECRET_0",
+        sess.config.key_log.log(sess.common.protocol.labels().server_traffic_secret_0,
                                 &self.handshake.randoms.client,
                                 &write_key);
 
@@ -664,7 +667,7 @@ impl ExpectClientHello {
             .get_key_schedule()
             .derive(SecretKind::ExporterMasterSecret,
                     &self.handshake.hash_at_server_fin);
-        sess.config.key_log.log("EXPORTER_SECRET",
+        sess.config.key_log.log(sess.common.protocol.labels().exporter_secret,
                                 &self.handshake.randoms.client,
                                 &exporter_secret);
         sess.common
@@ -866,7 +869,7 @@ impl ExpectClientHello {
         let secrets = SessionSecrets::new_resume(&self.handshake.randoms,
                                                  hashalg,
                                                  &resumedata.master_secret.0);
-        sess.config.key_log.log("CLIENT_RANDOM",
+        sess.config.key_log.log(sess.common.protocol.labels().client_random,
                                 &secrets.randoms.client,
                                 &secrets.master_secret);
         sess.common.start_encryption_tls12(secrets);
@@ -1425,7 +1428,7 @@ impl State for ExpectTLS12ClientKX {
                                 hashalg,
                                 &kxd.premaster_secret)
         };
-        sess.config.key_log.log("CLIENT_RANDOM",
+        sess.config.key_log.log(sess.common.protocol.labels().client_random,
                                 &secrets.randoms.client,
                                 &secrets.master_secret);
         sess.common.start_encryption_tls12(secrets);
@@ -1850,7 +1853,7 @@ impl State for ExpectTLS13Finished {
             .get_key_schedule()
             .derive(SecretKind::ClientApplicationTrafficSecret,
                     &self.handshake.hash_at_server_fin);
-        sess.config.key_log.log("CLIENT_TRAFFIC_SECRET_0",
+        sess.config.key_log.log(sess.common.protocol.labels().client_traffic_secret_0,
                                 &self.handshake.randoms.client,
                                 &read_key);
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -214,6 +214,42 @@ pub enum Protocol {
     Quic,
 }
 
+pub struct Labels {
+    pub client_early_traffic_secret: &'static str,
+    pub client_handshake_traffic_secret: &'static str,
+    pub server_handshake_traffic_secret: &'static str,
+    pub client_traffic_secret_0: &'static str,
+    pub server_traffic_secret_0: &'static str,
+    pub client_random: &'static str,
+    pub exporter_secret: &'static str,
+}
+
+impl Protocol {
+    pub fn labels(&self) -> &'static Labels {
+        match *self {
+            Protocol::Tls13 => &Labels {
+                client_early_traffic_secret: "CLIENT_EARLY_TRAFFIC_SECRET",
+                client_handshake_traffic_secret: "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+                server_handshake_traffic_secret: "SERVER_HANDSHAKE_TRAFFIC_SECRET",
+                client_traffic_secret_0: "CLIENT_TRAFFIC_SECRET_0",
+                server_traffic_secret_0: "SERVER_TRAFFIC_SECRET_0",
+                client_random: "CLIENT_RANDOM",
+                exporter_secret: "EXPORTER_SECRET",
+            },
+            #[cfg(feature = "quic")]
+            Protocol::Quic => &Labels {
+                client_early_traffic_secret: "QUIC_CLIENT_EARLY_TRAFFIC_SECRET",
+                client_handshake_traffic_secret: "QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+                server_handshake_traffic_secret: "QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET",
+                client_traffic_secret_0: "QUIC_CLIENT_TRAFFIC_SECRET_0",
+                server_traffic_secret_0: "QUIC_SERVER_TRAFFIC_SECRET_0",
+                client_random: "QUIC_CLIENT_RANDOM",
+                exporter_secret: "QUIC_EXPORTER_SECRET",
+            },
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SessionRandoms {
     pub we_are_client: bool,


### PR DESCRIPTION
This is the format expected by current wireshark builds. Also adds client early traffic secret key logging.