### PR TITLE
What is the reason webpki operation failed?

### DIFF
--- a/rustls-mio/tests/badssl.rs
+++ b/rustls-mio/tests/badssl.rs
@@ -38,7 +38,7 @@ mod online {
         polite();
         connect("expired.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPKIError\(CertExpired\)")
+            .expect(r"TLS error: WebPKIError\(CertExpired, ValidateServerCert\)")
             .go()
             .unwrap();
     }
@@ -48,7 +48,7 @@ mod online {
         polite();
         connect("wrong.host.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPKIError\(CertNotValidForName\)")
+            .expect(r"TLS error: WebPKIError\(CertNotValidForName, ValidateForDNSName\)")
             .go()
             .unwrap();
     }
@@ -58,7 +58,7 @@ mod online {
         polite();
         connect("self-signed.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPKIError\((UnknownIssuer|CertExpired)\)")
+            .expect(r"TLS error: WebPKIError\((UnknownIssuer|CertExpired), ValidateServerCert\)")
             .go()
             .unwrap();
     }
@@ -133,7 +133,7 @@ mod online {
         polite();
         connect("sha1-2016.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPKIError\(CertExpired\)")
+            .expect(r"TLS error: WebPKIError\(CertExpired, ValidateServerCert\)")
             .go()
             .unwrap();
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -498,11 +498,11 @@ fn handle_err(err: rustls::TLSError) -> ! {
         TLSError::AlertReceived(AlertDescription::DecompressionFailure) => {
             quit_err(":SSLV3_ALERT_DECOMPRESSION_FAILURE:")
         }
-        TLSError::WebPKIError(webpki::Error::BadDER) => quit(":CANNOT_PARSE_LEAF_CERT:"),
-        TLSError::WebPKIError(webpki::Error::InvalidSignatureForPublicKey) => {
+        TLSError::WebPKIError(webpki::Error::BadDER, ..) => quit(":CANNOT_PARSE_LEAF_CERT:"),
+        TLSError::WebPKIError(webpki::Error::InvalidSignatureForPublicKey, ..) => {
             quit(":BAD_SIGNATURE:")
         }
-        TLSError::WebPKIError(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey) => {
+        TLSError::WebPKIError(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey, ..) => {
             quit(":WRONG_SIGNATURE_TYPE:")
         }
         TLSError::PeerSentOversizedRecord => quit(":DATA_LENGTH_TOO_LONG:"),

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -62,7 +62,7 @@ fn communicate(host: String, port: u16, config: ClientConfig) -> Result<Verdict,
 
             if let Err(err) = client.process_new_packets() {
                 return match err {
-                    TLSError::WebPKIError(_) | TLSError::AlertReceived(_) => {
+                    TLSError::WebPKIError(..) | TLSError::AlertReceived(_) => {
                         Ok(Verdict::Reject(err))
                     }
                     _ => Err(From::from(format!("{:?}", err))),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -896,7 +896,7 @@ impl State for ExpectServerHelloOrHelloRetryRequest {
 
 pub fn send_cert_error_alert(sess: &mut ClientSessionImpl, err: TLSError) -> TLSError {
     match err {
-        TLSError::WebPKIError(webpki::Error::BadDER) => {
+        TLSError::WebPKIError(webpki::Error::BadDER, _) => {
             sess.common
                 .send_fatal_alert(AlertDescription::DecodeError);
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -643,7 +643,7 @@ impl ExpectCertificateVerify {
 
 fn send_cert_error_alert(sess: &mut ClientSessionImpl, err: TLSError) -> TLSError {
     match err {
-        TLSError::WebPKIError(webpki::Error::BadDER) => {
+        TLSError::WebPKIError(webpki::Error::BadDER, _) => {
             sess.common
                 .send_fatal_alert(AlertDescription::DecodeError);
         }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -264,6 +264,7 @@ pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientSession, WriteEarlyData};
 pub use crate::error::TLSError;
+pub use crate::error::WebPKIOp;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
 pub use crate::msgs::enums::CipherSuite;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -16,6 +16,7 @@ use rustls::ClientHello;
 use rustls::KeyLog;
 use rustls::Session;
 use rustls::TLSError;
+use rustls::WebPKIOp;
 use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
 use rustls::{ClientConfig, ClientSession, ResolvesClientCert};
 use rustls::{ResolvesServerCert, ServerConfig, ServerSession};
@@ -587,7 +588,8 @@ fn client_checks_server_certificate_with_given_name() {
             assert_eq!(
                 err,
                 Err(TLSErrorFromPeer::Client(TLSError::WebPKIError(
-                    webpki::Error::CertNotValidForName
+                    webpki::Error::CertNotValidForName,
+                    WebPKIOp::ValidateForDNSName,
                 )))
             );
         }


### PR DESCRIPTION
I don't know if it's me or everyone, but debugging TLS setup issues
is usually non-trivial.

For example, right now I'm fighting with this issue:
an `openssl s_client` works fine, but a client implemented with
rustls fails with an error:

```
Custom { kind: InvalidData, error: WebPKIError(UnknownIssuer) }
```

`WebPKIError` can be emitted for several reasons. This PR adds the
operation name to the error. I have identified five operations:
* validate server certificate
* validate client certificate
* validate certificate for DNS name
* parse the certificate
* verify message signature

The error can be expanded further later, but even this basic list
will provide some clue where to look.