### PR TITLE
Bump MSRV to Rust 1.47.0.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.40.0 # our MSRV
+          - 1.47.0 # our MSRV
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:


### PR DESCRIPTION
Rust 1.47.0 gets rid of `LengthAtMost32`. This allows *ring* to expose a
better API in `ring::rand` and to have a more clearly correct
implementation with less `unsafe`. Rust 1.46.0 added support for more
expressions in `const fn`s which will let me clean up some more parts of
*ring* to make them more clearly correct. So, I'm eager to require at
least Rust 1.47.0 for *ring*. I'd like to update Rustls to use the
latest version of *ring* that I plan to release this month.

Rustls PR #428 would be cleaner if we support at least Rust 1.44; see
the comment in the PR for details.