### PR TITLE
Center Ferris and overview text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-![Logo](https://raw.githubusercontent.com/ctz/rustls/master/admin/rustls-logo-web.png)
+<p align="center">
+  <img width="460" height="300" src="https://raw.githubusercontent.com/ctz/rustls/master/admin/rustls-logo-web.png">
+</p>
 
-Rustls is a modern TLS library written in Rust.  It's pronounced 'rustles'.
-It uses [*ring*](https://github.com/briansmith/ring) for cryptography
-and [libwebpki](https://github.com/briansmith/webpki) for certificate
+<p align="center">
+Rustls is a modern TLS library written in Rust.  It's pronounced 'rustles'. It uses <a href = "https://github.com/briansmith/ring"><em>ring</em></a> for cryptography and <a href = "https://github.com/briansmith/webpki">libwebpki</a> for certificate
 verification.
+</p>
 
 # Status
 Rustls is ready for use.  There are no major breaking interface changes


### PR DESCRIPTION
Ferris looking bit cramped there on the left.

[Futures](https://github.com/rust-lang/futures-rs) `README.md` opts to center the logo and overview text which I think looks nice.

Disadvantage is that using HTML tags rather than standard Markdown which may not be supported by all Markdown renderers.

![Screenshot from 2019-12-12 13-04-15](https://user-images.githubusercontent.com/26074448/70687218-1728f180-1ce1-11ea-8c1b-578787e70b4c.png)