### PR TITLE
Clarify that message header decoding doesn't panic.

### DIFF
--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -113,9 +113,22 @@ pub struct u24(pub u32);
 
 impl u24 {
     pub fn decode(bytes: &[u8]) -> Option<u24> {
-        Some(u24((u32::from(bytes[0]) << 16)
-            | (u32::from(bytes[1]) << 8)
-            | u32::from(bytes[2])))
+        let (a, b, c) = (bytes.get(0), bytes.get(1), bytes.get(2));
+        if let (Some(&a), Some(&b), Some(&c)) = (a, b, c) {
+            Some(u24((u32::from(a) << 16)
+                | (u32::from(b) << 8)
+                | u32::from(c)))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl Into<usize> for u24 {
+    #[inline]
+    fn into(self) -> usize {
+        self.0 as usize
     }
 }
 

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -75,12 +75,13 @@ impl HandshakeJoiner {
     /// enough to contain a header, and that header has a length which falls
     /// within `buf`.
     fn buf_contains_message(&self) -> bool {
-        self.buf.len() >= HEADER_SIZE
-            && self.buf.len()
-                >= (codec::u24::decode(&self.buf[1..4])
-                    .unwrap()
-                    .0 as usize)
-                    + HEADER_SIZE
+        let (len_bytes, rest) = (self.buf.get(1..HEADER_SIZE), self.buf.get(HEADER_SIZE..));
+        if let (Some(len_bytes), Some(rest)) = (len_bytes, rest) {
+            if let Some(len) = codec::u24::decode(len_bytes) {
+                return rest.get(..len.into()).is_some();
+            }
+        }
+        false
     }
 
     /// Take a TLS handshake payload off the front of `buf`, and put it onto


### PR DESCRIPTION
Add checking to `u24::decode()` to avoid array indexing errors.
Add similar checks to HandshakeJoiner::buf_contains_message.

Note that all of these checks are redundant but they allow us to avoid
slice indexing and unwrap in favor of type-safe access. When Rust has
generic consts we will probably be able to simplify this a lot.