### PR TITLE
Clarify that message header decoding doesn't panic

### DIFF
--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -120,6 +120,14 @@ impl u24 {
     }
 }
 
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl Into<usize> for u24 {
+    #[inline]
+    fn into(self) -> usize {
+        self.0 as usize
+    }
+}
+
 impl Codec for u24 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let be_bytes = u32::to_be_bytes(self.0);


### PR DESCRIPTION
Yet another take on #485 and #492. @briansmith, what do you think? I feel like this makes it statically clear to both machines and humans that no panics can happen while being slightly less dense/verbose than your version.