### PR TITLE
don't allocate a new vec in every `ChunkVecBuffer::write_to`

### DIFF
--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -115,7 +115,78 @@ impl ChunkVecBuffer {
             return Ok(0);
         }
 
-        let mut bufs = [io::IoSlice::new(&[]); 64];
+        // XXX: `rustls`'s MSRV is 1.40.0, where `IoSlice` doesn't implement
+        // `Copy`. When the MSRV is Rust 1.44.0, this could be the much more
+        // concise
+        // ```
+        // let mut bufs = [io::IoSlice::new(&[]); 64];
+        // ```
+        let mut bufs = [
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+            io::IoSlice::new(&[]),
+        ];
         for (iov, chunk) in bufs.iter_mut().zip(self.chunks.iter()) {
             *iov = io::IoSlice::new(&chunk);
         }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -88,9 +88,7 @@ impl ChunkVecBuffer {
         let mut offs = 0;
 
         while offs < buf.len() && !self.is_empty() {
-            let used = self.chunks[0]
-                .as_slice()
-                .read(&mut buf[offs..])?;
+            let used = self.chunks[0].as_slice().read(&mut buf[offs..])?;
 
             self.consume(used);
             offs += used;
@@ -117,13 +115,12 @@ impl ChunkVecBuffer {
             return Ok(0);
         }
 
-        let used = wr.write_vectored(
-            &self
-                .chunks
-                .iter()
-                .map(|ch| io::IoSlice::new(ch))
-                .collect::<Vec<io::IoSlice>>(),
-        )?;
+        let mut bufs = [io::IoSlice::new(&[]); 64];
+        for (iov, chunk) in bufs.iter_mut().zip(self.chunks.iter()) {
+            *iov = io::IoSlice::new(&chunk);
+        }
+
+        let used = wr.write_vectored(&bufs[..self.chunks.len()])?;
         self.consume(used);
         Ok(used)
     }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -115,78 +115,7 @@ impl ChunkVecBuffer {
             return Ok(0);
         }
 
-        // XXX: `rustls`'s MSRV is 1.40.0, where `IoSlice` doesn't implement
-        // `Copy`. When the MSRV is Rust 1.44.0, this could be the much more
-        // concise
-        // ```
-        // let mut bufs = [io::IoSlice::new(&[]); 64];
-        // ```
-        let mut bufs = [
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-            io::IoSlice::new(&[]),
-        ];
+        let mut bufs = [io::IoSlice::new(&[]); 64];
         for (iov, chunk) in bufs.iter_mut().zip(self.chunks.iter()) {
             *iov = io::IoSlice::new(&chunk);
         }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -190,8 +190,8 @@ impl ChunkVecBuffer {
         for (iov, chunk) in bufs.iter_mut().zip(self.chunks.iter()) {
             *iov = io::IoSlice::new(&chunk);
         }
-
-        let used = wr.write_vectored(&bufs[..self.chunks.len()])?;
+        let len = cmp::min(bufs.len(), self.chunks.len());
+        let used = wr.write_vectored(&bufs[..len])?;
         self.consume(used);
         Ok(used)
     }


### PR DESCRIPTION
This commit changes the implementation of `ChunkVecBuffer::write_to` so
that a vector is not allocated in every call. This should hopefully
reduce the overhead of writing TLS data to a stream.

Instead of using a `Vec`, a fixed-size array of 64 `IoSlice`s is used.
If the number of queued chunks exceeds 64, we may write fewer bytes in
one `write_to` call, but not allocating and dropping a vec in every call
is probably worth it. My intuition is that 64 `IoSlice`s is plenty and
it shouldn't be exceeded often, but I'll admit that it was chosen fairly
arbitrarily.

Another potential approach could be to use a single vec that lives in
the `ChunkVecBuffer`, and is `clear`ed when consuming written data,
retaining the allocated capacity. That way, the existing allocation is
reused, and we only allocate when the `VecDeque` of queued chunks has
grown longer than its the previous maximum length. However, this is not
presently possible, because an `IoSlice` is borrowed, and we can't add a
`Vec<IoSlice<'a>>` to the `ChunkVecBuffer`, since the lifetime `'a` here
would be the lifetime of the `&mut self` receiver of `write_to` --- so
the slices would not live long enough to be assigned to such a vec.

Therefore, I think using a stack array is the right approach for now.