### PR TITLE
QUIC: Don't set legacy_session_id, fix key update

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -25,10 +25,7 @@ use crate::log::{debug, trace};
 use crate::error::TLSError;
 use crate::handshake::check_handshake_message;
 #[cfg(feature = "quic")]
-use crate::{
-    msgs::base::PayloadU16,
-    session::Protocol
-};
+use crate::msgs::base::PayloadU16;
 
 use crate::client::common::{ServerCertDetails, HandshakeDetails};
 use crate::client::common::{ClientHelloDetails, ReceivedTicketDetails};
@@ -112,7 +109,7 @@ fn find_session(sess: &mut ClientSessionImpl, dns_name: webpki::DNSNameRef)
             None
         } else {
             #[cfg(feature = "quic")] {
-                if sess.common.protocol == Protocol::Quic {
+                if sess.common.is_quic() {
                     let params = PayloadU16::read(&mut reader)?;
                     sess.common.quic.params = Some(params.0);
                 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -205,7 +205,7 @@ fn emit_client_hello_for_retry(sess: &mut ClientSessionImpl,
         (resuming.session_id, resuming.ticket.0.clone(), resuming.version)
     } else {
         debug!("Not resuming any session");
-        if handshake.session_id.is_empty() {
+        if handshake.session_id.is_empty() && !sess.common.is_quic() {
             handshake.session_id = random_sessionid();
         }
         (handshake.session_id, Vec::new(), ProtocolVersion::Unknown(0))

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -305,9 +305,7 @@ pub fn prepare_resumption(sess: &mut ClientSessionImpl,
 }
 
 pub fn emit_fake_ccs(hs: &mut HandshakeDetails, sess: &mut ClientSessionImpl) {
-    #[cfg(feature = "quic")] {
-        if let Protocol::Quic = sess.common.protocol { return; }
-    }
+    if sess.common.is_quic() { return; }
 
     if hs.sent_tls13_fake_ccs {
         return;
@@ -784,10 +782,7 @@ fn emit_finished_tls13(handshake: &mut HandshakeDetails,
 
 fn emit_end_of_early_data_tls13(handshake: &mut HandshakeDetails,
                                 sess: &mut ClientSessionImpl) {
-    #[cfg(feature = "quic")]
-    {
-        if let Protocol::Quic = sess.common.protocol { return; }
-    }
+    if sess.common.is_quic() { return; }
 
     let m = Message {
         typ: ContentType::Handshake,

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -288,7 +288,7 @@ fn next_1rtt_keys(this: &mut SessionCommon) -> PacketKeySet {
 
     let next = next_1rtt_secrets(hkdf_alg, secrets);
 
-    let (local, remote) = secrets.local_remote(this.is_client);
+    let (local, remote) = next.local_remote(this.is_client);
     let keys = PacketKeySet {
         local: PacketKey::new(this.get_suite_assert(), local),
         remote: PacketKey::new(this.get_suite_assert(), remote),

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -211,9 +211,7 @@ impl CompleteClientHelloHandling {
 
     fn emit_fake_ccs(&mut self,
                      sess: &mut ServerSessionImpl) {
-        #[cfg(feature = "quic")] {
-            if let Protocol::Quic = sess.common.protocol { return; }
-        }
+        if sess.common.is_quic() { return; }
         let m = Message {
             typ: ContentType::ChangeCipherSpec,
             version: ProtocolVersion::TLSv1_2,

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -721,6 +721,15 @@ impl SessionCommon {
         let m = Message::build_alert(AlertLevel::Warning, desc);
         self.send_msg(m, self.record_layer.is_encrypting());
     }
+
+    pub fn is_quic(&self) -> bool {
+        #[cfg(feature = "quic")]
+        {
+            self.protocol == Protocol::Quic
+        }
+        #[cfg(not(feature = "quic"))]
+        false
+    }
 }
 
 


### PR DESCRIPTION
[QUIC TLS §8.4](https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#name-prohibit-tls-middlebox-comp):
> A server SHOULD treat the receipt of a TLS ClientHello with a non-empty legacy_session_id field as a connection error of type PROTOCOL_VIOLATION.

So, let's not send those.