### PR TITLE
Use the `find` combinator on iterators

### DIFF
--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -173,8 +173,7 @@ impl ExtensionProcessing {
 
             sess.alpn_protocol = our_protocols
                 .iter()
-                .filter(|protocol| their_protocols.contains(&protocol.as_slice()))
-                .nth(0)
+                .find(|protocol| their_protocols.contains(&protocol.as_slice()))
                 .cloned();
             if let Some(ref selected_protocol) = sess.alpn_protocol {
                 debug!("Chosen ALPN protocol {:?}", selected_protocol);
@@ -737,10 +736,7 @@ impl State for ExpectClientHello {
             trace!("sig schemes {:?}", sigschemes_ext);
             trace!("alpn protocols {:?}", alpn_protocols);
 
-            let alpn_slices = match alpn_protocols {
-                Some(ref vec) => Some(vec.as_slice()),
-                None => None,
-            };
+            let alpn_slices = alpn_protocols.as_ref().map(|vec| vec.as_slice());
 
             let client_hello = ClientHello::new(sni_ref, &sigschemes_ext, alpn_slices);
 
@@ -928,15 +924,13 @@ impl State for ExpectClientHello {
 
         let group = suites::KeyExchange::supported_groups()
             .iter()
-            .filter(|group| groups_ext.contains(group))
-            .nth(0)
+            .find(|group| groups_ext.contains(group))
             .cloned()
             .ok_or_else(|| incompatible(sess, "no supported group"))?;
 
         let ecpoint = ECPointFormatList::supported()
             .iter()
-            .filter(|format| ecpoints_ext.contains(format))
-            .nth(0)
+            .find(|format| ecpoints_ext.contains(format))
             .cloned()
             .ok_or_else(|| incompatible(sess, "no supported point format"))?;
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -582,8 +582,7 @@ impl CompleteClientHelloHandling {
         let supported_groups = suites::KeyExchange::supported_groups();
         let chosen_group = supported_groups
             .iter()
-            .filter(|group| share_groups.contains(group))
-            .nth(0)
+            .find(|group| share_groups.contains(group))
             .cloned();
 
         if chosen_group.is_none() {
@@ -591,8 +590,7 @@ impl CompleteClientHelloHandling {
             // send a HelloRetryRequest.
             let retry_group_maybe = supported_groups
                 .iter()
-                .filter(|group| groups_ext.contains(group))
-                .nth(0)
+                .find(|group| groups_ext.contains(group))
                 .cloned();
             self.handshake
                 .transcript

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -218,8 +218,7 @@ impl SigningKey for RSASigningKey {
     fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
         ALL_RSA_SCHEMES
             .iter()
-            .filter(|scheme| offered.contains(scheme))
-            .nth(0)
+            .find(|scheme| offered.contains(scheme))
             .map(|scheme| RSASigner::new(self.key.clone(), *scheme))
     }
 


### PR DESCRIPTION
and other minor refactorings of pattern-matches on `Option` / `Result` that have a direct combinator equivalent.

Reviewed from tool suggestions produced with [comby-rust](https://github.com/huitseeker/comby-rust).