### PR TITLE
Use single time for verifications (see #440)

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -453,6 +453,7 @@ mod danger {
             _presented_certs: &[rustls::Certificate],
             _dns_name: webpki::DNSNameRef<'_>,
             _ocsp: &[u8],
+            _now: std::time::SystemTime,
         ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
             Ok(rustls::ServerCertVerified::assertion())
         }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -23,6 +23,7 @@ use std::net;
 use std::ops::{Deref, DerefMut};
 use std::process;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 static BOGO_NACK: i32 = 89;
 
@@ -192,6 +193,7 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
         &self,
         _certs: &[rustls::Certificate],
         _sni: Option<&webpki::DNSName>,
+        _now: SystemTime,
     ) -> Result<rustls::ClientCertVerified, rustls::TLSError> {
         Ok(rustls::ClientCertVerified::assertion())
     }
@@ -206,6 +208,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
         _certs: &[rustls::Certificate],
         _hostname: webpki::DNSNameRef<'_>,
         _ocsp: &[u8],
+        _now: SystemTime,
     ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
         Ok(rustls::ServerCertVerified::assertion())
     }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -171,7 +171,7 @@ impl ClientConfig {
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             ct_logs: None,
             enable_sni: true,
-            verifier: Arc::new(verify::WebPKIVerifier::new()),
+            verifier: Arc::new(verify::WebPKIVerifier),
             key_log: Arc::new(NoKeyLog {}),
             enable_early_data: false,
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -688,6 +688,7 @@ impl hs::State for ExpectCertificateVerify {
             return Err(TLSError::NoCertificatesPresented);
         }
 
+        let now = std::time::SystemTime::now();
         let certv = sess
             .config
             .get_verifier()
@@ -696,6 +697,7 @@ impl hs::State for ExpectCertificateVerify {
                 &self.server_cert.cert_chain,
                 self.handshake.dns_name.as_ref(),
                 &self.server_cert.ocsp_response,
+                now,
             )
             .map_err(|err| send_cert_error_alert(sess, err))?;
 
@@ -717,7 +719,7 @@ impl hs::State for ExpectCertificateVerify {
         // 3. Verify any included SCTs.
         match (self.server_cert.scts.as_ref(), sess.config.ct_logs) {
             (Some(scts), Some(logs)) => {
-                verify::verify_scts(&self.server_cert.cert_chain[0], scts, logs)?;
+                verify::verify_scts(&self.server_cert.cert_chain[0], now, scts, logs)?;
             }
             (_, _) => {}
         }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -78,9 +78,10 @@ impl hs::State for ExpectCertificate {
 
         trace!("certs {:?}", cert_chain);
 
+        let now = std::time::SystemTime::now();
         sess.config
             .verifier
-            .verify_client_cert(cert_chain, sess.get_sni())
+            .verify_client_cert(cert_chain, sess.get_sni(), now)
             .or_else(|err| {
                 hs::incompatible(sess, "certificate invalid");
                 Err(err)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -785,9 +785,10 @@ impl hs::State for ExpectCertificate {
             return Err(TLSError::NoCertificatesPresented);
         }
 
+        let now = std::time::SystemTime::now();
         sess.config
             .get_verifier()
-            .verify_client_cert(&cert_chain, sess.get_sni())
+            .verify_client_cert(&cert_chain, sess.get_sni(), now)
             .or_else(|err| {
                 hs::incompatible(sess, "certificate invalid");
                 Err(err)

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -18,272 +18,190 @@ fn duration_nanos(d: Duration) -> u64 {
     ((d.as_secs() as f64) * 1e9 + (d.subsec_nanos() as f64)) as u64
 }
 
-fn bench<Fsetup, Ftest, S>(count: usize, name: &'static str, f_setup: Fsetup, f_test: Ftest)
-where
-    Fsetup: Fn() -> S,
-    Ftest: Fn(S),
-{
-    let mut times = Vec::new();
-
-    for _ in 0..count {
-        let state = f_setup();
-        let start = Instant::now();
-        f_test(state);
-        times.push(duration_nanos(Instant::now().duration_since(start)));
-    }
-
-    println!("{}: min {:?}us", name, times.iter().min().unwrap() / 1000);
-}
-
-fn fixed_time() -> SystemTime {
-    SystemTime::UNIX_EPOCH + Duration::from_secs(1500000000)
-}
-
 static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier;
 
 #[test]
 fn test_reddit_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-reddit.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-reddit.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(reddit)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("reddit.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "reddit",
+        "reddit.com",
+        &[
+            include_bytes!("testdata/cert-reddit.0.der"),
+            include_bytes!("testdata/cert-reddit.1.der")
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_github_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-github.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-github.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(github)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("github.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "github",
+        "github.com",
+        &[
+            include_bytes!("testdata/cert-github.0.der"),
+            include_bytes!("testdata/cert-github.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_arstechnica_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-arstechnica.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-arstechnica.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-arstechnica.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(arstechnica)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("arstechnica.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "arstechnica",
+        "arstechnica.com",
+        &[
+            include_bytes!("testdata/cert-arstechnica.0.der"),
+            include_bytes!("testdata/cert-arstechnica.1.der"),
+            include_bytes!("testdata/cert-arstechnica.2.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_servo_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-servo.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-servo.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-servo.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(servo)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("servo.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "servo",
+        "servo.org",
+        &[
+            include_bytes!("testdata/cert-servo.0.der"),
+            include_bytes!("testdata/cert-servo.1.der"),
+            include_bytes!("testdata/cert-servo.2.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_twitter_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-twitter.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-twitter.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(twitter)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("twitter.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "twitter",
+        "twitter.com",
+        &[
+            include_bytes!("testdata/cert-twitter.0.der"),
+            include_bytes!("testdata/cert-twitter.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_wikipedia_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-wikipedia.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-wikipedia.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(wikipedia)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("wikipedia.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "wikipedia",
+        "wikipedia.org",
+        &[
+            include_bytes!("testdata/cert-wikipedia.0.der"),
+            include_bytes!("testdata/cert-wikipedia.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_google_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-google.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-google.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-google.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(google)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.google.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "google",
+        "www.google.com",
+        &[
+            include_bytes!("testdata/cert-google.0.der"),
+            include_bytes!("testdata/cert-google.1.der"),
+            include_bytes!("testdata/cert-google.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_hn_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-hn.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-hn.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-hn.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(hn)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("news.ycombinator.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "hn",
+        "news.ycombinator.com",
+        &[
+            include_bytes!("testdata/cert-hn.0.der"),
+            include_bytes!("testdata/cert-hn.1.der"),
+            include_bytes!("testdata/cert-hn.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_stackoverflow_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-stackoverflow.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-stackoverflow.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(stackoverflow)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("stackoverflow.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "stackoverflow",
+        "stackoverflow.com",
+        &[
+            include_bytes!("testdata/cert-stackoverflow.0.der"),
+            include_bytes!("testdata/cert-stackoverflow.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_duckduckgo_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-duckduckgo.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-duckduckgo.1.der").to_vec());
-    let chain = [cert0, cert1];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(duckduckgo)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("duckduckgo.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "duckduckgo",
+        "duckduckgo.com",
+        &[
+            include_bytes!("testdata/cert-duckduckgo.0.der"),
+            include_bytes!("testdata/cert-duckduckgo.1.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_rustlang_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-rustlang.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-rustlang.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-rustlang.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(rustlang)",
-        || (),
-        |_| {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.rust-lang.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
-                .unwrap();
-        },
-    );
+    Context::new(
+        "rustlang",
+        "www.rust-lang.org",
+        &[
+            include_bytes!("testdata/cert-rustlang.0.der"),
+            include_bytes!("testdata/cert-rustlang.1.der"),
+            include_bytes!("testdata/cert-rustlang.2.der"),
+        ]
+    ).bench(100)
 }
 
 #[test]
 fn test_wapo_cert() {
-    let cert0 = key::Certificate(include_bytes!("testdata/cert-wapo.0.der").to_vec());
-    let cert1 = key::Certificate(include_bytes!("testdata/cert-wapo.1.der").to_vec());
-    let cert2 = key::Certificate(include_bytes!("testdata/cert-wapo.2.der").to_vec());
-    let chain = [cert0, cert1, cert2];
-    let mut anchors = anchors::RootCertStore::empty();
-    anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let now = fixed_time();
-    bench(
-        100,
-        "verify_server_cert(wapo)",
-        || (),
-        |_| {
-            let dns_name =
-                webpki::DNSNameRef::try_from_ascii_str("www.washingtonpost.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
+    Context::new(
+        "wapo",
+        "www.washingtonpost.com",
+        &[
+            include_bytes!("testdata/cert-wapo.0.der"),
+            include_bytes!("testdata/cert-wapo.1.der"),
+            include_bytes!("testdata/cert-wapo.2.der"),
+        ],
+    ).bench(100)
+}
+
+struct Context {
+    name: &'static str,
+    domain: &'static str,
+    roots: anchors::RootCertStore,
+    chain: Vec<key::Certificate>,
+    now: SystemTime,
+}
+
+impl Context {
+    fn new(name: &'static str, domain: &'static str, certs: &[&'static [u8]]) -> Self {
+        let mut roots = anchors::RootCertStore::empty();
+        roots.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        Self {
+            name,
+            domain,
+            roots,
+            chain: certs.iter().copied().map(|bytes| key::Certificate(bytes.to_vec())).collect(),
+            now: SystemTime::UNIX_EPOCH + Duration::from_secs(1500000000),
+        }
+    }
+
+    fn bench(&self, count: usize) {
+        let mut times = Vec::new();
+
+        for _ in 0..count {
+            let start = Instant::now();
+            let dns_name = webpki::DNSNameRef::try_from_ascii_str(self.domain).unwrap();
+            V.verify_server_cert(&self.roots, &self.chain[..], dns_name, &[], self.now)
                 .unwrap();
-        },
-    );
+            times.push(duration_nanos(Instant::now().duration_since(start)));
+        }
+
+        println!("verify_server_cert({}): min {:?}us", self.name, times.iter().min().unwrap() / 1000);
+    }
 }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -4,10 +4,9 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use crate::anchors;
-use crate::error::TLSError;
 use crate::key;
 use crate::verify;
 use crate::verify::ServerCertVerifier;
@@ -36,11 +35,11 @@ where
     println!("{}: min {:?}us", name, times.iter().min().unwrap() / 1000);
 }
 
-fn fixed_time() -> Result<webpki::Time, TLSError> {
-    Ok(webpki::Time::from_seconds_since_unix_epoch(1500000000))
+fn fixed_time() -> SystemTime {
+    SystemTime::UNIX_EPOCH + Duration::from_secs(1500000000)
 }
 
-static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier { time: fixed_time };
+static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier;
 
 #[test]
 fn test_reddit_cert() {
@@ -49,13 +48,14 @@ fn test_reddit_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(reddit)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("reddit.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -68,13 +68,14 @@ fn test_github_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(github)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("github.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -88,13 +89,14 @@ fn test_arstechnica_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(arstechnica)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("arstechnica.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -108,13 +110,14 @@ fn test_servo_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(servo)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("servo.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -127,13 +130,14 @@ fn test_twitter_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(twitter)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("twitter.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -146,13 +150,14 @@ fn test_wikipedia_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(wikipedia)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("wikipedia.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -166,13 +171,14 @@ fn test_google_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(google)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.google.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -186,13 +192,14 @@ fn test_hn_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(hn)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("news.ycombinator.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -205,13 +212,14 @@ fn test_stackoverflow_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(stackoverflow)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("stackoverflow.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -224,13 +232,14 @@ fn test_duckduckgo_cert() {
     let chain = [cert0, cert1];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(duckduckgo)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("duckduckgo.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -244,13 +253,14 @@ fn test_rustlang_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(rustlang)",
         || (),
         |_| {
             let dns_name = webpki::DNSNameRef::try_from_ascii_str("www.rust-lang.org").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );
@@ -264,6 +274,7 @@ fn test_wapo_cert() {
     let chain = [cert0, cert1, cert2];
     let mut anchors = anchors::RootCertStore::empty();
     anchors.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let now = fixed_time();
     bench(
         100,
         "verify_server_cert(wapo)",
@@ -271,7 +282,7 @@ fn test_wapo_cert() {
         |_| {
             let dns_name =
                 webpki::DNSNameRef::try_from_ascii_str("www.washingtonpost.com").unwrap();
-            V.verify_server_cert(&anchors, &chain[..], dns_name, &[])
+            V.verify_server_cert(&anchors, &chain[..], dns_name, &[], now)
                 .unwrap();
         },
     );

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -345,6 +345,7 @@ impl ClientCertVerifier for MockClientVerifier {
         &self,
         _presented_certs: &[Certificate],
         sni: Option<&webpki::DNSName>,
+        _now: std::time::SystemTime,
     ) -> Result<ClientCertVerified, TLSError> {
         assert!(sni.is_some());
         (self.verified)()


### PR DESCRIPTION
As suggested by @briansmith in #440. Criterion suggests this is a 2.4% improvement on read_tls with EWOULDBLOCK.

It does change the verifier traits, so would be breaking for everyone implementing those traits.