### PR TITLE
0-RTT bugfixes

### DIFF
--- a/src/msgs/persist.rs
+++ b/src/msgs/persist.rs
@@ -147,7 +147,7 @@ impl ClientSessionValue {
     pub fn get_obfuscated_ticket_age(&self, time_now: u64) -> u32 {
         let age_secs = time_now.saturating_sub(self.epoch);
         let age_millis = age_secs as u32 * 1000;
-        age_millis.wrapping_sub(self.age_add)
+        age_millis.wrapping_add(self.age_add)
     }
 
     pub fn take_ticket(&mut self) -> Vec<u8> {

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -237,6 +237,7 @@ impl ExpectClientHello {
 
                 if let Some(resume) = resumedata {
                     if sess.config.max_early_data_size > 0
+                        && hello.early_data_extension_offered()
                         && resume.version == sess.common.negotiated_version.unwrap()
                         && resume.cipher_suite == sess.common.get_suite_assert().suite
                         && resume.alpn.as_ref().map(|x| &x.0) == sess.alpn_protocol.as_ref()


### PR DESCRIPTION
Fixes a handshake failure when a 0-RTT capable server receives a non-0-RTT resumption.