### PR TITLE
Start using the *ring* 0.16.4 HDKF API in the TLS 1.3 key schedule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "cryptography"]
 [dependencies]
 base64 = "0.10"
 log = { version = "0.4.4", optional = true }
-ring = "0.16.3"
+ring = "0.16.4"
 sct = "0.6.0"
 webpki = "0.21.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "cryptography"]
 [dependencies]
 base64 = "0.10"
 log = { version = "0.4.4", optional = true }
-ring = "0.16.2"
+ring = "0.16.3"
 sct = "0.6.0"
 webpki = "0.21.0"
 

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -123,9 +123,8 @@ pub fn new_tls12(scs: &'static SupportedCipherSuite,
 
 pub fn new_tls13_read(scs: &'static SupportedCipherSuite,
                       secret: &[u8]) -> Box<dyn MessageDecrypter> {
-    let hash = scs.get_hash();
-    let key = derive_traffic_key(hash, secret, scs.enc_key_len);
-    let iv = derive_traffic_iv(hash, secret);
+    let key = derive_traffic_key(scs.hkdf_algorithm, secret, scs.enc_key_len);
+    let iv = derive_traffic_iv(scs.hkdf_algorithm, secret);
     let aead_alg = scs.get_aead_alg();
 
     Box::new(TLS13MessageDecrypter::new(aead_alg, &key, iv))
@@ -133,9 +132,8 @@ pub fn new_tls13_read(scs: &'static SupportedCipherSuite,
 
 pub fn new_tls13_write(scs: &'static SupportedCipherSuite,
                        secret: &[u8]) -> Box<dyn MessageEncrypter> {
-    let hash = scs.get_hash();
-    let key = derive_traffic_key(hash, secret, scs.enc_key_len);
-    let iv = derive_traffic_iv(hash, secret);
+    let key = derive_traffic_key(scs.hkdf_algorithm, secret, scs.enc_key_len);
+    let iv = derive_traffic_iv(scs.hkdf_algorithm, secret);
     let aead_alg = scs.get_aead_alg();
 
     Box::new(TLS13MessageEncrypter::new(aead_alg, &key, iv))

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -123,8 +123,9 @@ pub fn new_tls12(scs: &'static SupportedCipherSuite,
 
 pub fn new_tls13_read(scs: &'static SupportedCipherSuite,
                       secret: &[u8]) -> Box<dyn MessageDecrypter> {
-    let key = derive_traffic_key(scs.hkdf_algorithm, secret, scs.enc_key_len);
-    let iv = derive_traffic_iv(scs.hkdf_algorithm, secret);
+    let secret = hkdf::Prk::new_less_safe(scs.hkdf_algorithm, secret);
+    let key = derive_traffic_key(&secret, scs.enc_key_len);
+    let iv = derive_traffic_iv(&secret);
     let aead_alg = scs.get_aead_alg();
 
     Box::new(TLS13MessageDecrypter::new(aead_alg, &key, iv))
@@ -132,8 +133,9 @@ pub fn new_tls13_read(scs: &'static SupportedCipherSuite,
 
 pub fn new_tls13_write(scs: &'static SupportedCipherSuite,
                        secret: &[u8]) -> Box<dyn MessageEncrypter> {
-    let key = derive_traffic_key(scs.hkdf_algorithm, secret, scs.enc_key_len);
-    let iv = derive_traffic_iv(scs.hkdf_algorithm, secret);
+    let secret = hkdf::Prk::new_less_safe(scs.hkdf_algorithm, secret);
+    let key = derive_traffic_key(&secret, scs.enc_key_len);
+    let iv = derive_traffic_iv(&secret);
     let aead_alg = scs.get_aead_alg();
 
     Box::new(TLS13MessageEncrypter::new(aead_alg, &key, iv))

--- a/src/client/hs.rs
+++ b/src/client/hs.rs
@@ -330,7 +330,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
         let client_hello_hash = handshake.transcript.get_hash_given(resuming_suite.get_hash(), &[]);
         let client_early_traffic_secret = sess.common
             .get_key_schedule()
-            .derive(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash);
+            .derive_bytes(SecretKind::ClientEarlyTrafficSecret, &client_hello_hash);
         // Set early data encryption key
         sess.common
             .set_message_encrypter(cipher::new_tls13_write(resuming_suite, &client_early_traffic_secret));

--- a/src/client/tls13.rs
+++ b/src/client/tls13.rs
@@ -141,8 +141,7 @@ pub fn fill_in_psk_binder(sess: &mut ClientSessionImpl,
 
     // Run a fake key_schedule to simulate what the server will do if it choses
     // to resume.
-    let mut key_schedule = KeySchedule::new(hkdf_alg);
-    key_schedule.input_secret(&resuming.master_secret.0);
+    let key_schedule = KeySchedule::new(hkdf_alg, &resuming.master_secret.0);
     let base_key = key_schedule.derive(SecretKind::ResumptionPSKBinderKey, &empty_hash);
     let real_binder = key_schedule.sign_verify_data(&base_key, &handshake_hash);
 
@@ -185,9 +184,7 @@ pub fn start_handshake_traffic(sess: &mut ClientSessionImpl,
         // Discard the early data key schedule.
         sess.early_data.rejected();
         sess.common.early_traffic = false;
-        let mut key_schedule = KeySchedule::new(suite.hkdf_algorithm);
-        key_schedule.input_empty();
-        sess.common.set_key_schedule(key_schedule);
+        sess.common.set_key_schedule(KeySchedule::new_with_empty_secret(suite.hkdf_algorithm));
         handshake.resuming_session.take();
     }
 

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -76,8 +76,7 @@ impl KeySchedule {
 
     /// Input the given secret.
     pub fn input_secret(&mut self, secret: &[u8]) {
-        let salt: hkdf::Salt =
-            self.derive_for_empty_hash(self.algorithm, SecretKind::DerivedSecret);
+        let salt: hkdf::Salt = self.derive_for_empty_hash(SecretKind::DerivedSecret);
         self.current = salt.extract(secret);
     }
 
@@ -100,14 +99,13 @@ impl KeySchedule {
     /// for the handshake hash.  Useful only for
     /// `SecretKind::ResumptionPSKBinderKey` and
     /// `SecretKind::DerivedSecret`.
-    pub fn derive_for_empty_hash<T, L>(&self, key_type: L, kind: SecretKind) -> T
+    pub fn derive_for_empty_hash<T>(&self, kind: SecretKind) -> T
         where
-            T: for <'a> From<hkdf::Okm<'a, L>>,
-            L: hkdf::KeyType,
+            T: for <'a> From<hkdf::Okm<'a, hkdf::Algorithm>>
     {
         let digest_alg = self.algorithm.hmac_algorithm().digest_algorithm();
         let empty_hash = digest::digest(digest_alg, &[]);
-        self.derive(key_type, kind, empty_hash.as_ref())
+        self.derive(self.algorithm, kind, empty_hash.as_ref())
     }
 
     /// Return the current traffic secret, of given `kind`.

--- a/src/msgs/base.rs
+++ b/src/msgs/base.rs
@@ -117,6 +117,8 @@ impl PayloadU8 {
     pub fn empty() -> PayloadU8 {
         PayloadU8(Vec::new())
     }
+
+    pub fn into_inner(self) -> Vec<u8> { self.0 }
 }
 
 impl Codec for PayloadU8 {

--- a/src/quic.rs
+++ b/src/quic.rs
@@ -5,10 +5,11 @@ use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::server::{ServerConfig, ServerSession, ServerSessionImpl};
 use crate::error::TLSError;
-use crate::key_schedule::{KeySchedule, SecretKind};
+use crate::key_schedule;
 use crate::session::{SessionCommon, Protocol};
 
 use std::sync::Arc;
+use ring::hmac;
 use webpki;
 
 /// Secrets used to encrypt/decrypt traffic
@@ -123,14 +124,19 @@ fn write_hs(this: &mut SessionCommon, buf: &mut Vec<u8>) -> Option<Secrets> {
 }
 
 fn update_secrets(this: &SessionCommon, client: &[u8], server: &[u8]) -> Secrets {
-    let suite = this.get_suite_assert();
-    // TODO: Don't clone
-    let mut key_schedule = KeySchedule::new(suite.get_hash());
-    key_schedule.current_client_traffic_secret = client.into();
-    key_schedule.current_server_traffic_secret = server.into();
+    let hmac_alg= this.get_suite_assert().hkdf_algorithm.hmac_algorithm();
+    let digest_alg = hmac_alg.digest_algorithm();
     Secrets {
-        client: key_schedule.derive_next(SecretKind::ClientApplicationTrafficSecret),
-        server: key_schedule.derive_next(SecretKind::ServerApplicationTrafficSecret),
+        client: key_schedule::_hkdf_expand_label_vec(
+            &hmac::Key::new(hmac_alg, client),
+            b"traffic upd",
+            &[],
+            digest_alg.output_len),
+        server: key_schedule::_hkdf_expand_label_vec(
+            &hmac::Key::new(hmac_alg, server),
+            b"traffic upd",
+            &[],
+            digest_alg.output_len)
     }
 }
 

--- a/src/server/tls13.rs
+++ b/src/server/tls13.rs
@@ -69,12 +69,11 @@ impl CompleteClientHelloHandling {
         };
 
         let suite = sess.common.get_suite_assert();
-        let hkdf_alg = suite.hkdf_algorithm;
         let suite_hash = suite.get_hash();
         let handshake_hash = self.handshake.transcript.get_hash_given(suite_hash, &binder_plaintext);
 
-        let key_schedule = KeySchedule::new(hkdf_alg, &psk);
-        let base_key = key_schedule.derive_for_empty_hash(hkdf_alg, SecretKind::ResumptionPSKBinderKey);
+        let key_schedule = KeySchedule::new(suite.hkdf_algorithm, &psk);
+        let base_key = key_schedule.derive_for_empty_hash(SecretKind::ResumptionPSKBinderKey);
         let real_binder = key_schedule.sign_verify_data(&base_key, &handshake_hash);
 
         constant_time::verify_slices_are_equal(&real_binder, binder).is_ok()

--- a/src/server/tls13.rs
+++ b/src/server/tls13.rs
@@ -68,10 +68,12 @@ impl CompleteClientHelloHandling {
             _ => unreachable!(),
         };
 
-        let suite_hash = sess.common.get_suite_assert().get_hash();
+        let suite = sess.common.get_suite_assert();
+        let hkdf_alg = suite.hkdf_algorithm;
+        let suite_hash = suite.get_hash();
         let handshake_hash = self.handshake.transcript.get_hash_given(suite_hash, &binder_plaintext);
 
-        let mut key_schedule = KeySchedule::new(suite_hash);
+        let mut key_schedule = KeySchedule::new(hkdf_alg);
         key_schedule.input_secret(psk);
         let base_key = key_schedule.derive_for_empty_hash(SecretKind::ResumptionPSKBinderKey);
         let real_binder = key_schedule.sign_verify_data(&base_key, &handshake_hash);
@@ -153,7 +155,7 @@ impl CompleteClientHelloHandling {
 
         // Start key schedule
         let suite = sess.common.get_suite_assert();
-        let mut key_schedule = KeySchedule::new(suite.get_hash());
+        let mut key_schedule = KeySchedule::new(suite.hkdf_algorithm);
         if let Some(psk) = resuming_psk {
             key_schedule.input_secret(psk);
 

--- a/src/suites.rs
+++ b/src/suites.rs
@@ -156,6 +156,8 @@ pub struct SupportedCipherSuite {
     /// in a deterministic and safe way.  GCM needs this,
     /// chacha20poly1305 works this way by design.
     pub explicit_nonce_len: usize,
+
+    pub(crate) hkdf_algorithm: ring::hkdf::Algorithm,
 }
 
 impl PartialEq for SupportedCipherSuite {
@@ -167,12 +169,7 @@ impl PartialEq for SupportedCipherSuite {
 impl SupportedCipherSuite {
     /// Which hash function to use with this suite.
     pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
-        match self.hash {
-            HashAlgorithm::SHA256 => &ring::digest::SHA256,
-            HashAlgorithm::SHA384 => &ring::digest::SHA384,
-            HashAlgorithm::SHA512 => &ring::digest::SHA512,
-            _ => unreachable!(),
-        }
+        self.hkdf_algorithm.hmac_algorithm().digest_algorithm()
     }
 
     /// We have parameters and a verified public key in `kx_params`.
@@ -276,6 +273,7 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         enc_key_len: 32,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
+        hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     };
 
 pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
@@ -288,6 +286,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         enc_key_len: 32,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
+        hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     };
 
 pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
@@ -299,6 +298,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Support
     enc_key_len: 16,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
 };
 
 pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
@@ -310,6 +310,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Support
     enc_key_len: 32,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
 };
 
 pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
@@ -321,6 +322,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Suppo
     enc_key_len: 16,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
 };
 
 pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
@@ -332,6 +334,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Suppo
     enc_key_len: 32,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
 };
 
 pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite = SupportedCipherSuite {
@@ -343,6 +346,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite = SupportedCiphe
     enc_key_len: 32,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
 };
 
 pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
@@ -354,6 +358,7 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite
     enc_key_len: 32,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
 };
 
 pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
@@ -365,6 +370,7 @@ pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite
     enc_key_len: 16,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
+    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
 };
 
 /// A list of all the cipher suites supported by rustls.


### PR DESCRIPTION
Eliminate some of the inefficiency of the current key schedule  implementation by reducing `Vec<u8>` usage and reducing the number of times an `hmac::Key` is constructed for a given value. Further changes should be done, but those require changing the QUIC API.