### PR TITLE
Implement ResolvesServerCert for Arc<T>

### DIFF
--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -102,6 +102,24 @@ pub trait ResolvesServerCert : Send + Sync {
     fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey>;
 }
 
+impl<T> ResolvesServerCert for Box<T>
+where
+    T: ResolvesServerCert,
+{
+    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+        self.as_ref().resolve(client_hello)
+    }
+}
+
+impl<T> ResolvesServerCert for Arc<T>
+where
+    T: ResolvesServerCert,
+{
+    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+        self.as_ref().resolve(client_hello)
+    }
+}
+
 /// A struct representing the received Client Hello
 pub struct ClientHello<'a> {
     server_name: Option<webpki::DNSNameRef<'a>>,


### PR DESCRIPTION
Sounds like a useful implementation, in particular since the trait only requires `&self`. If this was added we could remove some additional boilerplate from our code.