### PR TITLE
Allow changing client cert verifier in ServerConfig

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,3 +301,5 @@ pub use crate::verify::{ServerCertVerifier, ServerCertVerified,
 #[cfg(feature = "dangerous_configuration")]
 pub use crate::client::danger::DangerousClientConfig;
 
+#[cfg(feature = "dangerous_configuration")]
+pub use crate::server::danger::DangerousServerConfig;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -256,6 +256,36 @@ impl ServerConfig {
         self.alpn_protocols.clear();
         self.alpn_protocols.extend_from_slice(protocols);
     }
+
+    /// Access configuration options whose use is dangerous and requires
+    /// extra care.
+    #[cfg(feature = "dangerous_configuration")]
+    pub fn dangerous(&mut self) -> danger::DangerousServerConfig {
+        danger::DangerousServerConfig { cfg: self }
+    }
+}
+
+/// Container for unsafe APIs
+#[cfg(feature = "dangerous_configuration")]
+pub mod danger {
+    use std::sync::Arc;
+
+    use super::ServerConfig;
+    use super::verify::ClientCertVerifier;
+
+    /// Accessor for dangerous configuration options.
+    pub struct DangerousServerConfig<'a> {
+        /// The underlying ClientConfig
+        pub cfg: &'a mut ServerConfig
+    }
+
+    impl<'a> DangerousServerConfig<'a> {
+        /// Overrides the default `ClientCertVerifier` with something else.
+        pub fn set_certificate_verifier(&mut self,
+                                        verifier: Arc<ClientCertVerifier>) {
+            self.cfg.verifier = verifier;
+        }
+    }
 }
 
 pub struct ServerSessionImpl {


### PR DESCRIPTION
Hello @ctz! 

I'm working on an implementation of OpenSSL's `SSL_CTX_set_verify()` API.  It would be great if `rustls::ServerConfig` could support `set_certificate_verifier()` like `rustls::ClientConfig` does.

In this PR, I (almostly) copied the `danger` module from `client/mod.rs` and added `set_certificate_verifier()` under `DangerousServerConfig`. I was wondering if you wouldn't mind reviewing this PR. And thank you for your time!