### PR TITLE
Expose ClientSession EarlyData is_enabled function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 *.gcda
 *.gcno
 *.info
+.idea

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -634,6 +634,11 @@ impl ClientSession {
     pub fn is_early_data_accepted(&self) -> bool {
         self.imp.early_data.is_accepted()
     }
+
+    /// Returns True if the client is enabled to send early data.
+    pub fn is_early_data_enabled(&self) -> bool {
+        self.imp.early_data.is_enabled()
+    }
 }
 
 impl Session for ClientSession {


### PR DESCRIPTION
In order to implement 0-RTT on rustls wrappers (like tokio-rustls) it is needed to know if current client session early data is accepted by the server (it's value is set on [client/tls13.rs#L268](https://github.com/ctz/rustls/blob/master/rustls/src/client/tls13.rs#L268]).

This PR just expose the EarlyData `is_enabled` function on the `ClientSession` implementation.