### PR TITLE
WIP: Implement subset of RFC 8701 - TLS GREASE

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -8,6 +8,7 @@ use crate::msgs::handshake::{ClientExtension, HasServerExtensions};
 use crate::msgs::handshake::{ECPointFormatList, SupportedPointFormats};
 use crate::msgs::handshake::{ProtocolNameList, ConvertProtocolNameList};
 use crate::msgs::handshake::HelloRetryRequest;
+use crate::msgs::handshake::GreaseExt;
 use crate::msgs::handshake::{CertificateStatusRequest, SCTList};
 use crate::msgs::enums::{PSKKeyExchangeMode, ECPointFormat};
 use crate::msgs::codec::{Codec, Reader};
@@ -234,6 +235,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
     exts.push(ClientExtension::SignatureAlgorithms(verify::supported_verify_schemes().to_vec()));
     exts.push(ClientExtension::ExtendedMasterSecretRequest);
     exts.push(ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()));
+    exts.push(ClientExtension::Grease(GreaseExt));
 
     if sess.config.ct_logs.is_some() {
         exts.push(ClientExtension::SignedCertificateTimestampRequest);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -235,7 +235,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
     exts.push(ClientExtension::SignatureAlgorithms(verify::supported_verify_schemes().to_vec()));
     exts.push(ClientExtension::ExtendedMasterSecretRequest);
     exts.push(ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()));
-    exts.push(ClientExtension::Grease(GreaseExt));
+    exts.push(ClientExtension::Grease(GreaseExt::new()));
 
     if sess.config.ct_logs.is_some() {
         exts.push(ClientExtension::SignedCertificateTimestampRequest);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -235,7 +235,10 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
     exts.push(ClientExtension::SignatureAlgorithms(verify::supported_verify_schemes().to_vec()));
     exts.push(ClientExtension::ExtendedMasterSecretRequest);
     exts.push(ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()));
-    exts.push(ClientExtension::Grease(GreaseExt::new()));
+
+    if sess.config.enable_tls_grease {
+        exts.push(ClientExtension::Grease(GreaseExt::new()));
+    }
 
     if sess.config.ct_logs.is_some() {
         exts.push(ClientExtension::SignedCertificateTimestampRequest);

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -136,6 +136,12 @@ pub struct ClientConfig {
     ///
     /// The default is false.
     pub enable_early_data: bool,
+
+    /// Whether to send TLS GREASE extensions in the TLS handshake
+    /// (RFC 8701).
+    ///
+    /// The default is false.
+    pub enable_tls_grease: bool,
 }
 
 impl Default for ClientConfig {
@@ -163,6 +169,7 @@ impl ClientConfig {
             verifier: Arc::new(verify::WebPKIVerifier::new()),
             key_log: Arc::new(NoKeyLog {}),
             enable_early_data: false,
+            enable_tls_grease: false,
         }
     }
 

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -235,7 +235,8 @@ enum_builder! {
         NextProtocolNegotiation => 0x3374,
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,
-        TransportParameters => 0xffa5
+        TransportParameters => 0xffa5,
+        Grease => 0x9a9a
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -8,6 +8,7 @@ use crate::msgs::enums::PSKKeyExchangeMode;
 use crate::msgs::base::{Payload, PayloadU8, PayloadU16, PayloadU24};
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
+use crate::rand;
 use crate::key;
 
 #[cfg(feature = "logging")]
@@ -580,10 +581,23 @@ pub enum ClientExtension {
 }
 
 #[derive(Clone, Debug)]
-pub struct GreaseExt;
+pub struct GreaseExt {
+    inner: [u8; 4],
+}
+
+impl GreaseExt {
+    pub fn new() -> Self {
+        let mut arr = [0u8; 4];
+        rand::fill_random(&mut arr);
+        GreaseExt {
+            inner: arr,
+        }
+    }
+}
 
 impl Codec for GreaseExt {
     fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend_from_slice(&self.inner);
     }
 
     fn read(r: &mut Reader) -> Option<Self> {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -575,7 +575,20 @@ pub enum ClientExtension {
     SignedCertificateTimestampRequest,
     TransportParameters(Vec<u8>),
     EarlyData,
+    Grease(GreaseExt),
     Unknown(UnknownExtension),
+}
+
+#[derive(Clone, Debug)]
+pub struct GreaseExt;
+
+impl Codec for GreaseExt {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+    }
+
+    fn read(r: &mut Reader) -> Option<Self> {
+        None
+    }
 }
 
 impl ClientExtension {
@@ -598,6 +611,7 @@ impl ClientExtension {
             ClientExtension::SignedCertificateTimestampRequest => ExtensionType::SCT,
             ClientExtension::TransportParameters(_) => ExtensionType::TransportParameters,
             ClientExtension::EarlyData => ExtensionType::EarlyData,
+            ClientExtension::Grease(_) => ExtensionType::Grease,
             ClientExtension::Unknown(ref r) => r.typ,
         }
     }
@@ -626,6 +640,7 @@ impl Codec for ClientExtension {
             ClientExtension::Cookie(ref r) => r.encode(&mut sub),
             ClientExtension::CertificateStatusRequest(ref r) => r.encode(&mut sub),
             ClientExtension::TransportParameters(ref r) => sub.extend_from_slice(r),
+            ClientExtension::Grease(ref r) => r.encode(&mut sub),
             ClientExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 


### PR DESCRIPTION
Closes #357.

This patch implements a subset of the TLS GREASE extension.
Specifically:
   A client MAY select one or more GREASE extension values and
   advertise them as extensions with varying length and contents.

This patch simply adds a hardcoded sample from the RFC's GREASE table
and appends it at a hardcoded position in the ClientHello.

I think as a start, this feature could be a part of the session ClientConfig. 

Any feedback welcome!