### PR TITLE
Add WriteV implementation for any Write objects

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -277,7 +277,7 @@ pub use crate::verify::{NoClientAuth, AllowAnyAuthenticatedClient,
 pub use crate::suites::{ALL_CIPHERSUITES, BulkAlgorithm, SupportedCipherSuite};
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, NoKeyLog, KeyLogFile};
-pub use crate::vecbuf::WriteV;
+pub use crate::vecbuf::{WriteV, WriteVAdapter};
 
 /// Message signing interfaces and implementations.
 pub mod sign;


### PR DESCRIPTION
Uses a write_vectored as a convenience function for implementing a WriteV adapter for any write object. It's a convenience function here, but I thought maybe this is food for thought in terms of changing `write_tls` to always use the `write_vectored` functionality if possible?