### PR TITLE
docs: prefer the IETF wording for cipher suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ obsolete cryptography.
 * ECDSA or RSA server authentication by servers.
 * Forward secrecy using ECDHE; with curve25519, nistp256 or nistp384 curves.
 * AES128-GCM and AES256-GCM bulk encryption, with safe nonces.
-* Chacha20Poly1305 bulk encryption.
+* ChaCha20-Poly1305 bulk encryption ([RFC7905](https://tools.ietf.org/html/rfc7905)).
 * ALPN support.
 * SNI support.
 * Tunable MTU to make TLS messages match size of underlying transport.
@@ -151,7 +151,7 @@ There are plenty of other libraries that provide these features should you
 need them.
 
 # Example code
-There are two example programs which use 
+There are two example programs which use
 [mio](https://github.com/carllerche/mio) to do asynchronous IO.
 
 ## Client example program


### PR DESCRIPTION
I also took the liberty of linking to the RFC page for curious readers.