### PR TITLE
add export_keying_material support in QUIC mode

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1046,4 +1046,11 @@ impl hs::State for ExpectQUICTraffic {
         self.0.handle_new_ticket_tls13(sess, nst)?;
         Ok(self)
     }
+
+    fn export_keying_material(&self,
+                              output: &mut [u8],
+                              label: &[u8],
+                              context: Option<&[u8]>) -> Result<(), TLSError> {
+        self.0.export_keying_material(output, label, context)
+    }
 }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2220,6 +2220,21 @@ mod test_quic {
                        Some(rustls::internal::msgs::enums::AlertDescription::NoApplicationProtocol));
         }
     }
+
+#[test]
+    fn test_quic_exporter() {
+        for  &kt in ALL_KEY_TYPES.iter() {
+            let mut client_config = make_client_config(kt);
+            client_config.versions = vec![ProtocolVersion::TLSv1_3];
+            client_config.alpn_protocols = vec!["bar".into()];
+
+            let mut server_config = make_server_config(kt);
+            server_config.versions = vec![ProtocolVersion::TLSv1_3];
+            server_config.alpn_protocols = vec!["foo".into()];
+
+            do_exporter_test(client_config, server_config);
+        }
+    }
 } // mod test_quic
 
 #[test]


### PR DESCRIPTION
This pull request makes it possible to call `export_keying_material` when rustls is used for QUIC.

Prior to applying the proposed patch, the `export_keying_material` method in the State impl for ExpectQUICTraffic is the default one, which returns `TLSError::HandshakeNotComplete`. After applying, export_keying_material correctly calls the KeyScheduleTraffic implementation of `export_keying_material`.

This PR also wires up the existing `do_exporter_test` in the `test_quic` module.