### PR TITLE
Reduce the number of times we allocate a `Vec<u8>` to hold an HMAC tag.

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -166,7 +166,7 @@ pub fn fill_in_psk_binder(
     let real_binder = key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
 
     if let HandshakePayload::ClientHello(ref mut ch) = hmp.payload {
-        ch.set_psk_binder(real_binder);
+        ch.set_psk_binder(real_binder.as_ref());
     };
 
     key_schedule
@@ -901,7 +901,7 @@ fn emit_finished_tls13(
 ) {
     let handshake_hash = handshake.transcript.get_current_hash();
     let verify_data = key_schedule.sign_client_finish(&handshake_hash);
-    let verify_data_payload = Payload::new(verify_data);
+    let verify_data_payload = Payload::new(verify_data.as_ref());
 
     let m = Message {
         typ: ContentType::Handshake,
@@ -975,7 +975,7 @@ impl hs::State for ExpectFinished {
             .key_schedule
             .sign_server_finish(&handshake_hash);
 
-        let fin = constant_time::verify_slices_are_equal(&expect_verify_data, &finished.0)
+        let fin = constant_time::verify_slices_are_equal(expect_verify_data.as_ref(), &finished.0)
             .map_err(|_| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecryptError);

--- a/rustls/src/key_schedule.rs
+++ b/rustls/src/key_schedule.rs
@@ -94,7 +94,7 @@ impl KeyScheduleEarly {
         )
     }
 
-    pub fn resumption_psk_binder_key_and_sign_verify_data(&self, hs_hash: &[u8]) -> Vec<u8> {
+    pub fn resumption_psk_binder_key_and_sign_verify_data(&self, hs_hash: &[u8]) -> hmac::Tag {
         let resumption_psk_binder_key = self
             .ks
             .derive_for_empty_hash(SecretKind::ResumptionPSKBinderKey);
@@ -175,7 +175,7 @@ impl KeyScheduleHandshake {
         secret
     }
 
-    pub fn sign_server_finish(&self, hs_hash: &[u8]) -> Vec<u8> {
+    pub fn sign_server_finish(&self, hs_hash: &[u8]) -> hmac::Tag {
         self.ks.sign_finish(
             self.current_server_traffic_secret
                 .as_ref()
@@ -211,7 +211,7 @@ pub struct KeyScheduleTrafficWithClientFinishedPending {
 }
 
 impl KeyScheduleTrafficWithClientFinishedPending {
-    pub fn sign_client_finish(&self, hs_hash: &[u8]) -> Vec<u8> {
+    pub fn sign_client_finish(&self, hs_hash: &[u8]) -> hmac::Tag {
         self.ks
             .sign_finish(&self.handshake_client_traffic_secret, hs_hash)
     }
@@ -407,18 +407,16 @@ impl KeySchedule {
 
     /// Sign the finished message consisting of `hs_hash` using a current
     /// traffic secret.
-    fn sign_finish(&self, base_key: &hkdf::Prk, hs_hash: &[u8]) -> Vec<u8> {
+    fn sign_finish(&self, base_key: &hkdf::Prk, hs_hash: &[u8]) -> hmac::Tag {
         self.sign_verify_data(base_key, hs_hash)
     }
 
     /// Sign the finished message consisting of `hs_hash` using the key material
     /// `base_key`.
-    fn sign_verify_data(&self, base_key: &hkdf::Prk, hs_hash: &[u8]) -> Vec<u8> {
+    fn sign_verify_data(&self, base_key: &hkdf::Prk, hs_hash: &[u8]) -> hmac::Tag {
         let hmac_alg = self.algorithm.hmac_algorithm();
         let hmac_key = hkdf_expand(base_key, hmac_alg, b"finished", &[]);
         hmac::sign(&hmac_key, hs_hash)
-            .as_ref()
-            .to_vec()
     }
 
     /// Derive the next application traffic secret, returning it.

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -16,8 +16,8 @@ impl Codec for Payload {
 }
 
 impl Payload {
-    pub fn new(bytes: Vec<u8>) -> Payload {
-        Payload(bytes)
+    pub fn new(bytes: impl Into<Vec<u8>>) -> Payload {
+        Payload(bytes.into())
     }
 
     pub fn empty() -> Payload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1011,10 +1011,10 @@ impl ClientHelloPayload {
     }
 
 
-    pub fn set_psk_binder(&mut self, binder: Vec<u8>) {
+    pub fn set_psk_binder(&mut self, binder: impl Into<Vec<u8>>) {
         let last_extension = self.extensions.last_mut().unwrap();
         if let ClientExtension::PresharedKey(ref mut offer) = *last_extension {
-            offer.binders[0] = PresharedKeyBinder::new(binder);
+            offer.binders[0] = PresharedKeyBinder::new(binder.into());
         }
     }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -79,7 +79,7 @@ impl CompleteClientHelloHandling {
         let real_binder =
             key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
 
-        constant_time::verify_slices_are_equal(&real_binder, binder).is_ok()
+        constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
     }
 
     fn into_expect_retried_client_hello(self) -> hs::NextState {
@@ -463,7 +463,7 @@ impl CompleteClientHelloHandling {
             .transcript
             .get_current_hash();
         let verify_data = key_schedule.sign_server_finish(&handshake_hash);
-        let verify_data_payload = Payload::new(verify_data);
+        let verify_data_payload = Payload::new(verify_data.as_ref());
 
         let m = Message {
             typ: ContentType::Handshake,
@@ -1009,7 +1009,7 @@ impl hs::State for ExpectFinished {
             .key_schedule
             .sign_client_finish(&handshake_hash);
 
-        let fin = constant_time::verify_slices_are_equal(&expect_verify_data, &finished.0)
+        let fin = constant_time::verify_slices_are_equal(expect_verify_data.as_ref(), &finished.0)
             .map_err(|_| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecryptError);


### PR DESCRIPTION
The serialization framework currently stores bytes in `Vec` so not all
of the allocations could be eliminated, but the ones that can were.