### PR TITLE
stream: implement write_vectored

### DIFF
--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -18,7 +18,7 @@ use crate::vecbuf::WriteV;
 use crate::log::trace;
 
 use std::sync::Arc;
-use std::io;
+use std::io::{self, IoSlice};
 use std::fmt;
 use std::mem;
 
@@ -740,6 +740,14 @@ impl io::Write for ClientSession {
     /// cause excess memory usage.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.imp.send_some_plaintext(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let mut sz = 0;
+        for buf in bufs {
+            sz += self.imp.send_some_plaintext(buf)?;
+        }
+        Ok(sz)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -17,7 +17,7 @@ use crate::log::trace;
 use webpki;
 
 use std::sync::Arc;
-use std::io;
+use std::io::{self, IoSlice};
 use std::fmt;
 
 #[macro_use]
@@ -649,6 +649,14 @@ impl io::Write for ServerSession {
     /// cause excess memory usage.
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.imp.send_some_plaintext(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let mut sz = 0;
+        for buf in bufs {
+            sz += self.imp.send_some_plaintext(buf)?;
+        }
+        Ok(sz)
     }
 
     fn flush(&mut self) -> io::Result<()> {


### PR DESCRIPTION
I'm not sure if this is something we want to do, but this allows queuing more data internally without flushing to the socket inbetween buffers