### PR TITLE
Require *ring* 0.16.19 and webpki 0.21.4.

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-webpki = "0.21.0"
+webpki = "0.21.4"
 
 [dependencies.rustls]
 path = "../rustls"

--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -17,7 +17,7 @@ quic = ["rustls/quic"]
 log = { version = "0.4.4", optional = true }
 rustls = { path = "../rustls" }
 sct = "0.6"
-webpki = "0.21.0"
+webpki = "0.21.4"
 
 [dev-dependencies]
 ct-logs = "0.8"
@@ -28,7 +28,7 @@ regex = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 webpki-roots = "0.21"
-ring = "0.16.0"
+ring = "0.16.9"
 
 [[example]]
 name = "tlsclient"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -14,9 +14,9 @@ autobenches = false
 [dependencies]
 base64 = "0.13.0"
 log = { version = "0.4.4", optional = true }
-ring = "0.16.11"
+ring = "0.16.19"
 sct = "0.6.0"
-webpki = "0.21.0"
+webpki = "0.21.4"
 
 [features]
 default = ["logging"]


### PR DESCRIPTION
*ring* 0.16.19 contains a workaround for an ARM CPU bug, sourced from
BoringSSL.