### PR TITLE
Allow applications to pass data through resumption tickets and reject early data

### DIFF
--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -172,6 +172,7 @@ pub struct ServerSessionValue {
     pub extended_ms: bool,
     pub client_cert_chain: Option<CertificatePayload>,
     pub alpn: Option<PayloadU8>,
+    pub application_data: PayloadU16,
 }
 
 impl Codec for ServerSessionValue {
@@ -199,6 +200,7 @@ impl Codec for ServerSessionValue {
         } else {
             0u8.encode(bytes);
         }
+        self.application_data.encode(bytes);
     }
 
     fn read(r: &mut Reader) -> Option<ServerSessionValue> {
@@ -227,6 +229,7 @@ impl Codec for ServerSessionValue {
         } else {
             None
         };
+        let application_data = PayloadU16::read(r)?;
 
         Some(ServerSessionValue {
             sni,
@@ -236,6 +239,7 @@ impl Codec for ServerSessionValue {
             extended_ms: ems == 1u8,
             client_cert_chain: ccert,
             alpn,
+            application_data,
         })
     }
 }
@@ -246,7 +250,8 @@ impl ServerSessionValue {
                cs: CipherSuite,
                ms: Vec<u8>,
                cert_chain: &Option<CertificatePayload>,
-               alpn: Option<Vec<u8>>)
+               alpn: Option<Vec<u8>>,
+               application_data: Vec<u8>)
                -> ServerSessionValue {
         ServerSessionValue {
             sni: sni.cloned(),
@@ -256,6 +261,7 @@ impl ServerSessionValue {
             extended_ms: false,
             client_cert_chain: cert_chain.clone(),
             alpn: alpn.map(PayloadU8::new),
+            application_data: PayloadU16::new(application_data),
         }
     }
 

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -35,7 +35,8 @@ fn serversessionvalue_is_debug() {
                                       CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
                                       vec![1, 2, 3],
                                       &None,
-                                      None);
+                                      None,
+                                      vec![4, 5, 6]);
     println!("{:?}", ssv);
 }
 
@@ -47,6 +48,7 @@ fn serversessionvalue_no_sni() {
         0xc0, 0x23,
         0x03, 0x01, 0x02, 0x03,
         0x00, 0x00, 0x00,
+        0x00, 0x00,
     ];
     let mut rd = Reader::init(&bytes);
     let ssv = ServerSessionValue::read(&mut rd).unwrap();
@@ -61,6 +63,7 @@ fn serversessionvalue_with_cert() {
         0xc0, 0x23,
         0x03, 0x01, 0x02, 0x03,
         0x00,
+        0x00, 0x00,
         0x00, 0x00,
     ];
     let mut rd = Reader::init(&bytes);

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -183,6 +183,7 @@ impl ExtensionProcessing {
                         && resume.version == sess.common.negotiated_version.unwrap()
                         && resume.cipher_suite == sess.common.get_suite_assert().suite
                         && resume.alpn.as_ref().map(|x| &x.0) == sess.alpn_protocol.as_ref()
+                        && !sess.reject_early_data
                     {
                         self.exts.push(ServerExtension::EarlyData);
                     } else {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -236,7 +236,9 @@ fn get_server_session_value_tls12(handshake: &HandshakeDetails,
         sess.get_sni(), version,
         scs.suite, secret,
         &sess.client_cert_chain,
-        sess.alpn_protocol.clone());
+        sess.alpn_protocol.clone(),
+        sess.resumption_data.clone(),
+    );
 
     if handshake.using_ems {
         v.set_extended_ms_used();

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -569,6 +569,10 @@ impl CompleteClientHelloHandling {
             self.send_ticket = true;
         }
 
+        if let Some(ref resume) = resumedata {
+            sess.received_resumption_data = Some(resume.application_data.0.clone());
+        }
+
         let full_handshake = resumedata.is_none();
         self.handshake.transcript.add_message(chm);
         self.emit_server_hello(sess, &client_hello.session_id,
@@ -731,7 +735,9 @@ fn get_server_session_value(handshake: &mut HandshakeDetails,
         sess.get_sni(), version,
         scs.suite, secret,
         &sess.client_cert_chain,
-        sess.alpn_protocol.clone())
+        sess.alpn_protocol.clone(),
+        sess.resumption_data.clone(),
+    )
 }
 
 pub struct ExpectFinished {


### PR DESCRIPTION
Needed for QUIC and HTTP/3. For example, a prior HTTP/3 session's SETTINGS frame may need to be embedded so that it can be respected in 0-RTT, or serve as grounds to reject 0-RTT if respecting it is impossible.