### PR TITLE
stream: add socket accessors

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -101,6 +101,16 @@ impl<S, T> StreamOwned<S, T> where S: Session, T: Read + Write {
     pub fn new(sess: S, sock: T) -> StreamOwned<S, T> {
         StreamOwned { sess, sock }
     }
+
+    /// Get a reference to the underlying socket
+    pub fn get_ref(&self) -> &T {
+        &self.sock
+    }
+
+    /// Get a mutable reference to the underlying socket
+    pub fn get_mut(&mut self) -> &T {
+        &mut self.sock
+    }
 }
 
 impl<'a, S, T> StreamOwned<S, T> where S: Session, T: Read + Write {


### PR DESCRIPTION
The other TLS libraries all provide those methods on their
stream implementations, this helps make things more similar
