### PR TITLE
Reduce usage of `SessionCommon::get_suite_assert()`.

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -719,7 +719,7 @@ impl State for ExpectServerHello {
 
                 let secrets = SessionSecrets::new_resume(
                     &self.handshake.randoms,
-                    scs.hmac_algorithm(),
+                    scs,
                     &resuming.master_secret.0,
                 );
                 sess.config.key_log.log(

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -609,10 +609,7 @@ impl State for ExpectServerHello {
         }
 
         let version = sess.common.negotiated_version.unwrap();
-        if !sess
-            .common
-            .get_suite_assert()
-            .usable_for_version(version)
+        if !scs.usable_for_version(version)
         {
             return Err(illegal_param(
                 sess,
@@ -621,13 +618,9 @@ impl State for ExpectServerHello {
         }
 
         // Start our handshake hash, and input the server-hello.
-        let starting_hash = sess
-            .common
-            .get_suite_assert()
-            .get_hash();
         self.handshake
             .transcript
-            .start_hash(starting_hash);
+            .start_hash(scs.get_hash());
         self.handshake
             .transcript
             .add_message(&m);
@@ -637,6 +630,7 @@ impl State for ExpectServerHello {
         if sess.common.is_tls13() {
             tls13::validate_server_hello(sess, &server_hello)?;
             let (key_schedule, hash_at_client_recvd_server_hello) = tls13::start_handshake_traffic(
+                scs,
                 sess,
                 self.early_key_schedule.take(),
                 &server_hello,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::cipher;
+use crate::{cipher, SupportedCipherSuite};
 use crate::client::ClientSessionImpl;
 use crate::error::TLSError;
 use crate::key_schedule::{KeyScheduleEarly, KeyScheduleHandshake};
@@ -183,7 +183,7 @@ struct ExpectServerHelloOrHelloRetryRequest {
 
 pub fn compatible_suite(
     sess: &ClientSessionImpl,
-    resuming_suite: &suites::SupportedCipherSuite,
+    resuming_suite: &SupportedCipherSuite,
 ) -> bool {
     match sess.common.get_suite() {
         Some(suite) => suite.can_resume_to(&resuming_suite),
@@ -494,9 +494,10 @@ impl ExpectServerHello {
         })
     }
 
-    fn into_expect_tls12_certificate(self) -> NextState {
+    fn into_expect_tls12_certificate(self, suite: &'static SupportedCipherSuite) -> NextState {
         Box::new(tls12::ExpectCertificate {
             handshake: self.handshake,
+            suite,
             server_cert: self.server_cert,
             may_send_cert_status: self.may_send_cert_status,
             must_issue_new_ticket: self.must_issue_new_ticket,
@@ -744,7 +745,7 @@ impl State for ExpectServerHello {
             }
         }
 
-        Ok(self.into_expect_tls12_certificate())
+        Ok(self.into_expect_tls12_certificate(scs))
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,5 +1,5 @@
 use crate::check::check_message;
-use crate::cipher;
+use crate::{cipher, SupportedCipherSuite};
 use crate::client::ClientSessionImpl;
 use crate::error::TLSError;
 use crate::key_schedule::{
@@ -167,14 +167,13 @@ pub fn fill_in_psk_binder(
 }
 
 pub fn start_handshake_traffic(
+    suite: &'static SupportedCipherSuite,
     sess: &mut ClientSessionImpl,
     early_key_schedule: Option<KeyScheduleEarly>,
     server_hello: &ServerHelloPayload,
     handshake: &mut HandshakeDetails,
     hello: &mut ClientHelloDetails,
 ) -> Result<(KeyScheduleHandshake, Digest), TLSError> {
-    let suite = sess.common.get_suite_assert();
-
     let their_key_share = server_hello
         .get_key_share()
         .ok_or_else(|| {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -576,13 +576,12 @@ impl ExpectClientHello {
         self.handshake.session_id = *id;
         self.emit_server_hello(sess, None, client_hello, Some(&resumedata))?;
 
-        let hmac_alg = sess
+        let suite = sess
             .common
-            .get_suite_assert()
-            .hmac_algorithm();
+            .get_suite_assert();
         let secrets = SessionSecrets::new_resume(
             &self.handshake.randoms,
-            hmac_alg,
+            suite,
             &resumedata.master_secret.0,
         );
         sess.config.key_log.log(

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -790,7 +790,7 @@ impl State for ExpectClientHello {
         if sess.common.is_tls13() {
             return self
                 .into_complete_tls13_client_hello_handling()
-                .handle_client_hello(sess, certkey, &m);
+                .handle_client_hello(ciphersuite, sess, certkey, &m);
         }
 
         // -- TLS1.2 only from hereon in --


### PR DESCRIPTION
`SessionCommon::get_suite_assert()` unwraps an `Option` containing the agreed-upon cipher suite. In many cases within the handshake state machine, it is easy to retrieve this value without unwrapping, so do so. This is an incremental step towards removing all uses of the function.

See each individual commit message for a description of each commit.