### PR TITLE
Take `extra_exts` out of `HandshakeDetails`.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -4,7 +4,6 @@ use crate::log::trace;
 use crate::msgs::enums::ExtensionType;
 use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::CertificatePayload;
-use crate::msgs::handshake::ClientExtension;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::SCTList;
 use crate::msgs::handshake::ServerExtension;
@@ -60,11 +59,10 @@ pub struct HandshakeDetails {
     pub session_id: SessionID,
     pub sent_tls13_fake_ccs: bool,
     pub dns_name: webpki::DNSName,
-    pub extra_exts: Vec<ClientExtension>,
 }
 
 impl HandshakeDetails {
-    pub fn new(host_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> HandshakeDetails {
+    pub fn new(host_name: webpki::DNSName) -> HandshakeDetails {
         HandshakeDetails {
             resuming_session: None,
             transcript: hash_hs::HandshakeHash::new(),
@@ -74,7 +72,6 @@ impl HandshakeDetails {
             session_id: SessionID::empty(),
             sent_tls13_fake_ccs: false,
             dns_name: host_name,
-            extra_exts,
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -126,12 +126,14 @@ fn random_sessionid_for_ticket(csv: &mut persist::ClientSessionValue) {
 
 struct InitialState {
     handshake: HandshakeDetails,
+    extra_exts: Vec<ClientExtension>,
 }
 
 impl InitialState {
     fn new(host_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> InitialState {
         InitialState {
-            handshake: HandshakeDetails::new(host_name, extra_exts),
+            handshake: HandshakeDetails::new(host_name),
+            extra_exts,
         }
     }
 
@@ -146,7 +148,7 @@ impl InitialState {
                 .set_client_auth_enabled();
         }
         let hello_details = ClientHelloDetails::new();
-        emit_client_hello_for_retry(sess, self.handshake, hello_details, None)
+        emit_client_hello_for_retry(sess, self.handshake, hello_details, None, self.extra_exts)
     }
 }
 
@@ -167,7 +169,10 @@ struct ExpectServerHello {
     must_issue_new_ticket: bool,
 }
 
-struct ExpectServerHelloOrHelloRetryRequest(ExpectServerHello);
+struct ExpectServerHelloOrHelloRetryRequest {
+    next: ExpectServerHello,
+    extra_exts: Vec<ClientExtension>,
+}
 
 pub fn compatible_suite(
     sess: &ClientSessionImpl,
@@ -190,6 +195,7 @@ fn emit_client_hello_for_retry(
     mut handshake: HandshakeDetails,
     mut hello: ClientHelloDetails,
     retryreq: Option<&HelloRetryRequest>,
+    extra_exts: Vec<ClientExtension>,
 ) -> NextState {
     // Do we have a SessionID or ticket cached for this host?
     handshake.resuming_session = find_session(sess, handshake.dns_name.as_ref());
@@ -289,7 +295,7 @@ fn emit_client_hello_for_retry(
     }
 
     // Extra extensions must be placed before the PSK extension
-    exts.extend(handshake.extra_exts.iter().cloned());
+    exts.extend(extra_exts.iter().cloned());
 
     let fill_in_binder = if support_tls13
         && sess.config.enable_tickets
@@ -408,7 +414,7 @@ fn emit_client_hello_for_retry(
     };
 
     if support_tls13 && retryreq.is_none() {
-        Box::new(ExpectServerHelloOrHelloRetryRequest(next))
+        Box::new(ExpectServerHelloOrHelloRetryRequest { next, extra_exts })
     } else {
         Box::new(next)
     }
@@ -748,7 +754,7 @@ impl State for ExpectServerHello {
 
 impl ExpectServerHelloOrHelloRetryRequest {
     fn into_expect_server_hello(self) -> NextState {
-        Box::new(self.0)
+        Box::new(self.next)
     }
 
     fn handle_hello_retry_request(
@@ -772,7 +778,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         // retry of a group we already sent.
         if !has_cookie
             && req_group
-                .map(|g| self.0.hello.has_key_share(g))
+                .map(|g| self.next.hello.has_key_share(g))
                 .unwrap_or(false)
         {
             return Err(illegal_param(sess, "server requested hrr with our group"));
@@ -841,15 +847,15 @@ impl ExpectServerHelloOrHelloRetryRequest {
         sess.common.set_suite(cs);
 
         // This is the draft19 change where the transcript became a tree
-        self.0
+        self.next
             .handshake
             .transcript
             .start_hash(cs.get_hash());
-        self.0
+        self.next
             .handshake
             .transcript
             .rollup_for_hrr();
-        self.0
+        self.next
             .handshake
             .transcript
             .add_message(&m);
@@ -861,9 +867,10 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         Ok(emit_client_hello_for_retry(
             sess,
-            self.0.handshake,
-            self.0.hello,
+            self.next.handshake,
+            self.next.hello,
             Some(&hrr),
+            self.extra_exts,
         ))
     }
 }


### PR DESCRIPTION
It is only needed at the beginning of the handshake, not through the
whole handshake.