### PR TITLE
Reduce `unwrap()`ing in `HandshakeHash`.

### DIFF
--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -107,12 +107,15 @@ impl HandshakeHash {
     /// Get the hash value if we were to hash `extra` too,
     /// using hash function `hash`.
     pub fn get_hash_given(&self, hash: &'static digest::Algorithm, extra: &[u8]) -> Vec<u8> {
-        let mut ctx = if self.ctx.is_none() {
-            let mut ctx = digest::Context::new(hash);
-            ctx.update(&self.buffer);
-            ctx
-        } else {
-            self.ctx.as_ref().unwrap().clone()
+        let mut ctx = match &self.ctx {
+            None => {
+                let mut ctx = digest::Context::new(hash);
+                ctx.update(&self.buffer);
+                ctx
+            },
+            Some(ctx) => {
+                ctx.clone()
+            }
         };
 
         ctx.update(extra);


### PR DESCRIPTION
Replace an instance of the `is_none()`+`unwrap()` pattern. Eliminate the redundant `alg` field; the value of `alg` was always the same as `ctx.algorithm()`.