### PR TITLE
remove unnecessary dependency from rustls-mio

### DIFF
--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -17,7 +17,6 @@ dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
 
 [dependencies]
-base64 = "0.10"
 log = { version = "0.4.4", optional = true }
 rustls = { path = "../rustls" }
 sct = "0.6"


### PR DESCRIPTION
Noticed this pulling in the older bytes and some other dependencies. Looks like it's no longer used.