### PR TITLE
Client: Clarify when server cert details are filled in and fully available.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -23,11 +23,13 @@ pub struct ServerCertDetails {
 }
 
 impl ServerCertDetails {
-    pub fn new() -> ServerCertDetails {
+    pub fn new(cert_chain: CertificatePayload,
+               ocsp_response: Vec<u8>,
+               scts: Option<SCTList>) -> ServerCertDetails {
         ServerCertDetails {
-            cert_chain: Vec::new(),
-            ocsp_response: Vec::new(),
-            scts: None,
+            cert_chain,
+            ocsp_response,
+            scts,
         }
     }
 


### PR DESCRIPTION
Clarify when the full `ServerCertDetails` and related inputs are available *with their correct and complete values*. Now the point at which `ServerCertDetails` is constructed is the earliest point in which the validation could happen.

Drop the `ServerCertDetails` immediately after certificate validation to free up memory. The TLS 1.3 state machine was holding onto the `ServerCertDetails` for many messages longer than needed.