### PR TITLE
Add dangerous server cert verifier which uses pinned DNS name for cert validation

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -298,4 +298,5 @@ pub use crate::verify::{ServerCertVerifier, ServerCertVerified,
     ClientCertVerifier, ClientCertVerified};
 #[cfg(feature = "dangerous_configuration")]
 pub use crate::client::danger::DangerousClientConfig;
-
+#[cfg(feature = "dangerous_configuration")]
+pub use crate::verify::danger::DangerousWebPKIVerifierPinnedDNS;


### PR DESCRIPTION
Hello again!

As commit message states, this allows users to have a client config which will trust the server based on if its certificates are valid for the pinned DNS name.

This is useful when you want to use the SNI to indicate to the target to the server, but the server does not have a certificate valid for the target. Specifically useful for TLS proxies. Let me know if tests would be needed seeing as this is a `dangerous`-only provided struct.