### PR TITLE
Remove CertifiedKey::has_sct_list()

### DIFF
--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -86,11 +86,6 @@ impl CertifiedKey {
         mem::replace(&mut self.ocsp, None)
     }
 
-    /// Return true if there's an SCT list.
-    pub fn has_sct_list(&self) -> bool {
-        self.sct_list.is_some()
-    }
-
     /// Steal ownership of the SCT list.
     pub fn take_sct_list(&mut self) -> Option<Vec<u8>> {
         mem::replace(&mut self.sct_list, None)


### PR DESCRIPTION
This became unused in #505. It was originally added 4 years ago in
df361f832bd466f1da263d65bf0a6df64254d3a5, so it seems there was no
specific reason for making it public. In addition, we already have
some breaking API changes lined up, so might as well remove this.