### PR TITLE
Show ALPN upgrade protocol as string in debug logs

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -360,7 +360,7 @@ pub fn process_alpn_protocol(sess: &mut ClientSessionImpl,
         !sess.config.alpn_protocols.contains(sess.alpn_protocol.as_ref().unwrap()) {
         return Err(illegal_param(sess, "server sent non-offered ALPN protocol"));
     }
-    debug!("ALPN protocol is {:?}", sess.alpn_protocol);
+    debug!("ALPN protocol is {:?}", sess.alpn_protocol.as_ref().map(|us| std::str::from_utf8(us).unwrap_or("")));
     Ok(())
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -361,10 +361,11 @@ pub fn process_alpn_protocol(sess: &mut ClientSessionImpl,
         return Err(illegal_param(sess, "server sent non-offered ALPN protocol"));
     }
     debug!(
-        "ALPN protocol is {:?}",
+        "ALPN protocol is {:?} ({:?})",
         sess.alpn_protocol
             .as_ref()
-            .map(|us| String::from_utf8_lossy(us))
+            .map(|us| String::from_utf8_lossy(us)),
+        sess.alpn_protocol
     );
     Ok(())
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -364,7 +364,7 @@ pub fn process_alpn_protocol(sess: &mut ClientSessionImpl,
         "ALPN protocol is {:?}",
         sess.alpn_protocol
             .as_ref()
-            .map(|us| std::str::from_utf8(us).unwrap_or(""))
+            .map(|us| String::from_utf8_lossy(us))
     );
     Ok(())
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -360,7 +360,12 @@ pub fn process_alpn_protocol(sess: &mut ClientSessionImpl,
         !sess.config.alpn_protocols.contains(sess.alpn_protocol.as_ref().unwrap()) {
         return Err(illegal_param(sess, "server sent non-offered ALPN protocol"));
     }
-    debug!("ALPN protocol is {:?}", sess.alpn_protocol.as_ref().map(|us| std::str::from_utf8(us).unwrap_or("")));
+    debug!(
+        "ALPN protocol is {:?}",
+        sess.alpn_protocol
+            .as_ref()
+            .map(|us| std::str::from_utf8(us).unwrap_or(""))
+    );
     Ok(())
 }
 


### PR DESCRIPTION
This is an almost trivial request, but it would have helped me as a TLS noob to figure out what the ALPN upgrade does here.

The chosen conversion avoids allocations. Downside: If the ALPN string is ever not valid UTF-8, it will be invisible in the logs. However, [RFC 7301](https://tools.ietf.org/html/rfc7301#section-6) gives some expectation that the ALPN protocol strings are and will consist of characters in the ASCII subset.

Before:
```
[2020-10-24T16:00:32Z DEBUG rustls::client::hs] ALPN protocol is Some([104, 50])
```

After: 
```
[2020-10-24T16:00:32Z DEBUG rustls::client::hs] ALPN protocol is Some("h2")
```