### PR TITLE
env_logger 0.6.1 replaced `.parse` with `.parse_filters`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ quic = []
 
 [dev-dependencies]
 log = "0.4"
-env_logger = "0.6"
+env_logger = "0.6.1"
 mio = "0.6"
 docopt = "1.0"
 serde = "1.0"

--- a/examples/tlsclient.rs
+++ b/examples/tlsclient.rs
@@ -519,7 +519,7 @@ fn main() {
 
     if args.flag_verbose {
         env_logger::Builder::new()
-            .parse("trace")
+            .parse_filters("trace")
             .init();
     }
 

--- a/examples/tlsserver.rs
+++ b/examples/tlsserver.rs
@@ -583,7 +583,7 @@ fn main() {
 
     if args.flag_verbose {
         env_logger::Builder::new()
-            .parse("trace")
+            .parse_filters("trace")
             .init();
     }
 


### PR DESCRIPTION
This updates rustls to env_logger 0.6.1. In addition, env_logger 0.6.1 deprecated `Builder::parse`, and replaced it with `Builder::parse_filter`.