### PR TITLE
Avoid allocating a `Vec` for each digest created during the handshake.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -16,6 +16,7 @@ use crate::suites;
 use webpki;
 
 use std::mem;
+use ring::digest;
 
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
@@ -54,7 +55,7 @@ impl ServerKXDetails {
 pub struct HandshakeDetails {
     pub resuming_session: Option<persist::ClientSessionValue>,
     pub transcript: hash_hs::HandshakeHash,
-    pub hash_at_client_recvd_server_hello: Vec<u8>,
+    pub hash_at_client_recvd_server_hello: Option<digest::Digest>,
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub session_id: SessionID,
@@ -68,7 +69,7 @@ impl HandshakeDetails {
         HandshakeDetails {
             resuming_session: None,
             transcript: hash_hs::HandshakeHash::new(),
-            hash_at_client_recvd_server_hello: Vec::new(),
+            hash_at_client_recvd_server_hello: None,
             randoms: SessionRandoms::for_client(),
             using_ems: false,
             session_id: SessionID::empty(),

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -247,12 +247,13 @@ pub fn start_handshake_traffic(
     // the two halves will have different record layer protections.  Disallow this.
     hs::check_aligned_handshake(sess)?;
 
-    handshake.hash_at_client_recvd_server_hello = handshake.transcript.get_current_hash();
+    let hash_at_client_recvd_server_hello = handshake.transcript.get_current_hash();
+    handshake.hash_at_client_recvd_server_hello = Some(hash_at_client_recvd_server_hello);
 
     let _maybe_write_key = if !sess.early_data.is_enabled() {
         // Set the client encryption key for handshakes if early data is not used
         let write_key = key_schedule.client_handshake_traffic_secret(
-            &handshake.hash_at_client_recvd_server_hello,
+            &hash_at_client_recvd_server_hello,
             &*sess.config.key_log,
             &handshake.randoms.client,
         );
@@ -265,7 +266,7 @@ pub fn start_handshake_traffic(
     };
 
     let read_key = key_schedule.server_handshake_traffic_secret(
-        &handshake.hash_at_client_recvd_server_hello,
+        &hash_at_client_recvd_server_hello,
         &*sess.config.key_log,
         &handshake.randoms.client,
     );
@@ -278,7 +279,7 @@ pub fn start_handshake_traffic(
         let write_key = if sess.early_data.is_enabled() {
             // Traffic secret wasn't computed and stored above, so do it here.
             key_schedule.client_handshake_traffic_secret(
-                &handshake.hash_at_client_recvd_server_hello,
+                &hash_at_client_recvd_server_hello,
                 &*sess.config.key_log,
                 &handshake.randoms.client,
             )
@@ -479,9 +480,11 @@ impl hs::State for ExpectEncryptedExtensions {
                 let write_key = self
                     .key_schedule
                     .client_handshake_traffic_secret(
-                        &self
+                        self
                             .handshake
-                            .hash_at_client_recvd_server_hello,
+                            .hash_at_client_recvd_server_hello
+                            .as_ref()
+                            .unwrap(),
                         &*sess.config.key_log,
                         &self.handshake.randoms.client,
                     );
@@ -989,8 +992,8 @@ impl hs::State for ExpectFinished {
             let key = st
                 .key_schedule
                 .client_handshake_traffic_secret(
-                    &st.handshake
-                        .hash_at_client_recvd_server_hello,
+                    st.handshake
+                        .hash_at_client_recvd_server_hello.as_ref().unwrap(),
                     &*sess.config.key_log,
                     &st.handshake.randoms.client,
                 );

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -106,7 +106,7 @@ impl HandshakeHash {
 
     /// Get the hash value if we were to hash `extra` too,
     /// using hash function `hash`.
-    pub fn get_hash_given(&self, hash: &'static digest::Algorithm, extra: &[u8]) -> Vec<u8> {
+    pub fn get_hash_given(&self, hash: &'static digest::Algorithm, extra: &[u8]) -> digest::Digest {
         let mut ctx = if self.ctx.is_none() {
             let mut ctx = digest::Context::new(hash);
             ctx.update(&self.buffer);
@@ -116,10 +116,7 @@ impl HandshakeHash {
         };
 
         ctx.update(extra);
-        let hash = ctx.finish();
-        let mut ret = Vec::new();
-        ret.extend_from_slice(hash.as_ref());
-        ret
+        ctx.finish()
     }
 
     /// Take the current hash value, and encapsulate it in a
@@ -135,16 +132,13 @@ impl HandshakeHash {
     }
 
     /// Get the current hash value.
-    pub fn get_current_hash(&self) -> Vec<u8> {
-        let hash = self
+    pub fn get_current_hash(&self) -> digest::Digest {
+        self
             .ctx
             .as_ref()
             .unwrap()
             .clone()
-            .finish();
-        let mut ret = Vec::new();
-        ret.extend_from_slice(hash.as_ref());
-        ret
+            .finish()
     }
 
     /// Takes this object's buffer containing all handshake messages
@@ -170,6 +164,7 @@ mod test {
         assert_eq!(hh.buffer.len(), 0);
         hh.update_raw(b"world");
         let h = hh.get_current_hash();
+        let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);
         assert_eq!(h[2], 0x18);
@@ -187,6 +182,7 @@ mod test {
         hh.update_raw(b"world");
         assert_eq!(hh.buffer.len(), 10);
         let h = hh.get_current_hash();
+        let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);
         assert_eq!(h[2], 0x18);
@@ -208,6 +204,7 @@ mod test {
         hh.update_raw(b"world");
         assert_eq!(hh.buffer.len(), 0);
         let h = hh.get_current_hash();
+        let h = h.as_ref();
         assert_eq!(h[0], 0x93);
         assert_eq!(h[1], 0x6a);
         assert_eq!(h[2], 0x18);

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -5,10 +5,11 @@ use crate::session::SessionRandoms;
 use crate::suites;
 
 use std::mem;
+use ring::digest;
 
 pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
-    pub hash_at_server_fin: Vec<u8>,
+    pub hash_at_server_fin: Option<digest::Digest>,
     pub session_id: SessionID,
     pub randoms: SessionRandoms,
     pub using_ems: bool,
@@ -19,7 +20,7 @@ impl HandshakeDetails {
     pub fn new(extra_exts: Vec<ServerExtension>) -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
-            hash_at_server_fin: Vec::new(),
+            hash_at_server_fin: None,
             session_id: SessionID::empty(),
             randoms: SessionRandoms::for_server(),
             using_ems: false,

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -13,6 +13,7 @@ use crate::log::{debug, trace, warn};
 use crate::msgs::enums::SignatureScheme;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::SCTList;
+use ring::digest::Digest;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
 
@@ -565,20 +566,20 @@ fn convert_alg_tls13(
 }
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
-pub fn construct_tls13_client_verify_message(handshake_hash: &[u8]) -> Vec<u8> {
+pub fn construct_tls13_client_verify_message(handshake_hash: &Digest) -> Vec<u8> {
     construct_tls13_verify_message(handshake_hash, b"TLS 1.3, client CertificateVerify\x00")
 }
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
-pub fn construct_tls13_server_verify_message(handshake_hash: &[u8]) -> Vec<u8> {
+pub fn construct_tls13_server_verify_message(handshake_hash: &Digest) -> Vec<u8> {
     construct_tls13_verify_message(handshake_hash, b"TLS 1.3, server CertificateVerify\x00")
 }
 
-fn construct_tls13_verify_message(handshake_hash: &[u8], context_string_with_0: &[u8]) -> Vec<u8> {
+fn construct_tls13_verify_message(handshake_hash: &Digest, context_string_with_0: &[u8]) -> Vec<u8> {
     let mut msg = Vec::new();
     msg.resize(64, 0x20u8);
     msg.extend_from_slice(context_string_with_0);
-    msg.extend_from_slice(handshake_hash);
+    msg.extend_from_slice(handshake_hash.as_ref());
     msg
 }
 


### PR DESCRIPTION
Avoid heap allocation at every time where a digest is computed; that
happens frequently in the TLS 1.3 handshake. Use a stronger type to
hold the digest where practical.