### PR TITLE
Add TLS Certificate Compression (RFC8879)

### DIFF
--- a/rustls-mio/Cargo.toml
+++ b/rustls-mio/Cargo.toml
@@ -12,6 +12,7 @@ default = ["logging"]
 logging = ["log"]
 dangerous_configuration = ["rustls/dangerous_configuration"]
 quic = ["rustls/quic"]
+certificate_compression = ["rustls/certificate_compression"]
 
 [dependencies]
 log = { version = "0.4.4", optional = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,6 +16,9 @@ log = { version = "0.4.4", optional = true }
 ring = "0.16.19"
 sct = "0.6.0"
 webpki = "0.21.4"
+brotli = "3.3.0"
+flate2 = "1.0"
+zstd = "0.6"
 
 [features]
 default = ["logging"]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,15 +16,16 @@ log = { version = "0.4.4", optional = true }
 ring = "0.16.19"
 sct = "0.6.0"
 webpki = "0.21.4"
-brotli = "3.3.0"
-flate2 = "1.0"
-zstd = "0.6"
+brotli = { version = "3.3.0", optional = true }
+flate2 = { version = "1.0", optional = true }
+zstd = { version = "0.6", optional = true }
 
 [features]
 default = ["logging"]
 logging = ["log"]
 dangerous_configuration = []
 quic = []
+certificate_compression = ['brotli', 'flate2', 'zstd']
 
 [dev-dependencies]
 env_logger = "0.8.2"

--- a/rustls/src/certificate/compression/brotli.rs
+++ b/rustls/src/certificate/compression/brotli.rs
@@ -1,0 +1,117 @@
+//! Brotli compression functions
+
+use super::{CertificateCompressor, CertificateDecompressor};
+use crate::TLSError;
+use brotli::{enc::BrotliEncoderParams, CompressorWriter, DecompressorWriter};
+use std::io::{Result, Write};
+
+/// Configuration parameters for Brotli
+#[derive(Debug, Clone)]
+pub struct BrotliParams {
+    buffer_size: usize,
+    encoder_params: BrotliEncoderParams,
+}
+
+impl BrotliParams {
+    /// Create new BrotliParams given a quality and buffer_size
+    /// * quality: Value must be between 0-11,
+    /// defaults to [::brotli::enc::encode::BrotliEncoderInitParams]
+    /// * buffer_size: internal brotli buffer size, defaults to 4096
+    pub fn new(quality: i32, buffer_size: usize) -> std::result::Result<Self, TLSError> {
+        if !(0i32..=11).contains(&quality) {
+            return Err(TLSError::General(
+                "quality must be between 0 and 11".to_string(),
+            ));
+        }
+
+        let encoder_params = BrotliEncoderParams {
+            quality,
+            ..Default::default()
+        };
+
+        Ok(Self {
+            buffer_size,
+            encoder_params,
+        })
+    }
+}
+
+impl Default for BrotliParams {
+    fn default() -> Self {
+        Self {
+            // This value is used throughout the brotli crate as a default size.
+            buffer_size: 4096,
+            encoder_params: BrotliEncoderParams::default(),
+        }
+    }
+}
+
+pub(crate) struct BrotliCompress<W: Write>(CompressorWriter<W>);
+
+impl<W: Write> BrotliCompress<W> {
+    pub fn new(writer: W, params: &BrotliParams) -> Self {
+        Self(CompressorWriter::with_params(
+            writer,
+            params.buffer_size,
+            &params.encoder_params,
+        ))
+    }
+}
+
+impl<W: Write> Write for BrotliCompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateCompressor for BrotliCompress<W> {
+    type Writer = W;
+
+    fn finish(mut self) -> Result<Self::Writer> {
+        self.0.flush()?;
+        Ok(self.0.into_inner())
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}
+
+pub(crate) struct BrotliDecompress<W: Write>(DecompressorWriter<W>);
+
+impl<W: Write> BrotliDecompress<W> {
+    pub fn new(writer: W, params: &BrotliParams) -> Self {
+        Self(DecompressorWriter::new(writer, params.buffer_size))
+    }
+}
+
+impl<W: Write> Write for BrotliDecompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateDecompressor for BrotliDecompress<W> {
+    type Writer = W;
+
+    fn finish(mut self) -> Result<Self::Writer> {
+        self.0.flush()?;
+
+        Ok(match self.0.into_inner() {
+            Ok(w) => w,
+            Err(w) => w,
+        })
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}

--- a/rustls/src/certificate/compression/mod.rs
+++ b/rustls/src/certificate/compression/mod.rs
@@ -1,0 +1,69 @@
+//! Implementation of compression functions for TLS Certificate Compression
+
+use std::io::{Result, Write};
+
+pub(crate) mod brotli;
+pub(crate) mod zlib;
+pub(crate) mod zstd;
+
+use crate::certificate::compression::brotli::BrotliParams;
+use crate::certificate::compression::zlib::ZlibParams;
+use crate::certificate::compression::zstd::ZstdParams;
+
+/// A trait providing commonality between certificate compressors
+pub(crate) trait CertificateCompressor: Write {
+    type Writer: Write;
+
+    fn finish(self) -> Result<Self::Writer>;
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer>;
+}
+
+impl<C: CertificateCompressor + ?Sized> CertificateCompressor for Box<C> {
+    type Writer = C::Writer;
+
+    fn finish(self) -> Result<Self::Writer> {
+        self.into_inner()
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).into_inner()
+    }
+}
+
+/// A trait providing commonality between certificate de-compressors
+pub(crate) trait CertificateDecompressor: Write {
+    type Writer: Write;
+
+    fn finish(self) -> Result<Self::Writer>;
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer>;
+}
+
+impl<D: CertificateDecompressor + ?Sized> CertificateDecompressor for Box<D> {
+    type Writer = D::Writer;
+
+    fn finish(self) -> Result<Self::Writer> {
+        self.into_inner()
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).into_inner()
+    }
+}
+
+/// Configuration of compression algorithms
+#[derive(Debug, Clone, Default)]
+pub struct CertificateCompressionConfig {
+    /// Brotli parameters
+    pub brotli: BrotliParams,
+    /// Zlib parameters
+    pub zlib: ZlibParams,
+    /// Zstd parameters
+    pub zstd: ZstdParams,
+}
+
+impl CertificateCompressionConfig {
+    /// Create a new certificate compression configuration with defaults
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/rustls/src/certificate/compression/zlib.rs
+++ b/rustls/src/certificate/compression/zlib.rs
@@ -1,0 +1,89 @@
+//! Zlib compression functions
+
+use super::{CertificateCompressor, CertificateDecompressor};
+use crate::TLSError;
+use flate2::write::{ZlibDecoder, ZlibEncoder};
+use std::io::{Result, Write};
+
+/// Configuration parameters for Zlib
+#[derive(Debug, Clone, Default)]
+pub struct ZlibParams {
+    compression_level: flate2::Compression,
+}
+
+impl ZlibParams {
+    /// Create new ZlibParams given a compression level
+    ///
+    /// Value must be between 0-9, defaults to [flate2::Compression::default]
+    pub fn new(compression_level: u32) -> std::result::Result<Self, TLSError> {
+        if !(0..=9).contains(&compression_level) {
+            return Err(TLSError::General(
+                "compression level must be between 0 and 9".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            compression_level: flate2::Compression::new(compression_level),
+        })
+    }
+}
+
+pub(crate) struct ZlibCompress<W: Write>(ZlibEncoder<W>);
+
+impl<W: Write> ZlibCompress<W> {
+    pub fn new(writer: W, params: &ZlibParams) -> Self {
+        Self(ZlibEncoder::new(writer, params.compression_level))
+    }
+}
+
+impl<W: Write> Write for ZlibCompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateCompressor for ZlibCompress<W> {
+    type Writer = W;
+
+    fn finish(self) -> Result<Self::Writer> {
+        self.0.finish()
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}
+
+pub(crate) struct ZlibDecompress<W: Write>(ZlibDecoder<W>);
+
+impl<W: Write> ZlibDecompress<W> {
+    pub fn new(writer: W) -> Self {
+        Self(ZlibDecoder::new(writer))
+    }
+}
+
+impl<W: Write> Write for ZlibDecompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateDecompressor for ZlibDecompress<W> {
+    type Writer = W;
+
+    fn finish(self) -> Result<Self::Writer> {
+        self.0.finish()
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}

--- a/rustls/src/certificate/compression/zstd.rs
+++ b/rustls/src/certificate/compression/zstd.rs
@@ -1,0 +1,96 @@
+//! Zstd compression functions
+
+use super::{CertificateCompressor, CertificateDecompressor};
+use crate::TLSError;
+use std::io::{Result, Write};
+use zstd::stream::write::{Decoder, Encoder};
+
+/// Configuration parameters for Zstd
+#[derive(Debug, Clone)]
+pub struct ZstdParams {
+    compression_level: i32,
+}
+
+impl ZstdParams {
+    /// Create new ZstdParams given a compression level
+    ///
+    /// Value must be between 0-21.
+    /// A value of 0 defaults to [::zstd::DEFAULT_COMPRESSION_LEVEL]
+    pub fn new(compression_level: i32) -> std::result::Result<Self, TLSError> {
+        if !(0..=21).contains(&compression_level) {
+            return Err(TLSError::General(
+                "compression level must be between 0 and 9".to_string(),
+            ));
+        }
+
+        Ok(Self { compression_level })
+    }
+}
+
+impl Default for ZstdParams {
+    fn default() -> Self {
+        Self {
+            compression_level: ::zstd::DEFAULT_COMPRESSION_LEVEL,
+        }
+    }
+}
+
+pub(crate) struct ZstdCompress<W: Write>(Encoder<'static, W>);
+
+impl<W: Write> ZstdCompress<W> {
+    pub fn new(writer: W, params: &ZstdParams) -> Result<Self> {
+        Ok(Self(Encoder::new(writer, params.compression_level)?))
+    }
+}
+
+impl<W: Write> Write for ZstdCompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateCompressor for ZstdCompress<W> {
+    type Writer = W;
+
+    fn finish(self) -> Result<Self::Writer> {
+        self.0.finish()
+    }
+
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}
+
+pub(crate) struct ZstdDecompress<W: Write>(Decoder<'static, W>);
+
+impl<W: Write> ZstdDecompress<W> {
+    pub fn new(writer: W) -> Result<Self> {
+        Ok(Self(Decoder::new(writer)?))
+    }
+}
+
+impl<W: Write> Write for ZstdDecompress<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<W: Write> CertificateDecompressor for ZstdDecompress<W> {
+    type Writer = W;
+
+    fn finish(mut self) -> Result<Self::Writer> {
+        (&mut self).flush()?; // We need to flush here https://github.com/gyscos/zstd-rs/issues/80
+        Ok(self.0.into_inner())
+    }
+    fn into_inner(self: Box<Self>) -> Result<Self::Writer> {
+        (*self).finish()
+    }
+}

--- a/rustls/src/certificate/mod.rs
+++ b/rustls/src/certificate/mod.rs
@@ -1,0 +1,1 @@
+pub mod compression;

--- a/rustls/src/certificate/mod.rs
+++ b/rustls/src/certificate/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "certificate_compression")]
 pub mod compression;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,6 +1,7 @@
 use crate::hash_hs;
 #[cfg(feature = "logging")]
 use crate::log::trace;
+use crate::msgs::enums::CertificateCompressionAlgorithm;
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::CertificatePayload;
@@ -14,8 +15,6 @@ use crate::session::SessionRandoms;
 use crate::sign;
 use crate::suites;
 use webpki;
-
-use crate::msgs::enums::CertificateCompressionAlgorithm;
 
 use std::mem;
 

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -15,6 +15,8 @@ use crate::sign;
 use crate::suites;
 use webpki;
 
+use crate::msgs::enums::CertificateCompressionAlgorithm;
+
 use std::mem;
 
 pub struct ServerCertDetails {
@@ -61,6 +63,7 @@ pub struct HandshakeDetails {
     pub sent_tls13_fake_ccs: bool,
     pub dns_name: webpki::DNSName,
     pub extra_exts: Vec<ClientExtension>,
+    pub certificate_compression_algorithm: Option<CertificateCompressionAlgorithm>,
 }
 
 impl HandshakeDetails {
@@ -75,6 +78,7 @@ impl HandshakeDetails {
             sent_tls13_fake_ccs: false,
             dns_name: host_name,
             extra_exts,
+            certificate_compression_algorithm: None,
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -277,6 +277,17 @@ fn emit_client_hello_for_retry(
         exts.push(ClientExtension::PresharedKeyModes(psk_modes));
     }
 
+    if support_tls13 {
+        if let Some(cert_comp_algos) = &sess
+            .config
+            .certificate_compression_algorithms
+        {
+            exts.push(ClientExtension::CompressCertificate(
+                cert_comp_algos.clone(),
+            ))
+        }
+    }
+
     if !sess.config.alpn_protocols.is_empty() {
         exts.push(ClientExtension::Protocols(ProtocolNameList::from_slices(
             &sess

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -277,14 +277,17 @@ fn emit_client_hello_for_retry(
         exts.push(ClientExtension::PresharedKeyModes(psk_modes));
     }
 
-    if support_tls13 {
-        if let Some(cert_comp_algos) = &sess
-            .config
-            .certificate_compression_algorithms
-        {
-            exts.push(ClientExtension::CompressCertificate(
-                cert_comp_algos.clone(),
-            ))
+    #[cfg(feature = "certificate_compression")]
+    {
+        if support_tls13 {
+            if let Some(cert_comp_algos) = &sess
+                .config
+                .certificate_compression_algorithms
+            {
+                exts.push(ClientExtension::CompressCertificate(
+                    cert_comp_algos.clone(),
+                ))
+            }
         }
     }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -16,8 +16,11 @@ use crate::sign;
 use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use crate::verify;
 
-use crate::certificate::compression::CertificateCompressionConfig;
-use crate::msgs::enums::CertificateCompressionAlgorithm;
+#[cfg(feature = "certificate_compression")]
+use crate::{
+    certificate::compression::CertificateCompressionConfig,
+    msgs::enums::CertificateCompressionAlgorithm,
+};
 
 use std::fmt;
 use std::io::{self, IoSlice};
@@ -107,9 +110,11 @@ pub struct ClientConfig {
 
     /// Certificate compression algorithms.
     /// If None, certificate compression won't be enabled
+    #[cfg(feature = "certificate_compression")]
     pub certificate_compression_algorithms: Option<Vec<CertificateCompressionAlgorithm>>,
 
     /// Certificate compression configuration
+    #[cfg(feature = "certificate_compression")]
     pub certificate_compression_config: CertificateCompressionConfig,
 
     /// Whether to support RFC5077 tickets.  You must provide a working
@@ -177,7 +182,9 @@ impl ClientConfig {
             session_persistence: handy::ClientSessionMemoryCache::new(32),
             mtu: None,
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
+            #[cfg(feature = "certificate_compression")]
             certificate_compression_algorithms: None,
+            #[cfg(feature = "certificate_compression")]
             certificate_compression_config: CertificateCompressionConfig::default(),
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -16,6 +16,9 @@ use crate::sign;
 use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use crate::verify;
 
+use crate::certificate::compression::CertificateCompressionConfig;
+use crate::msgs::enums::CertificateCompressionAlgorithm;
+
 use std::fmt;
 use std::io::{self, IoSlice};
 use std::mem;
@@ -102,6 +105,13 @@ pub struct ClientConfig {
     /// How to decide what client auth certificate/keys to use.
     pub client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
 
+    /// Certificate compression algorithms.
+    /// If None, certificate compression won't be enabled
+    pub certificate_compression_algorithms: Option<Vec<CertificateCompressionAlgorithm>>,
+
+    /// Certificate compression configuration
+    pub certificate_compression_config: CertificateCompressionConfig,
+
     /// Whether to support RFC5077 tickets.  You must provide a working
     /// `session_persistence` member for this to have any meaningful
     /// effect.
@@ -167,6 +177,8 @@ impl ClientConfig {
             session_persistence: handy::ClientSessionMemoryCache::new(32),
             mtu: None,
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
+            certificate_compression_algorithms: None,
+            certificate_compression_config: CertificateCompressionConfig::default(),
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             ct_logs: None,

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -64,6 +64,12 @@ pub enum TLSError {
     /// We failed to figure out what time it currently is.
     FailedToGetCurrentTime,
 
+    /// We failed to perform certificate decompression
+    FailedCertificateDecompression,
+
+    /// We failed to perform certificate compression
+    FailedCertificateCompression,
+
     /// This function doesn't work until the TLS handshake
     /// is complete.
     HandshakeNotComplete,
@@ -119,6 +125,12 @@ impl fmt::Display for TLSError {
             TLSError::NoApplicationProtocol => write!(f, "peer doesn't support any known protocol"),
             TLSError::InvalidSCT(ref err) => write!(f, "invalid certificate timestamp: {:?}", err),
             TLSError::FailedToGetCurrentTime => write!(f, "failed to get current time"),
+            TLSError::FailedCertificateDecompression => {
+                write!(f, "failed to decompress certificate")
+            }
+            TLSError::FailedCertificateCompression => {
+                write!(f, "failed to compress certificate")
+            }
             TLSError::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
         }
     }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -190,6 +190,10 @@
 //!   details of these.  You will only need this if you're writing a QUIC
 //!   implementation.
 //!
+//! - `compressed_certificates`: this feature enables TLS certificate compression
+//!   (RFC8879). This can reduce the amount of data transmitted by compressing
+//!   certificates during the handshake.
+//!
 
 // Require docs for public APIs, deny unsafe code, etc.
 #![forbid(unsafe_code, unused_must_use, unstable_features)]
@@ -261,9 +265,6 @@ pub mod internal {
 
 // The public interface is:
 pub use crate::anchors::{DistinguishedNames, OwnedTrustAnchor, RootCertStore};
-pub use crate::certificate::compression::{
-    brotli::BrotliParams, zlib::ZlibParams, zstd::ZstdParams, CertificateCompressionConfig,
-};
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
@@ -271,7 +272,6 @@ pub use crate::client::{ClientConfig, ClientSession, WriteEarlyData};
 pub use crate::error::TLSError;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
-pub use crate::msgs::enums::CertificateCompressionAlgorithm;
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
@@ -286,6 +286,13 @@ pub use crate::suites::{BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES};
 pub use crate::ticketer::Ticketer;
 pub use crate::verify::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
+};
+#[cfg(feature = "certificate_compression")]
+pub use crate::{
+    certificate::compression::{
+        brotli::BrotliParams, zlib::ZlibParams, zstd::ZstdParams, CertificateCompressionConfig,
+    },
+    msgs::enums::CertificateCompressionAlgorithm,
 };
 
 /// All defined ciphersuites appear in this module.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -19,6 +19,7 @@
 //! * TLS1.2 resumption via tickets (RFC5077).
 //! * TLS1.3 resumption via tickets or session storage.
 //! * TLS1.3 0-RTT data for clients.
+//! * TLS1.3 certificate compression.
 //! * Client authentication by clients.
 //! * Client authentication by servers.
 //! * Extended master secret support (RFC7627).
@@ -241,6 +242,7 @@ mod x509;
 #[macro_use]
 mod check;
 mod bs_debug;
+mod certificate;
 mod client;
 mod key;
 mod keylog;
@@ -259,6 +261,9 @@ pub mod internal {
 
 // The public interface is:
 pub use crate::anchors::{DistinguishedNames, OwnedTrustAnchor, RootCertStore};
+pub use crate::certificate::compression::{
+    brotli::BrotliParams, zlib::ZlibParams, zstd::ZstdParams, CertificateCompressionConfig,
+};
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
@@ -266,6 +271,7 @@ pub use crate::client::{ClientConfig, ClientSession, WriteEarlyData};
 pub use crate::error::TLSError;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
+pub use crate::msgs::enums::CertificateCompressionAlgorithm;
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -122,6 +122,7 @@ enum_builder! {
         CertificateURL => 0x15,
         CertificateStatus => 0x16,
         KeyUpdate => 0x18,
+        CompressedCertificate => 0x19,
         MessageHash => 0xfe
     }
 }
@@ -221,6 +222,7 @@ enum_builder! {
         SCT => 0x0012,
         Padding => 0x0015,
         ExtendedMasterSecret => 0x0017,
+        CompressCertificate => 0x001b,
         SessionTicket => 0x0023,
         PreSharedKey => 0x0029,
         EarlyData => 0x002a,
@@ -788,5 +790,18 @@ enum_builder! {
     EnumName: CertificateStatusType;
     EnumVal{
         OCSP => 0x01
+    }
+}
+
+enum_builder! {
+    /// The `CertificateCompressionAlgorithm` TLS protocol enum.  Values in this enum are taken
+    /// from the various RFCs covering TLS, and are listed by IANA.
+    /// The `Unknown` item is used when processing unrecognised ordinals.
+    @U16
+    EnumName: CertificateCompressionAlgorithm;
+    EnumVal{
+        Zlib => 0x01,
+        Brotli => 0x02,
+        Zstd => 0x03
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,7 +1,8 @@
-use crate::key;
 use crate::msgs::base::{Payload, PayloadU8, PayloadU16, PayloadU24};
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
+use crate::msgs::enums::CertificateCompressionAlgorithm;
+use crate::msgs::enums::ContentType;
 use crate::msgs::enums::ECCurveType;
 use crate::msgs::enums::PSKKeyExchangeMode;
 use crate::msgs::enums::{CertificateStatusType, ClientCertificateType};
@@ -9,11 +10,20 @@ use crate::msgs::enums::{CipherSuite, Compression, ECPointFormat, ExtensionType}
 use crate::msgs::enums::{HandshakeType, ProtocolVersion};
 use crate::msgs::enums::{HashAlgorithm, ServerNameType, SignatureAlgorithm};
 use crate::msgs::enums::{KeyUpdateRequest, NamedGroup, SignatureScheme};
+use crate::{key, TLSError};
+
+use crate::certificate::compression::{
+    brotli::{BrotliCompress, BrotliDecompress},
+    zlib::{ZlibCompress, ZlibDecompress},
+    zstd::{ZstdCompress, ZstdDecompress},
+    CertificateCompressionConfig, CertificateCompressor, CertificateDecompressor,
+};
 
 #[cfg(feature = "logging")]
 use crate::log::warn;
 
 use std::collections;
+use std::convert::TryFrom;
 use std::fmt;
 use std::io::Write;
 use std::mem;
@@ -543,6 +553,10 @@ pub type SCTList = VecU16OfPayloadU16;
 declare_u8_vec!(PSKKeyExchangeModes, PSKKeyExchangeMode);
 declare_u16_vec!(KeyShareEntries, KeyShareEntry);
 declare_u8_vec!(ProtocolVersions, ProtocolVersion);
+declare_u8_vec!(
+    CertificateCompressionAlgorithms,
+    CertificateCompressionAlgorithm
+);
 
 #[derive(Clone, Debug)]
 pub enum ClientExtension {
@@ -563,6 +577,7 @@ pub enum ClientExtension {
     SignedCertificateTimestampRequest,
     TransportParameters(Vec<u8>),
     EarlyData,
+    CompressCertificate(CertificateCompressionAlgorithms),
     Unknown(UnknownExtension),
 }
 
@@ -587,6 +602,7 @@ impl ClientExtension {
             ClientExtension::SignedCertificateTimestampRequest => ExtensionType::SCT,
             ClientExtension::TransportParameters(_) => ExtensionType::TransportParameters,
             ClientExtension::EarlyData => ExtensionType::EarlyData,
+            ClientExtension::CompressCertificate(_) => ExtensionType::CompressCertificate,
             ClientExtension::Unknown(ref r) => r.typ,
         }
     }
@@ -615,6 +631,7 @@ impl Codec for ClientExtension {
             ClientExtension::Cookie(ref r) => r.encode(&mut sub),
             ClientExtension::CertificateStatusRequest(ref r) => r.encode(&mut sub),
             ClientExtension::TransportParameters(ref r) => sub.extend_from_slice(r),
+            ClientExtension::CompressCertificate(ref r) => r.encode(&mut sub),
             ClientExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 
@@ -670,6 +687,9 @@ impl Codec for ClientExtension {
                 let csr = CertificateStatusRequest::read(&mut sub)?;
                 ClientExtension::CertificateStatusRequest(csr)
             }
+            ExtensionType::CompressCertificate => ClientExtension::CompressCertificate(
+                CertificateCompressionAlgorithms::read(&mut sub)?,
+            ),
             ExtensionType::SCT if !sub.any_left() => {
                 ClientExtension::SignedCertificateTimestampRequest
             }
@@ -956,6 +976,14 @@ impl ClientHelloPayload {
         let ext = self.find_extension(ExtensionType::KeyShare)?;
         match *ext {
             ClientExtension::KeyShare(ref shares) => Some(shares),
+            _ => None,
+        }
+    }
+
+    pub fn get_compress_certificate_extension(&self) -> Option<&CertificateCompressionAlgorithms> {
+        let ext = self.find_extension(ExtensionType::CompressCertificate)?;
+        match *ext {
+            ClientExtension::CompressCertificate(ref algorithms) => Some(algorithms),
             _ => None,
         }
     }
@@ -1427,6 +1455,121 @@ impl CertificateEntry {
 }
 
 #[derive(Debug)]
+pub struct CompressedCertificatePayload {
+    pub algorithm: CertificateCompressionAlgorithm,
+    pub uncompressed_length: codec::u24,
+    pub compressed_certificate_message: PayloadU24,
+}
+
+impl Codec for CompressedCertificatePayload {
+    fn encode(&self, bytes: &mut Vec<u8>) {
+        self.algorithm.encode(bytes);
+        self.uncompressed_length.encode(bytes);
+        self.compressed_certificate_message
+            .encode(bytes);
+    }
+
+    fn read(r: &mut Reader) -> Option<CompressedCertificatePayload> {
+        Some(CompressedCertificatePayload {
+            algorithm: CertificateCompressionAlgorithm::read(r)?,
+            uncompressed_length: codec::u24::read(r)?,
+            compressed_certificate_message: PayloadU24::read(r)?,
+        })
+    }
+}
+
+impl CompressedCertificatePayload {
+    pub fn compress_with(
+        certificate: CertificatePayloadTLS13,
+        algorithm: CertificateCompressionAlgorithm,
+        config: &CertificateCompressionConfig,
+    ) -> Result<Self, TLSError> {
+        let mut input = Vec::new();
+        certificate.encode(&mut input);
+
+        let input_len = input.len();
+
+        let mut compressor: Box<dyn CertificateCompressor<Writer = Vec<u8>>> = match algorithm {
+            CertificateCompressionAlgorithm::Zlib => {
+                Box::new(ZlibCompress::new(Vec::new(), &config.zlib))
+            }
+            CertificateCompressionAlgorithm::Brotli => {
+                Box::new(BrotliCompress::new(Vec::new(), &config.brotli))
+            }
+            CertificateCompressionAlgorithm::Zstd => Box::new(
+                ZstdCompress::new(Vec::new(), &config.zstd)
+                    .map_err(|_e| TLSError::FailedCertificateCompression)?,
+            ),
+            CertificateCompressionAlgorithm::Unknown(_) => {
+                return Err(TLSError::FailedCertificateCompression);
+            }
+        };
+
+        compressor
+            .write_all(&input)
+            .map_err(|_e| TLSError::FailedCertificateCompression)?;
+
+        let output = compressor
+            .finish()
+            .map_err(|_e| TLSError::FailedCertificateCompression)?;
+
+        Ok(CompressedCertificatePayload {
+            algorithm,
+            uncompressed_length: codec::u24(input_len as u32),
+            compressed_certificate_message: PayloadU24::new(output),
+        })
+    }
+
+    pub fn decompress(
+        &self,
+        config: &CertificateCompressionConfig,
+    ) -> Result<Option<CertificatePayloadTLS13>, TLSError> {
+        let input = &self.compressed_certificate_message.0;
+
+        let uncompressed_length = usize::try_from(self.uncompressed_length.0).map_err(|_e| {
+            TLSError::General(format!(
+                "Failed to convert uncompressed_lenth {} to usize",
+                self.uncompressed_length.0
+            ))
+        })?;
+
+        let mut decompressor: Box<dyn CertificateDecompressor<Writer = Vec<u8>>> = {
+            let buf = Vec::with_capacity(uncompressed_length);
+            match self.algorithm {
+                CertificateCompressionAlgorithm::Zlib => Box::new(ZlibDecompress::new(buf)),
+                CertificateCompressionAlgorithm::Brotli => {
+                    Box::new(BrotliDecompress::new(buf, &config.brotli))
+                }
+                CertificateCompressionAlgorithm::Zstd => Box::new(
+                    ZstdDecompress::new(buf)
+                        .map_err(|_e| TLSError::FailedCertificateDecompression)?,
+                ),
+                CertificateCompressionAlgorithm::Unknown(_) => {
+                    return Ok(None);
+                }
+            }
+        };
+
+        decompressor
+            .write_all(&input)
+            .map_err(|_e| TLSError::FailedCertificateDecompression)?;
+
+        let output = decompressor
+            .finish()
+            .map_err(|_e| TLSError::FailedCertificateDecompression)?;
+
+        if output.len() != uncompressed_length {
+            return Err(TLSError::CorruptMessagePayload(ContentType::Handshake));
+        }
+
+        match CertificatePayloadTLS13::read_bytes(&output) {
+            Some(v) => Ok(Some(v)),
+            None => Err(TLSError::CorruptMessagePayload(ContentType::Handshake)),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct CertificatePayloadTLS13 {
     pub context: PayloadU8,
     pub entries: Vec<CertificateEntry>,
@@ -1452,6 +1595,14 @@ impl CertificatePayloadTLS13 {
             context: PayloadU8::empty(),
             entries,
         }
+    }
+
+    pub fn compress_with(
+        self,
+        algorithm: CertificateCompressionAlgorithm,
+        config: &CertificateCompressionConfig,
+    ) -> Result<CompressedCertificatePayload, TLSError> {
+        CompressedCertificatePayload::compress_with(self, algorithm, config)
     }
 
     pub fn any_entry_has_duplicate_extension(&self) -> bool {
@@ -2093,6 +2244,7 @@ pub enum HandshakePayload {
     HelloRetryRequest(HelloRetryRequest),
     Certificate(CertificatePayload),
     CertificateTLS13(CertificatePayloadTLS13),
+    CompressedCertificate(CompressedCertificatePayload),
     ServerKeyExchange(ServerKeyExchangePayload),
     CertificateRequest(CertificateRequestPayload),
     CertificateRequestTLS13(CertificateRequestPayloadTLS13),
@@ -2123,6 +2275,7 @@ impl HandshakePayload {
             HandshakePayload::HelloRetryRequest(ref x) => x.encode(bytes),
             HandshakePayload::Certificate(ref x) => x.encode(bytes),
             HandshakePayload::CertificateTLS13(ref x) => x.encode(bytes),
+            HandshakePayload::CompressedCertificate(ref x) => x.encode(bytes),
             HandshakePayload::ServerKeyExchange(ref x) => x.encode(bytes),
             HandshakePayload::ClientKeyExchange(ref x) => x.encode(bytes),
             HandshakePayload::CertificateRequest(ref x) => x.encode(bytes),
@@ -2203,6 +2356,10 @@ impl HandshakeMessagePayload {
             HandshakeType::Certificate if vers == ProtocolVersion::TLSv1_3 => {
                 let p = CertificatePayloadTLS13::read(&mut sub)?;
                 HandshakePayload::CertificateTLS13(p)
+            }
+            HandshakeType::CompressedCertificate if vers == ProtocolVersion::TLSv1_3 => {
+                let p = CompressedCertificatePayload::read(&mut sub)?;
+                HandshakePayload::CompressedCertificate(p)
             }
             HandshakeType::Certificate => {
                 HandshakePayload::Certificate(CertificatePayload::read(&mut sub)?)

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1,8 +1,8 @@
+use crate::key;
 use crate::msgs::base::{Payload, PayloadU8, PayloadU16, PayloadU24};
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::CertificateCompressionAlgorithm;
-use crate::msgs::enums::ContentType;
 use crate::msgs::enums::ECCurveType;
 use crate::msgs::enums::PSKKeyExchangeMode;
 use crate::msgs::enums::{CertificateStatusType, ClientCertificateType};
@@ -10,20 +10,26 @@ use crate::msgs::enums::{CipherSuite, Compression, ECPointFormat, ExtensionType}
 use crate::msgs::enums::{HandshakeType, ProtocolVersion};
 use crate::msgs::enums::{HashAlgorithm, ServerNameType, SignatureAlgorithm};
 use crate::msgs::enums::{KeyUpdateRequest, NamedGroup, SignatureScheme};
-use crate::{key, TLSError};
 
-use crate::certificate::compression::{
-    brotli::{BrotliCompress, BrotliDecompress},
-    zlib::{ZlibCompress, ZlibDecompress},
-    zstd::{ZstdCompress, ZstdDecompress},
-    CertificateCompressionConfig, CertificateCompressor, CertificateDecompressor,
+#[cfg(feature = "certificate_compression")]
+use {
+    crate::{
+        certificate::compression::{
+            brotli::{BrotliCompress, BrotliDecompress},
+            zlib::{ZlibCompress, ZlibDecompress},
+            zstd::{ZstdCompress, ZstdDecompress},
+            CertificateCompressionConfig, CertificateCompressor, CertificateDecompressor,
+        },
+        msgs::enums::ContentType,
+        TLSError,
+    },
+    std::convert::TryFrom,
 };
 
 #[cfg(feature = "logging")]
 use crate::log::warn;
 
 use std::collections;
-use std::convert::TryFrom;
 use std::fmt;
 use std::io::Write;
 use std::mem;
@@ -1479,6 +1485,7 @@ impl Codec for CompressedCertificatePayload {
 }
 
 impl CompressedCertificatePayload {
+    #[cfg(feature = "certificate_compression")]
     pub fn compress_with(
         certificate: CertificatePayloadTLS13,
         algorithm: CertificateCompressionAlgorithm,
@@ -1520,6 +1527,7 @@ impl CompressedCertificatePayload {
         })
     }
 
+    #[cfg(feature = "certificate_compression")]
     pub fn decompress(
         &self,
         config: &CertificateCompressionConfig,
@@ -1597,6 +1605,7 @@ impl CertificatePayloadTLS13 {
         }
     }
 
+    #[cfg(feature = "certificate_compression")]
     pub fn compress_with(
         self,
         algorithm: CertificateCompressionAlgorithm,

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -3,7 +3,6 @@ use crate::key;
 use crate::keylog::{KeyLog, NoKeyLog};
 #[cfg(feature = "logging")]
 use crate::log::trace;
-use crate::msgs::enums::CertificateCompressionAlgorithm;
 use crate::msgs::enums::ContentType;
 use crate::msgs::enums::SignatureScheme;
 use crate::msgs::enums::{AlertDescription, HandshakeType, ProtocolVersion};
@@ -14,7 +13,11 @@ use crate::sign;
 use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use crate::verify;
 
-use crate::certificate::compression::CertificateCompressionConfig;
+#[cfg(feature = "certificate_compression")]
+use crate::{
+    certificate::compression::CertificateCompressionConfig,
+    msgs::enums::CertificateCompressionAlgorithm,
+};
 
 use webpki;
 
@@ -176,9 +179,11 @@ pub struct ServerConfig {
 
     /// Certificate compression algorithms.
     /// If None, certificate compression won't be enabled
+    #[cfg(feature = "certificate_compression")]
     pub certificate_compression_algorithms: Option<Vec<CertificateCompressionAlgorithm>>,
 
     /// Certificate compression configuration
+    #[cfg(feature = "certificate_compression")]
     pub certificate_compression_config: CertificateCompressionConfig,
 
     /// Protocol names we support, most preferred first.
@@ -245,7 +250,9 @@ impl ServerConfig {
             ticketer: Arc::new(handy::NeverProducesTickets {}),
             alpn_protocols: Vec::new(),
             cert_resolver: Arc::new(handy::FailResolveChain {}),
+            #[cfg(feature = "certificate_compression")]
             certificate_compression_algorithms: None,
+            #[cfg(feature = "certificate_compression")]
             certificate_compression_config: CertificateCompressionConfig::default(),
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             verifier: client_cert_verifier,

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -3,6 +3,7 @@ use crate::key;
 use crate::keylog::{KeyLog, NoKeyLog};
 #[cfg(feature = "logging")]
 use crate::log::trace;
+use crate::msgs::enums::CertificateCompressionAlgorithm;
 use crate::msgs::enums::ContentType;
 use crate::msgs::enums::SignatureScheme;
 use crate::msgs::enums::{AlertDescription, HandshakeType, ProtocolVersion};
@@ -12,6 +13,8 @@ use crate::session::{MiddleboxCCS, Session, SessionCommon};
 use crate::sign;
 use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
 use crate::verify;
+
+use crate::certificate::compression::CertificateCompressionConfig;
 
 use webpki;
 
@@ -171,6 +174,13 @@ pub struct ServerConfig {
     /// How to choose a server cert and key.
     pub cert_resolver: Arc<dyn ResolvesServerCert>,
 
+    /// Certificate compression algorithms.
+    /// If None, certificate compression won't be enabled
+    pub certificate_compression_algorithms: Option<Vec<CertificateCompressionAlgorithm>>,
+
+    /// Certificate compression configuration
+    pub certificate_compression_config: CertificateCompressionConfig,
+
     /// Protocol names we support, most preferred first.
     /// If empty we don't do ALPN at all.
     pub alpn_protocols: Vec<Vec<u8>>,
@@ -235,6 +245,8 @@ impl ServerConfig {
             ticketer: Arc::new(handy::NeverProducesTickets {}),
             alpn_protocols: Vec::new(),
             cert_resolver: Arc::new(handy::FailResolveChain {}),
+            certificate_compression_algorithms: None,
+            certificate_compression_config: CertificateCompressionConfig::default(),
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             verifier: client_cert_verifier,
             key_log: Arc::new(NoKeyLog {}),


### PR DESCRIPTION
Hello RustTLS maintainers! Thanks for the awesome library. It has been a pleasure to develop with.

This PR implements [RFC8879](https://tools.ietf.org/html/rfc8879)

Issue: https://github.com/ctz/rustls/issues/436

## Questions
- `certificate_compression` feature, should this be changed into separate features for each algorithm? Users may only want to support a number of algorithms without the added dependencies.
- I'd like to include arguments in tlsclient/tlsserver examples, with the current DocOpt impl, this would be hacky to integrate. Any appetite to using [structopt](https://github.com/TeXitoi/structopt) instead? If so, I can create a PR for this.
- Any guidance in regards to testing would be appreciated. I'm not sure what the best strategy is. Smoke tests in `tests/api.rs` is possible, although is there any way to assert on plaintext messages vs encrypted opaque blobs?

## TODO
- Minimum version errors in CI, they don't seem to indicate exactly what's wrong, but it seems to be related to zstd. I can't seem to reproduce this locally... most likely ubuntu package differences...

<details>
  <summary>How to test w/ tlsclient/tlsserver</summary>
  
Modify Client/Server configs

For example,
```rust
    config.certificate_compression_algorithms =
        Some(vec![rustls::CertificateCompressionAlgorithm::Brotli]);
```

Generate certs w/ `subjectAltName` (this seems to be required in rustls?)

`cd rustls/rustls-mio`

```
openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -out localhost.cert -keyout localhost.key -subj '/CN=localhost' -config openssl.cfg
```

```
# openssl.cfg
[req]
distinguished_name=dn
x509_extensions=ext
[ dn ]
CN=localhost
[ ext ]
subjectAltName = @alt_names
[alt_names]
DNS.1 = localhost
IP.1 = 127.0.0.1
IP.2 = ::1
```

Server
```
RUST_LOG=trace SSLKEYLOGFILE=$HOME/keylog cargo run --example tlsserver -- --certs ./localhost.cert --key ./localhost.key --port 8083 --verbose http
```

Client
```
RUST_LOG=trace cargo run --example tlsclient -- --cafile ./localhost.cert -p 8083 --verbose --http localhost
```

- Open wireshark
- Observe ClientHello, see new certificate_compression extension (plain text), with 1 compression option (brotli, as configured in tlsclient.rs)
- Observe ServerHello (this will be encrypted)
- Right click on ServerHello -> Protocol Preferences -> (Pre)-Master Secret Log Filename -> Click Browse under "(Pre)-Master Secret Log Filename", select `~/keylog`
- Observe decrypted ServerHello and `CompressedCertificate` extention (brotli)
</details>