### PR TITLE
Update minimal dependencies versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
       sudo: required
       rust: nightly
       env: COVERAGE=1
+    - os: linux
+      dist: trusty
+      sudo: required
+      rust: nightly
+      script:
+          - cargo -Z minimal-versions test --all-features
     - os: osx
       rust: stable
 before_install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 
 [dependencies]
 base64 = "0.10"
-log = { version = "0.4.0", optional = true }
+log = { version = "0.4.4", optional = true }
 ring = "0.14"
 sct = "0.5"
 untrusted = "0.6.2"
@@ -26,10 +26,10 @@ quic = []
 
 [dev-dependencies]
 env_logger = "0.6.1"
-log = "0.4.0"
+log = "0.4.4"
 tempfile = "3.0"
 webpki-roots = "0.16"
-criterion = "0.2"
+criterion = "0.2.11"
 
 [[example]]
 name = "bogo_shim"


### PR DESCRIPTION
Doesn't build (at least with a recent rustc) with minimal versions without those bumps.

Add CI target to make sure we update the minimal bounds when needed.