### PR TITLE
Remove QUIC-specific key logging labels

### DIFF
--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -332,7 +332,6 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
             .get_key_schedule()
             .derive_logged_secret(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash,
                                   &*sess.config.key_log,
-                                  "CLIENT_EARLY_TRAFFIC_SECRET",
                                   &handshake.randoms.client);
         // Set early data encryption key
         sess.common

--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -332,7 +332,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
             .get_key_schedule()
             .derive_logged_secret(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().client_early_traffic_secret,
+                                  "CLIENT_EARLY_TRAFFIC_SECRET",
                                   &handshake.randoms.client);
         // Set early data encryption key
         sess.common
@@ -593,7 +593,7 @@ impl State for ExpectServerHello {
                 let secrets = SessionSecrets::new_resume(&self.handshake.randoms,
                                                          scs.unwrap().get_hash(),
                                                          &resuming.master_secret.0);
-                sess.config.key_log.log(sess.common.protocol.labels().client_random,
+                sess.config.key_log.log("CLIENT_RANDOM",
                                         &secrets.randoms.client,
                                         &secrets.master_secret);
                 sess.common.start_encryption_tls12(secrets);

--- a/src/client/tls12.rs
+++ b/src/client/tls12.rs
@@ -548,7 +548,7 @@ impl hs::State for ExpectServerDone {
                                 hashalg,
                                 &kxd.premaster_secret)
         };
-        sess.config.key_log.log(sess.common.protocol.labels().client_random,
+        sess.config.key_log.log("CLIENT_RANDOM",
                                 &secrets.randoms.client,
                                 &secrets.master_secret);
         sess.common.start_encryption_tls12(secrets);

--- a/src/client/tls13.rs
+++ b/src/client/tls13.rs
@@ -214,7 +214,7 @@ pub fn start_handshake_traffic(sess: &mut ClientSessionImpl,
             .derive_logged_secret(SecretKind::ClientHandshakeTrafficSecret,
                                   &handshake.hash_at_client_recvd_server_hello,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().client_handshake_traffic_secret,
+                                  "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                                   &handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         sess.common.get_mut_key_schedule().current_client_traffic_secret = Some(write_key);
@@ -224,7 +224,7 @@ pub fn start_handshake_traffic(sess: &mut ClientSessionImpl,
         .derive_logged_secret(SecretKind::ServerHandshakeTrafficSecret,
                               &handshake.hash_at_client_recvd_server_hello,
                               &*sess.config.key_log,
-                              sess.common.protocol.labels().server_handshake_traffic_secret,
+                              "SERVER_HANDSHAKE_TRAFFIC_SECRET",
                               &handshake.randoms.client);
     sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
     sess.common.get_mut_key_schedule().current_server_traffic_secret = Some(read_key);
@@ -405,7 +405,7 @@ impl hs::State for ExpectEncryptedExtensions {
                         SecretKind::ClientHandshakeTrafficSecret,
                         &self.handshake.hash_at_client_recvd_server_hello,
                         &*sess.config.key_log,
-                        sess.common.protocol.labels().client_handshake_traffic_secret,
+                        "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                         &self.handshake.randoms.client);
                 sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
                 sess.common.get_mut_key_schedule()
@@ -833,7 +833,7 @@ impl hs::State for ExpectFinished {
                     SecretKind::ClientHandshakeTrafficSecret,
                     &st.handshake.hash_at_client_recvd_server_hello,
                     &*sess.config.key_log,
-                    sess.common.protocol.labels().client_handshake_traffic_secret,
+                    "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                     &st.handshake.randoms.client);
             Some(key)
         } else {
@@ -853,7 +853,7 @@ impl hs::State for ExpectFinished {
                 SecretKind::ServerApplicationTrafficSecret,
                 &handshake_hash,
                 &*sess.config.key_log,
-                sess.common.protocol.labels().server_traffic_secret_0,
+                "SERVER_TRAFFIC_SECRET_0",
                 &st.handshake.randoms.client);
         sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
         sess.common
@@ -865,7 +865,7 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ExporterMasterSecret,
                                   &handshake_hash,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().exporter_secret,
+                                  "EXPORTER_SECRET",
                                   &st.handshake.randoms.client);
         sess.common
             .get_mut_key_schedule()
@@ -901,7 +901,7 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ClientApplicationTrafficSecret,
                                   &handshake_hash,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().client_traffic_secret_0,
+                                  "CLIENT_TRAFFIC_SECRET_0",
                                   &st.handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         sess.common

--- a/src/client/tls13.rs
+++ b/src/client/tls13.rs
@@ -214,7 +214,6 @@ pub fn start_handshake_traffic(sess: &mut ClientSessionImpl,
             .derive_logged_secret(SecretKind::ClientHandshakeTrafficSecret,
                                   &handshake.hash_at_client_recvd_server_hello,
                                   &*sess.config.key_log,
-                                  "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                                   &handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         sess.common.get_mut_key_schedule().current_client_traffic_secret = Some(write_key);
@@ -224,7 +223,6 @@ pub fn start_handshake_traffic(sess: &mut ClientSessionImpl,
         .derive_logged_secret(SecretKind::ServerHandshakeTrafficSecret,
                               &handshake.hash_at_client_recvd_server_hello,
                               &*sess.config.key_log,
-                              "SERVER_HANDSHAKE_TRAFFIC_SECRET",
                               &handshake.randoms.client);
     sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
     sess.common.get_mut_key_schedule().current_server_traffic_secret = Some(read_key);
@@ -405,7 +403,6 @@ impl hs::State for ExpectEncryptedExtensions {
                         SecretKind::ClientHandshakeTrafficSecret,
                         &self.handshake.hash_at_client_recvd_server_hello,
                         &*sess.config.key_log,
-                        "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                         &self.handshake.randoms.client);
                 sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
                 sess.common.get_mut_key_schedule()
@@ -833,7 +830,6 @@ impl hs::State for ExpectFinished {
                     SecretKind::ClientHandshakeTrafficSecret,
                     &st.handshake.hash_at_client_recvd_server_hello,
                     &*sess.config.key_log,
-                    "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
                     &st.handshake.randoms.client);
             Some(key)
         } else {
@@ -853,7 +849,6 @@ impl hs::State for ExpectFinished {
                 SecretKind::ServerApplicationTrafficSecret,
                 &handshake_hash,
                 &*sess.config.key_log,
-                "SERVER_TRAFFIC_SECRET_0",
                 &st.handshake.randoms.client);
         sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
         sess.common
@@ -865,7 +860,6 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ExporterMasterSecret,
                                   &handshake_hash,
                                   &*sess.config.key_log,
-                                  "EXPORTER_SECRET",
                                   &st.handshake.randoms.client);
         sess.common
             .get_mut_key_schedule()
@@ -901,7 +895,6 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ClientApplicationTrafficSecret,
                                   &handshake_hash,
                                   &*sess.config.key_log,
-                                  "CLIENT_TRAFFIC_SECRET_0",
                                   &st.handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         sess.common

--- a/src/keylog.rs
+++ b/src/keylog.rs
@@ -26,6 +26,8 @@ pub trait KeyLog : Send + Sync {
     /// `secret` means:
     ///
     /// - `CLIENT_RANDOM`: `secret` is the master secret for a TLSv1.2 session.
+    /// - `CLIENT_EARLY_TRAFFIC_SECRET`: `secret` encrypts early data
+    ///   transmitted by a client
     /// - `SERVER_HANDSHAKE_TRAFFIC_SECRET`: `secret` encrypts
     ///   handshake messages from the server during a TLSv1.3 handshake.
     /// - `CLIENT_HANDSHAKE_TRAFFIC_SECRET`: `secret` encrypts

--- a/src/server/hs.rs
+++ b/src/server/hs.rs
@@ -507,7 +507,7 @@ impl ExpectClientHello {
         let secrets = SessionSecrets::new_resume(&self.handshake.randoms,
                                                  hashalg,
                                                  &resumedata.master_secret.0);
-        sess.config.key_log.log(sess.common.protocol.labels().client_random,
+        sess.config.key_log.log("CLIENT_RANDOM",
                                 &secrets.randoms.client,
                                 &secrets.master_secret);
         sess.common.start_encryption_tls12(secrets);

--- a/src/server/tls12.rs
+++ b/src/server/tls12.rs
@@ -127,7 +127,7 @@ impl hs::State for ExpectClientKX {
                                 hashalg,
                                 &kxd.premaster_secret)
         };
-        sess.config.key_log.log(sess.common.protocol.labels().client_random,
+        sess.config.key_log.log("CLIENT_RANDOM",
                                 &secrets.randoms.client,
                                 &secrets.master_secret);
         sess.common.start_encryption_tls12(secrets);

--- a/src/server/tls13.rs
+++ b/src/server/tls13.rs
@@ -164,7 +164,6 @@ impl CompleteClientHelloHandling {
                             SecretKind::ClientEarlyTrafficSecret,
                             &client_hello_hash,
                             &*sess.config.key_log,
-                            "CLIENT_EARLY_TRAFFIC_SECRET",
                             &self.handshake.randoms.client);
                     // If 0-RTT should be rejected, this will be clobbered by ExtensionProcessing
                     // before the application can see.
@@ -181,7 +180,6 @@ impl CompleteClientHelloHandling {
             SecretKind::ServerHandshakeTrafficSecret,
             &handshake_hash,
             &*sess.config.key_log,
-            "SERVER_HANDSHAKE_TRAFFIC_SECRET",
             &self.handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
 
@@ -189,7 +187,6 @@ impl CompleteClientHelloHandling {
             SecretKind::ClientHandshakeTrafficSecret,
             &handshake_hash,
             &*sess.config.key_log,
-            "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
             &self.handshake.randoms.client);
         sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
 
@@ -416,7 +413,6 @@ impl CompleteClientHelloHandling {
             .derive_logged_secret(SecretKind::ServerApplicationTrafficSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  "SERVER_TRAFFIC_SECRET_0",
                                   &self.handshake.randoms.client);
         let suite = sess.common.get_suite_assert();
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
@@ -439,7 +435,6 @@ impl CompleteClientHelloHandling {
             .derive_logged_secret(SecretKind::ExporterMasterSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  "EXPORTER_SECRET",
                                   &self.handshake.randoms.client);
         sess.common
             .get_mut_key_schedule()
@@ -849,7 +844,6 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ClientApplicationTrafficSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  "CLIENT_TRAFFIC_SECRET_0",
                                   &self.handshake.randoms.client);
 
         let suite = sess.common.get_suite_assert();

--- a/src/server/tls13.rs
+++ b/src/server/tls13.rs
@@ -164,7 +164,7 @@ impl CompleteClientHelloHandling {
                             SecretKind::ClientEarlyTrafficSecret,
                             &client_hello_hash,
                             &*sess.config.key_log,
-                            sess.common.protocol.labels().client_early_traffic_secret,
+                            "CLIENT_EARLY_TRAFFIC_SECRET",
                             &self.handshake.randoms.client);
                     // If 0-RTT should be rejected, this will be clobbered by ExtensionProcessing
                     // before the application can see.
@@ -181,7 +181,7 @@ impl CompleteClientHelloHandling {
             SecretKind::ServerHandshakeTrafficSecret,
             &handshake_hash,
             &*sess.config.key_log,
-            sess.common.protocol.labels().server_handshake_traffic_secret,
+            "SERVER_HANDSHAKE_TRAFFIC_SECRET",
             &self.handshake.randoms.client);
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
 
@@ -189,7 +189,7 @@ impl CompleteClientHelloHandling {
             SecretKind::ClientHandshakeTrafficSecret,
             &handshake_hash,
             &*sess.config.key_log,
-            sess.common.protocol.labels().client_handshake_traffic_secret,
+            "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
             &self.handshake.randoms.client);
         sess.common.set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
 
@@ -416,7 +416,7 @@ impl CompleteClientHelloHandling {
             .derive_logged_secret(SecretKind::ServerApplicationTrafficSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().server_traffic_secret_0,
+                                  "SERVER_TRAFFIC_SECRET_0",
                                   &self.handshake.randoms.client);
         let suite = sess.common.get_suite_assert();
         sess.common.set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
@@ -439,7 +439,7 @@ impl CompleteClientHelloHandling {
             .derive_logged_secret(SecretKind::ExporterMasterSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().exporter_secret,
+                                  "EXPORTER_SECRET",
                                   &self.handshake.randoms.client);
         sess.common
             .get_mut_key_schedule()
@@ -849,7 +849,7 @@ impl hs::State for ExpectFinished {
             .derive_logged_secret(SecretKind::ClientApplicationTrafficSecret,
                                   &self.handshake.hash_at_server_fin,
                                   &*sess.config.key_log,
-                                  sess.common.protocol.labels().client_traffic_secret_0,
+                                  "CLIENT_TRAFFIC_SECRET_0",
                                   &self.handshake.randoms.client);
 
         let suite = sess.common.get_suite_assert();

--- a/src/session.rs
+++ b/src/session.rs
@@ -213,42 +213,6 @@ pub enum Protocol {
     Quic,
 }
 
-pub struct Labels {
-    pub client_early_traffic_secret: &'static str,
-    pub client_handshake_traffic_secret: &'static str,
-    pub server_handshake_traffic_secret: &'static str,
-    pub client_traffic_secret_0: &'static str,
-    pub server_traffic_secret_0: &'static str,
-    pub client_random: &'static str,
-    pub exporter_secret: &'static str,
-}
-
-impl Protocol {
-    pub fn labels(self) -> &'static Labels {
-        match self {
-            Protocol::Tls13 => &Labels {
-                client_early_traffic_secret: "CLIENT_EARLY_TRAFFIC_SECRET",
-                client_handshake_traffic_secret: "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
-                server_handshake_traffic_secret: "SERVER_HANDSHAKE_TRAFFIC_SECRET",
-                client_traffic_secret_0: "CLIENT_TRAFFIC_SECRET_0",
-                server_traffic_secret_0: "SERVER_TRAFFIC_SECRET_0",
-                client_random: "CLIENT_RANDOM",
-                exporter_secret: "EXPORTER_SECRET",
-            },
-            #[cfg(feature = "quic")]
-            Protocol::Quic => &Labels {
-                client_early_traffic_secret: "QUIC_CLIENT_EARLY_TRAFFIC_SECRET",
-                client_handshake_traffic_secret: "QUIC_CLIENT_HANDSHAKE_TRAFFIC_SECRET",
-                server_handshake_traffic_secret: "QUIC_SERVER_HANDSHAKE_TRAFFIC_SECRET",
-                client_traffic_secret_0: "QUIC_CLIENT_TRAFFIC_SECRET_0",
-                server_traffic_secret_0: "QUIC_SERVER_TRAFFIC_SECRET_0",
-                client_random: "QUIC_CLIENT_RANDOM",
-                exporter_secret: "QUIC_EXPORTER_SECRET",
-            },
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct SessionRandoms {
     pub we_are_client: bool,


### PR DESCRIPTION
Wireshark decided these were no longer appropriate since most of the divergence between conventional TLS and QUIC crypto was removed.