### PR TITLE
Client: Lookup session once per connection.

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -136,6 +136,12 @@ impl InitialState {
     }
 
     fn emit_initial_client_hello(mut self, sess: &mut ClientSessionImpl) -> NextState {
+        // During retries "the client MUST send the same ClientHello without
+        // modification" with only a few exceptions as noted in
+        // https://tools.ietf.org/html/rfc8446#section-4.1.2,
+        // Calculate all inputs to the client hellos that might otherwise
+        // change between the initial and retry hellos here to enforce this.
+
         if sess
             .config
             .client_auth_cert_resolver
@@ -145,6 +151,8 @@ impl InitialState {
                 .transcript
                 .set_client_auth_enabled();
         }
+
+        self.handshake.resuming_session = find_session(sess, self.handshake.dns_name.as_ref());
         let hello_details = ClientHelloDetails::new();
         emit_client_hello_for_retry(sess, self.handshake, hello_details, None, self.extra_exts)
     }
@@ -190,7 +198,6 @@ fn emit_client_hello_for_retry(
     extra_exts: Vec<ClientExtension>,
 ) -> NextState {
     // Do we have a SessionID or ticket cached for this host?
-    handshake.resuming_session = find_session(sess, handshake.dns_name.as_ref());
     let (session_id, ticket, resume_version) = if handshake.resuming_session.is_some() {
         let resuming = handshake
             .resuming_session


### PR DESCRIPTION
Only do the lookup of the session during the initial client hello.
Otherwise, if we do a session lookup during retries, the session cache
may have changed and we might get back a different session, e.g. because
a different connection modified the session cache in the interim.