### PR TITLE
Cache current time at start of handshake.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -16,6 +16,7 @@ use crate::suites;
 use webpki;
 
 use std::mem;
+use std::time::SystemTime;
 
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
@@ -61,6 +62,17 @@ pub struct HandshakeDetails {
     pub sent_tls13_fake_ccs: bool,
     pub dns_name: webpki::DNSName,
     pub extra_exts: Vec<ClientExtension>,
+
+    /// This time is used as the "current time", i.e. "now", for (TODO: almost)
+    /// all operations that need the current time. If the handshake were to be
+    /// stretched out over a long period of time (as an attacker might try to
+    /// do) then there could be an arbitrarily large difference between this
+    /// time and the current time later in the handshake. In theory a
+    /// certificate could get revoked during that window, or similar, which
+    /// could be a material difference. However, on some operating systems it
+    /// is inefficient to query the system time so doing it as little as
+    /// practical is generally good.
+    pub(super) start_time: SystemTime,
 }
 
 impl HandshakeDetails {
@@ -75,6 +87,7 @@ impl HandshakeDetails {
             sent_tls13_fake_ccs: false,
             dns_name: host_name,
             extra_exts,
+            start_time: SystemTime::now()
         }
     }
 }

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -8,6 +8,7 @@ use webpki;
 
 use std::cmp;
 use std::mem;
+use std::time::{SystemTime, UNIX_EPOCH, Duration};
 
 // These are the keys and values we store in session storage.
 
@@ -145,8 +146,14 @@ impl ClientSessionValue {
         self.age_add = age_add;
     }
 
-    pub fn has_expired(&self, time_now: u64) -> bool {
-        self.lifetime != 0 && self.epoch + u64::from(self.lifetime) < time_now
+    pub fn has_expired(&self, now: SystemTime) -> bool {
+        if self.lifetime == 0 {
+            false
+        } else if let Ok(time_now) = now.duration_since(UNIX_EPOCH).as_ref().map(Duration::as_secs) {
+            self.epoch + u64::from(self.lifetime) < time_now
+        } else {
+            true
+        }
     }
 
     pub fn get_obfuscated_ticket_age(&self, time_now: u64) -> u32 {

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -5,6 +5,7 @@ use crate::session::SessionRandoms;
 use crate::suites;
 
 use std::mem;
+use std::time::SystemTime;
 
 pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
@@ -13,6 +14,9 @@ pub struct HandshakeDetails {
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub extra_exts: Vec<ServerExtension>,
+
+    /// See the detailed description in `client::common::HandshakeDetails`.
+    pub(super) start_time: SystemTime,
 }
 
 impl HandshakeDetails {
@@ -24,6 +28,7 @@ impl HandshakeDetails {
             randoms: SessionRandoms::for_server(),
             using_ems: false,
             extra_exts,
+            start_time: SystemTime::now()
         }
     }
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -78,7 +78,7 @@ impl hs::State for ExpectCertificate {
 
         trace!("certs {:?}", cert_chain);
 
-        let now = std::time::SystemTime::now();
+        let now = self.handshake.start_time;
         sess.config
             .verifier
             .verify_client_cert(cert_chain, sess.get_sni(), now)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -785,7 +785,7 @@ impl hs::State for ExpectCertificate {
             return Err(TLSError::NoCertificatesPresented);
         }
 
-        let now = std::time::SystemTime::now();
+        let now = self.handshake.start_time;
         sess.config
             .get_verifier()
             .verify_client_cert(&cert_chain, sess.get_sni(), now)


### PR DESCRIPTION
Cache the current time at the start of the handshake and use that time
in various places in the handshake. A couple other uses of
`SystemTime::now()` remain; I hope to eliminate them in a future commit
after some other refactoring is done.