### PR TITLE
Expose WebPKIVerifier under dangerous feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 *.gcda
 *.gcno
 *.info
+sslkeylogfile.txt

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -295,7 +295,7 @@ mod quic {
 
 #[cfg(feature = "dangerous_configuration")]
 pub use crate::verify::{ServerCertVerifier, ServerCertVerified,
-    ClientCertVerifier, ClientCertVerified};
+    ClientCertVerifier, ClientCertVerified, WebPKIVerifier};
 #[cfg(feature = "dangerous_configuration")]
 pub use crate::client::danger::DangerousClientConfig;
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -90,11 +90,18 @@ pub trait ClientCertVerifier : Send + Sync {
                           presented_certs: &[Certificate]) -> Result<ClientCertVerified, TLSError>;
 }
 
+/// Default `ServerCertVerifier`, see the trait impl for more information.
 pub struct WebPKIVerifier {
+    /// time provider
     pub time: fn() -> Result<webpki::Time, TLSError>,
 }
 
 impl ServerCertVerifier for WebPKIVerifier {
+    /// Will verify the certificate is valid in the following ways:
+    /// - Signed by a  trusted `RootCertStore` CA
+    /// - Not Expired
+    /// - Valid for DNS entry
+    /// - OCSP data is present
     fn verify_server_cert(&self,
                           roots: &RootCertStore,
                           presented_certs: &[Certificate],
@@ -118,6 +125,7 @@ impl ServerCertVerifier for WebPKIVerifier {
 }
 
 impl WebPKIVerifier {
+    /// Create a new `WebPKIVerifier`
     pub fn new() -> WebPKIVerifier {
         WebPKIVerifier {
             time: try_now,


### PR DESCRIPTION
As mentioned in [a closed issue](https://github.com/ctz/rustls/pull/312#issuecomment-542419246), `WebPKIVerifier` should be exposed so users of the `dangerous` flag can potentially wrap this verifier.