### PR TITLE
Refactor client hello retrying to avoid unwrapping

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -761,12 +761,12 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         check_aligned_handshake(sess)?;
 
-        let has_cookie = hrr.get_cookie().is_some();
+        let cookie = hrr.get_cookie();
         let req_group = hrr.get_requested_key_share_group();
 
         // A retry request is illegal if it contains no cookie and asks for
         // retry of a group we already sent.
-        if !has_cookie
+        if cookie.is_none()
             && req_group
                 .map(|g| self.next.hello.has_key_share(g))
                 .unwrap_or(false)
@@ -782,11 +782,13 @@ impl ExpectServerHelloOrHelloRetryRequest {
         }
 
         // Or has an empty cookie.
-        if has_cookie && hrr.get_cookie().unwrap().0.is_empty() {
-            return Err(illegal_param(
-                sess,
-                "server requested hrr with empty cookie",
-            ));
+        if let Some(cookie) = cookie {
+            if cookie.0.is_empty() {
+                return Err(illegal_param(
+                    sess,
+                    "server requested hrr with empty cookie",
+                ));
+            }
         }
 
         // Or has something unrecognised
@@ -804,7 +806,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         }
 
         // Or asks us to change nothing.
-        if !has_cookie && req_group.is_none() {
+        if cookie.is_none() && req_group.is_none() {
             return Err(illegal_param(sess, "server requested hrr with no changes"));
         }
 


### PR DESCRIPTION
Refactor `ExpectServerHelloOrHelloRetryRequest::handle_hello_retry_request` to avoid unwrapping