### PR TITLE
Prevent panic while panicking in tests/api.rs

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -610,8 +610,10 @@ impl ClientCheckCertResolve {
 
 impl Drop for ClientCheckCertResolve {
     fn drop(&mut self) {
-        let count = self.query_count.load(Ordering::SeqCst);
-        assert_eq!(count, self.expect_queries);
+        if !std::thread::panicking() {
+            let count = self.query_count.load(Ordering::SeqCst);
+            assert_eq!(count, self.expect_queries);
+        }
     }
 }
 


### PR DESCRIPTION
While playing around with rustls I broke the `client_cert_resolve` test and if the `ResolvesClientCert` implementation for `ClientCheckCertResolve` panics, then it will panic again in the `drop` call leading to an illegal instruction error.