### PR TITLE
Expose resumption ciphersuite

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -374,6 +374,7 @@ pub struct ClientSessionImpl {
     pub state: Option<Box<dyn hs::State + Send + Sync>>,
     pub server_cert_chain: CertificatePayload,
     pub early_data: EarlyData,
+    pub resumption_ciphersuite: Option<&'static SupportedCipherSuite>,
 }
 
 impl fmt::Debug for ClientSessionImpl {
@@ -392,6 +393,7 @@ impl ClientSessionImpl {
             state: None,
             server_cert_chain: Vec::new(),
             early_data: EarlyData::new(),
+            resumption_ciphersuite: None,
         }
     }
 
@@ -692,7 +694,7 @@ impl Session for ClientSession {
     }
 
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {
-        self.imp.get_negotiated_ciphersuite()
+        self.imp.get_negotiated_ciphersuite().or(self.imp.resumption_ciphersuite)
     }
 
 }

--- a/src/client/tls13.rs
+++ b/src/client/tls13.rs
@@ -259,6 +259,7 @@ pub fn prepare_resumption(sess: &mut ClientSessionImpl,
         .and_then(|resume| sess.find_cipher_suite(resume.cipher_suite));
 
     if hs::compatible_suite(sess, resuming_suite) {
+        sess.resumption_ciphersuite = resuming_suite;
         // The EarlyData extension MUST be supplied together with the
         // PreSharedKey extension.
         let max_early_data_size = handshake

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1791,6 +1791,7 @@ fn quic_handshake() {
     // 0-RTT handshake
     let mut client =
         ClientSession::new_quic(&client_config, dns_name("localhost"), client_params.into());
+    assert!(client.get_negotiated_ciphersuite().is_some());
     let mut server = ServerSession::new_quic(&server_config, server_params.into());
     step(&mut client, &mut server).unwrap();
     assert_eq!(client.get_quic_transport_parameters(), Some(server_params));


### PR DESCRIPTION
Needed for QUIC to select the correct 0-RTT header protection cipher, fixing an interop issue with the quant implementation. Please sanity-check the adjustment to the "server varied selected ciphersuite" error detection.