### PR TITLE
Change the certificate validation API to guarantee end-entity is present.

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -449,8 +449,9 @@ mod danger {
     impl rustls::ServerCertVerifier for NoCertificateVerification {
         fn verify_server_cert(
             &self,
+            _end_entity: &rustls::Certificate,
+            _intermediates: &[rustls::Certificate],
             _roots: &rustls::RootCertStore,
-            _presented_certs: &[rustls::Certificate],
             _dns_name: webpki::DNSNameRef<'_>,
             _ocsp: &[u8],
             _now: std::time::SystemTime,

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -191,7 +191,8 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
 
     fn verify_client_cert(
         &self,
-        _certs: &[rustls::Certificate],
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
         _sni: Option<&webpki::DNSName>,
         _now: SystemTime,
     ) -> Result<rustls::ClientCertVerified, rustls::TLSError> {
@@ -204,8 +205,9 @@ struct DummyServerAuth {}
 impl rustls::ServerCertVerifier for DummyServerAuth {
     fn verify_server_cert(
         &self,
-        _roots: &rustls::RootCertStore,
+        _end_entity: &rustls::Certificate,
         _certs: &[rustls::Certificate],
+        _roots: &rustls::RootCertStore,
         _hostname: webpki::DNSNameRef<'_>,
         _ocsp: &[u8],
         _now: SystemTime,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -520,17 +520,19 @@ impl hs::State for ExpectServerDone {
         // 6. emit a Finished, our first encrypted message under the new keys.
 
         // 1.
-        if st.server_cert.cert_chain.is_empty() {
-            return Err(TLSError::NoCertificatesPresented);
-        }
-
+        let (end_entity, intermediates) = st
+            .server_cert
+            .cert_chain
+            .split_first()
+            .ok_or(TLSError::NoCertificatesPresented)?;
         let now = std::time::SystemTime::now();
         let certv = sess
             .config
             .get_verifier()
             .verify_server_cert(
+                end_entity,
+                intermediates,
                 &sess.config.root_store,
-                &st.server_cert.cert_chain,
                 st.handshake.dns_name.as_ref(),
                 &st.server_cert.ocsp_response,
                 now,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -684,17 +684,19 @@ impl hs::State for ExpectCertificateVerify {
         trace!("Server cert is {:?}", self.server_cert.cert_chain);
 
         // 1. Verify the certificate chain.
-        if self.server_cert.cert_chain.is_empty() {
-            return Err(TLSError::NoCertificatesPresented);
-        }
-
+        let (end_entity, intermediates) = self
+            .server_cert
+            .cert_chain
+            .split_first()
+            .ok_or(TLSError::NoCertificatesPresented)?;
         let now = std::time::SystemTime::now();
         let certv = sess
             .config
             .get_verifier()
             .verify_server_cert(
+                end_entity,
+                intermediates,
                 &sess.config.root_store,
-                &self.server_cert.cert_chain,
                 self.handshake.dns_name.as_ref(),
                 &self.server_cert.ocsp_response,
                 now,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -63,25 +63,26 @@ impl hs::State for ExpectCertificate {
                 TLSError::General("client rejected by client_auth_mandatory".into())
             })?;
 
-        if cert_chain.is_empty() {
-            if !mandatory {
-                debug!("client auth requested but no certificate supplied");
-                self.handshake
-                    .transcript
-                    .abandon_client_auth();
-                return Ok(self.into_expect_tls12_client_kx(None));
-            }
-            sess.common
-                .send_fatal_alert(AlertDescription::CertificateRequired);
-            return Err(TLSError::NoCertificatesPresented);
-        }
-
         trace!("certs {:?}", cert_chain);
+
+        let (end_entity, intermediates) = match cert_chain.split_first() {
+            None => {
+                if !mandatory {
+                    debug!("client auth requested but no certificate supplied");
+                    self.handshake.transcript.abandon_client_auth();
+                    return Ok(self.into_expect_tls12_client_kx(None));
+                }
+                sess.common
+                    .send_fatal_alert(AlertDescription::CertificateRequired);
+                return Err(TLSError::NoCertificatesPresented);
+            }
+            Some(chain) => chain,
+        };
 
         let now = std::time::SystemTime::now();
         sess.config
             .verifier
-            .verify_client_cert(cert_chain, sess.get_sni(), now)
+            .verify_client_cert(end_entity, intermediates, sess.get_sni(), now)
             .or_else(|err| {
                 hs::incompatible(sess, "certificate invalid");
                 Err(err)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -771,24 +771,25 @@ impl hs::State for ExpectCertificate {
                 TLSError::General("client rejected by client_auth_mandatory".into())
             })?;
 
-        if cert_chain.is_empty() {
-            if !mandatory {
-                debug!("client auth requested but no certificate supplied");
-                self.handshake
-                    .transcript
-                    .abandon_client_auth();
-                return Ok(self.into_expect_finished());
-            }
+        let (end_entity, intermediates) = match cert_chain.split_first() {
+            None => {
+                if !mandatory {
+                    debug!("client auth requested but no certificate supplied");
+                    self.handshake.transcript.abandon_client_auth();
+                    return Ok(self.into_expect_finished());
+                }
 
-            sess.common
-                .send_fatal_alert(AlertDescription::CertificateRequired);
-            return Err(TLSError::NoCertificatesPresented);
-        }
+                sess.common
+                    .send_fatal_alert(AlertDescription::CertificateRequired);
+                return Err(TLSError::NoCertificatesPresented);
+            }
+            Some(chain) => chain,
+        };
 
         let now = std::time::SystemTime::now();
         sess.config
             .get_verifier()
-            .verify_client_cert(&cert_chain, sess.get_sni(), now)
+            .verify_client_cert(end_entity, intermediates, sess.get_sni(), now)
             .or_else(|err| {
                 hs::incompatible(sess, "certificate invalid");
                 Err(err)

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -78,13 +78,18 @@ impl ClientCertVerified {
 /// Something that can verify a server certificate chain, and verify
 /// signatures made by certificates.
 pub trait ServerCertVerifier: Send + Sync {
-    /// Verify a the certificate chain `presented_certs` against the roots
-    /// configured in `roots`.  Make sure that `dns_name` is quoted by
-    /// the top certificate in the chain.
+    /// Verify the end-entity certificate `end_entity` is valid for the
+    /// hostname `dns_name` and chains to at least one of the trust anchors
+    /// in `roots`.
+    ///
+    /// `intermediates` contains the intermediate certificates the client sent
+    /// along with the end-entity certificate; it is in the same order that the
+    /// peer sent them and may be empty.
     fn verify_server_cert(
         &self,
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
         roots: &RootCertStore,
-        presented_certs: &[Certificate],
         dns_name: webpki::DNSNameRef,
         ocsp_response: &[u8],
         now: SystemTime,
@@ -117,7 +122,6 @@ pub trait ServerCertVerifier: Send + Sync {
     ) -> Result<HandshakeSignatureValid, TLSError> {
         verify_signed_struct(message, cert, dss)
     }
-
 
     /// Verify a signature allegedly by the given server certificate.
     ///
@@ -181,13 +185,19 @@ pub trait ClientCertVerifier: Send + Sync {
         sni: Option<&webpki::DNSName>,
     ) -> Option<DistinguishedNames>;
 
-    /// Verify a certificate chain. `presented_certs` is the certificate chain from the client.
+    /// Verify the end-entity certificate `end_entity` is valid for the
+    /// and chains to at least one of the trust anchors in `roots`.
+    ///
+    /// `intermediates` contains the intermediate certificates the
+    /// client sent along with the end-entity certificate; it is in the same
+    /// order that the peer sent them and may be empty.
     ///
     /// `sni` is the server name quoted by the client in its ClientHello; it has
     /// been validated as a proper DNS name but is otherwise untrusted.
     fn verify_client_cert(
         &self,
-        presented_certs: &[Certificate],
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         now: SystemTime,
     ) -> Result<ClientCertVerified, TLSError>;
@@ -261,15 +271,15 @@ impl ServerCertVerifier for WebPKIVerifier {
     /// - OCSP data is present
     fn verify_server_cert(
         &self,
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
         roots: &RootCertStore,
-        presented_certs: &[Certificate],
         dns_name: webpki::DNSNameRef,
         ocsp_response: &[u8],
         now: SystemTime,
     ) -> Result<ServerCertVerified, TLSError> {
-        let (cert, chain, trustroots) = prepare(roots, presented_certs)?;
-        let now = webpki::Time::try_from(now)
-            .map_err(|_| TLSError::FailedToGetCurrentTime)?;
+        let (cert, chain, trustroots) = prepare(end_entity, intermediates, roots)?;
+        let now = webpki::Time::try_from(now).map_err(|_| TLSError::FailedToGetCurrentTime)?;
 
         let cert = cert
             .verify_is_valid_tls_server_cert(
@@ -319,21 +329,14 @@ type CertChainAndRoots<'a, 'b> = (
 );
 
 fn prepare<'a, 'b>(
+    end_entity: &'a Certificate,
+    intermediates: &'a [Certificate],
     roots: &'b RootCertStore,
-    presented_certs: &'a [Certificate],
 ) -> Result<CertChainAndRoots<'a, 'b>, TLSError> {
-    if presented_certs.is_empty() {
-        return Err(TLSError::NoCertificatesPresented);
-    }
-
     // EE cert must appear first.
-    let cert = webpki::EndEntityCert::from(&presented_certs[0].0).map_err(TLSError::WebPKIError)?;
+    let cert = webpki::EndEntityCert::from(&end_entity.0).map_err(TLSError::WebPKIError)?;
 
-    let chain: Vec<&'a [u8]> = presented_certs
-        .iter()
-        .skip(1)
-        .map(|cert| cert.0.as_ref())
-        .collect();
+    let intermediates: Vec<&'a [u8]> = intermediates.iter().map(|cert| cert.0.as_ref()).collect();
 
     let trustroots: Vec<webpki::TrustAnchor> = roots
         .roots
@@ -341,7 +344,7 @@ fn prepare<'a, 'b>(
         .map(OwnedTrustAnchor::to_trust_anchor)
         .collect();
 
-    Ok((cert, chain, trustroots))
+    Ok((cert, intermediates, trustroots))
 }
 
 /// A `ClientCertVerifier` that will ensure that every client provides a trusted
@@ -377,13 +380,13 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
 
     fn verify_client_cert(
         &self,
-        presented_certs: &[Certificate],
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
         _sni: Option<&webpki::DNSName>,
         now: SystemTime,
     ) -> Result<ClientCertVerified, TLSError> {
-        let (cert, chain, trustroots) = prepare(&self.roots, presented_certs)?;
-        let now = webpki::Time::try_from(now)
-            .map_err(|_| TLSError::FailedToGetCurrentTime)?;
+        let (cert, chain, trustroots) = prepare(end_entity, intermediates, &self.roots)?;
+        let now = webpki::Time::try_from(now).map_err(|_| TLSError::FailedToGetCurrentTime)?;
         cert.verify_is_valid_tls_client_cert(
             SUPPORTED_SIG_ALGS,
             &webpki::TLSClientTrustAnchors(&trustroots),
@@ -429,18 +432,18 @@ impl ClientCertVerifier for AllowAnyAnonymousOrAuthenticatedClient {
         &self,
         sni: Option<&webpki::DNSName>,
     ) -> Option<DistinguishedNames> {
-        self.inner
-            .client_auth_root_subjects(sni)
+        self.inner.client_auth_root_subjects(sni)
     }
 
     fn verify_client_cert(
         &self,
-        presented_certs: &[Certificate],
+        end_entity: &Certificate,
+        intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         now: SystemTime,
     ) -> Result<ClientCertVerified, TLSError> {
         self.inner
-            .verify_client_cert(presented_certs, sni, now)
+            .verify_client_cert(end_entity, intermediates, sni, now)
     }
 }
 
@@ -468,7 +471,8 @@ impl ClientCertVerifier for NoClientAuth {
 
     fn verify_client_cert(
         &self,
-        _presented_certs: &[Certificate],
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
         _sni: Option<&webpki::DNSName>,
         _now: SystemTime,
     ) -> Result<ClientCertVerified, TLSError> {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -194,10 +194,11 @@ impl Context {
     fn bench(&self, count: usize) {
         let mut times = Vec::new();
 
+        let (end_entity, intermediates) = self.chain.split_first().unwrap();
         for _ in 0..count {
             let start = Instant::now();
             let dns_name = webpki::DNSNameRef::try_from_ascii_str(self.domain).unwrap();
-            V.verify_server_cert(&self.roots, &self.chain[..], dns_name, &[], self.now)
+            V.verify_server_cert(end_entity, intermediates, &self.roots, dns_name, &[], self.now)
                 .unwrap();
             times.push(duration_nanos(Instant::now().duration_since(start)));
         }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -343,7 +343,8 @@ impl ClientCertVerifier for MockClientVerifier {
 
     fn verify_client_cert(
         &self,
-        _presented_certs: &[Certificate],
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         _now: std::time::SystemTime,
     ) -> Result<ClientCertVerified, TLSError> {


### PR DESCRIPTION
Rustls already handles internally the case where no certificate is
present in the Certificate message. Every implementation of the
certificate verification APIs currently needs to deal with the
possibility that the end-entity certificate wasn't provided, or
dangerously assume that the list of certificates it is given is never
empty. Make it clear that it will be given at least the end-entity
certificate by splitting the end-entity certificate out into its own
parameter. This makes it easier to correctly and safely implement the
certificate verifier interfaces.

In the previous API, the ordering of the certificates in the chain was
not documented; the API required knowledge of the TLS specification and
an assumption that Rustls does the "obvious" thing to know that the
end-entity certificate is at the beginning. The new API avoids any
doubt about this. Also, there is now documentation that guarantees that
the intermediates are in the same order that they were in the handshake.

This also makes static analysis easier because it eliminates a use of
the panic-prone `[]` slice indexing operator.