### PR TITLE
Make examples better

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -160,6 +160,21 @@ impl TlsClient {
         self.closing
     }
 }
+impl io::Write for TlsClient {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.tls_session.write(bytes)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.tls_session.flush()
+    }
+}
+
+impl io::Read for TlsClient {
+    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
+        self.tls_session.read(bytes)
+    }
+}
 
 /// This is an example cache for client session data.
 /// It optionally dumps cached data to a file, but otherwise
@@ -530,21 +545,5 @@ fn main() {
             tlsclient.ready(&ev);
             tlsclient.reregister(poll.registry());
         }
-    }
-}
-
-impl io::Write for TlsClient {
-    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.tls_session.write(bytes)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.tls_session.flush()
-    }
-}
-
-impl io::Read for TlsClient {
-    fn read(&mut self, bytes: &mut [u8]) -> io::Result<usize> {
-        self.tls_session.read(bytes)
     }
 }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -46,6 +46,7 @@ impl TlsClient {
         }
     }
 
+    /// Handles events sent to the TlsClient by mio::Poll
     fn ready(&mut self, ev: &mio::event::Event) {
         assert_eq!(ev.token(), CLIENT);
 
@@ -128,18 +129,20 @@ impl TlsClient {
         self.tls_session.write_tls(&mut self.socket).unwrap();
     }
 
+    /// Registers self as a 'listener' in mio::Registry
     fn register(&mut self, registry: &mio::Registry) {
         let interest = self.event_set();
         registry.register(&mut self.socket, CLIENT, interest).unwrap();
     }
 
+    /// Reregisters self as a 'listener' in mio::Registry.
     fn reregister(&mut self, registry: &mio::Registry) {
         let interest = self.event_set();
         registry.reregister(&mut self.socket, CLIENT, interest).unwrap();
     }
 
-    // Use wants_read/wants_write to register for different mio-level
-    // IO readiness events.
+    /// Use wants_read/wants_write to register for different mio-level
+    /// IO readiness events.
     fn event_set(&self) -> mio::Interest {
         let rd = self.tls_session.wants_read();
         let wr = self.tls_session.wants_write();


### PR DESCRIPTION
- make TLS client example a little more consistent with the TLS server example.
- make TLS client have a cleaner implementation code block