### PR TITLE
Update to *ring* 0.16.2 to improve sealing operations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "cryptography"]
 [dependencies]
 base64 = "0.10"
 log = { version = "0.4.4", optional = true }
-ring = "0.16.0"
+ring = "0.16.2"
 sct = "0.6.0"
 webpki = "0.21.0"
 


### PR DESCRIPTION
Restore the allocation/copying behavior to what it was before the
*ring* 0.16.0 upgrade.