### PR TITLE
server rejects SNI containing multiple hostnames

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -314,18 +314,23 @@ impl Codec for ServerName {
 declare_u16_vec!(ServerNameRequest, ServerName);
 
 pub trait ConvertServerNameList {
-    fn get_hostname(&self) -> Option<webpki::DNSNameRef>;
+    fn get_hostname(&self) -> Vec<webpki::DNSNameRef>;
 }
 
 impl ConvertServerNameList for ServerNameRequest {
-    fn get_hostname(&self) -> Option<webpki::DNSNameRef> {
+    fn get_hostname(&self) -> Vec<webpki::DNSNameRef> {
+        let mut hostname = Vec::new();
+        if self.is_empty() {
+            return hostname;
+        }
+
         for name in self {
             if let ServerNamePayload::HostName(ref dns_name) = name.payload {
-                return Some(dns_name.as_ref());
+                hostname.push(dns_name.as_ref());
             }
         }
 
-        None
+        return hostname;
     }
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -137,7 +137,7 @@ fn get_hostname_returns_none_for_other_sni_name_types() {
 
     assert_eq!(ext.get_type(), ExtensionType::ServerName);
     if let ClientExtension::ServerName(snr) = ext {
-        assert!(snr.get_hostname().is_none());
+        assert!(snr.get_hostname().is_empty());
     } else {
         unreachable!();
     }
@@ -163,7 +163,7 @@ fn can_roundtrip_multiname_sni() {
         ClientExtension::ServerName(req) => {
             assert_eq!(2, req.len());
 
-            let dns_name_str: &str = req.get_hostname().unwrap().into();
+            let dns_name_str: &str = req.get_hostname()[0].into();
             assert_eq!(dns_name_str, "hi");
 
             assert_eq!(req[0].typ, ServerNameType::HostName);

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -577,12 +577,15 @@ impl State for ExpectClientHello {
         // different way.
         let sni: Option<webpki::DNSName> = match client_hello.get_sni_extension() {
             Some(sni) => {
-                match sni.get_hostname() {
-                    Some(sni) => Some(sni.into()),
-                    None => {
-                        return Err(illegal_param(sess,
-                            "ClientHello SNI did not contain a hostname."));
-                    },
+                let hostnames = sni.get_hostname();
+                if hostnames.len() == 1 {
+                    Some(hostnames[0].into())
+                } else if hostnames.len() > 1 {
+                    return Err(decode_error(sess,
+                        "ClientHello SNI contains more than one hostnames."));
+                } else {
+                    return Err(illegal_param(sess,
+                        "ClientHello SNI did not contain a hostname."));
                 }
             },
             None => None,


### PR DESCRIPTION
Hi!

This PR is related to #104 issue.

This makes that server rejects ClientHello SNI containing multiple hostnames.
The server aborts the handshake with a `decode_error` alert, received ClientHello SNI containing multiple hostnames.