### PR TITLE
Refactor `ClientConfig` verifier configuration to better support custom certificate verifiers

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -453,6 +453,7 @@ mod danger {
             _intermediates: &[rustls::Certificate],
             _roots: &rustls::RootCertStore,
             _dns_name: webpki::DNSNameRef<'_>,
+            _scts: &mut dyn Iterator<Item=&[u8]>,
             _ocsp: &[u8],
             _now: std::time::SystemTime,
         ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
@@ -501,7 +502,6 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
         config
             .root_store
             .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-        config.ct_logs = Some(&ct_logs::LOGS);
     }
 
     if args.flag_no_tickets {

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -470,7 +470,7 @@ struct Args {
 }
 
 fn find_suite(name: &str) -> Option<&'static rustls::SupportedCipherSuite> {
-    for suite in &rustls::ALL_CIPHERSUITES {
+    for suite in rustls::ALL_CIPHERSUITES {
         let sname = format!("{:?}", suite.suite).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -309,14 +309,13 @@ fn make_client_config(
     clientauth: ClientAuth,
     resume: Resumption,
 ) -> ClientConfig {
-    let mut cfg = ClientConfig::new();
+    let mut root_store = RootCertStore::empty();
     let mut rootbuf =
         io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());
-    cfg.root_store
+    root_store
         .add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
-    cfg.ciphersuites.clear();
-    cfg.ciphersuites
-        .push(params.ciphersuite);
+
+    let mut cfg = ClientConfig::new(root_store, &[], &[params.ciphersuite]);
     cfg.versions.clear();
     cfg.versions.push(params.version);
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -7,7 +7,6 @@
 use base64;
 use env_logger;
 use rustls;
-use sct;
 use webpki;
 
 use rustls::internal::msgs::enums::ProtocolVersion;
@@ -200,20 +199,25 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
     }
 }
 
-struct DummyServerAuth {}
+struct DummyServerAuth {
+    send_sct: bool,
+}
 
 impl rustls::ServerCertVerifier for DummyServerAuth {
     fn verify_server_cert(
         &self,
         _end_entity: &rustls::Certificate,
         _certs: &[rustls::Certificate],
-        _roots: &rustls::RootCertStore,
         _hostname: webpki::DNSNameRef<'_>,
         _scts: &mut dyn Iterator<Item=&[u8]>,
         _ocsp: &[u8],
         _now: SystemTime,
     ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
         Ok(rustls::ServerCertVerified::assertion())
+    }
+
+    fn request_scts(&self) -> bool {
+        self.send_sct
     }
 }
 
@@ -367,8 +371,6 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
     Arc::new(cfg)
 }
 
-static EMPTY_LOGS: [&sct::Log<'_>; 0] = [];
-
 struct ClientCacheWithoutKxHints(Arc<rustls::ClientSessionMemoryCache>);
 
 impl ClientCacheWithoutKxHints {
@@ -394,18 +396,15 @@ impl rustls::StoresClientSessions for ClientCacheWithoutKxHints {
 }
 
 fn make_client_cfg(opts: &Options) -> Arc<rustls::ClientConfig> {
-    let mut cfg = rustls::ClientConfig::new();
+    let mut cfg = rustls::ClientConfig::new_dangerous(
+        Arc::new(DummyServerAuth{
+            send_sct: opts.send_sct,
+        }),
+        &rustls::DEFAULT_CIPHERSUITES);
     let persist = ClientCacheWithoutKxHints::new();
     cfg.set_persistence(persist);
-    cfg.root_store
-        .add(&load_cert("cert.pem")[0])
-        .unwrap();
     cfg.enable_sni = opts.use_sni;
     cfg.mtu = opts.mtu;
-
-    if opts.send_sct {
-        cfg.ct_logs = Some(&EMPTY_LOGS);
-    }
 
     if !opts.cert_file.is_empty() && !opts.key_file.is_empty() {
         let cert = load_cert(&opts.cert_file);
@@ -421,9 +420,6 @@ fn make_client_cfg(opts: &Options) -> Arc<rustls::ClientConfig> {
             scheme,
         });
     }
-
-    cfg.dangerous()
-        .set_certificate_verifier(Arc::new(DummyServerAuth {}));
 
     if !opts.protocols.is_empty() {
         cfg.set_protocols(

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -209,6 +209,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
         _certs: &[rustls::Certificate],
         _roots: &rustls::RootCertStore,
         _hostname: webpki::DNSNameRef<'_>,
+        _scts: &mut dyn Iterator<Item=&[u8]>,
         _ocsp: &[u8],
         _now: SystemTime,
     ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -7,7 +7,7 @@
 use webpki;
 use webpki_roots;
 
-use rustls::{ClientConfig, ClientSession, Session, TLSError};
+use rustls::{ClientConfig, ClientSession, Session, TLSError, RootCertStore, DEFAULT_CIPHERSUITES};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -22,23 +22,27 @@ enum Verdict {
 }
 
 fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<dyn Error>> {
-    let mut config = ClientConfig::new();
+    let mut root_store = RootCertStore::empty();
     match args.len() {
         3 => {
-            config
-                .root_store
+            root_store
                 .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
         }
         4 => {
             let f = File::open(&args[3])?;
-            config
-                .root_store
+            root_store
                 .add_parsable_certificates(&rustls_pemfile::certs(&mut BufReader::new(f)).unwrap());
         }
         _ => {
             return Err(From::from("Incorrect number of arguments"));
         }
     };
+    let config = ClientConfig::new(
+        root_store,
+        &[],
+        DEFAULT_CIPHERSUITES
+    );
+
     let port = args[2].parse()?;
     Ok((args[1].clone(), port, config))
 }

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -13,12 +13,14 @@ use webpki_roots;
 use rustls::Session;
 
 fn main() {
-    let mut config = rustls::ClientConfig::with_ciphersuites(&[
-        &rustls::ciphersuite::TLS13_CHACHA20_POLY1305_SHA256,
-    ]);
-    config
-        .root_store
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let config = rustls::ClientConfig::new(
+        root_store,
+        &[],
+        &[&rustls::ciphersuite::TLS13_CHACHA20_POLY1305_SHA256]
+    );
 
     let dns_name = webpki::DNSNameRef::try_from_ascii_str("google.com").unwrap();
     let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -7,6 +7,7 @@ use env_logger;
 use rustls;
 use webpki;
 use webpki_roots;
+use rustls::RootCertStore;
 
 fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
     let dns_name = webpki::DNSNameRef::try_from_ascii_str(domain_name).unwrap();
@@ -53,13 +54,18 @@ fn start_session(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
 
 fn main() {
     env_logger::init();
-    let mut config = rustls::ClientConfig::new();
+
+    let mut root_store = RootCertStore::empty();
+    root_store
+        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+    let mut config = rustls::ClientConfig::new(
+        root_store,
+        &[],
+        rustls::DEFAULT_CIPHERSUITES);
 
     // Enable early data.
     config.enable_early_data = true;
-    config
-        .root_store
-        .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     let config = Arc::new(config);
 
     // Do two sessions. The first will be a normal request, the

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -16,13 +16,16 @@ use rustls;
 use webpki;
 use webpki_roots;
 
-use rustls::Session;
+use rustls::{Session, RootCertStore};
 
 fn main() {
-    let mut config = rustls::ClientConfig::new();
-    config
-        .root_store
+    let mut root_store = RootCertStore::empty();
+    root_store
         .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+    let config = rustls::ClientConfig::new(
+        root_store,
+        &[],
+        rustls::DEFAULT_CIPHERSUITES);
 
     let dns_name = webpki::DNSNameRef::try_from_ascii_str("google.com").unwrap();
     let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -36,6 +36,15 @@ impl ServerCertDetails {
     pub fn take_chain(&mut self) -> CertificatePayload {
         mem::replace(&mut self.cert_chain, Vec::new())
     }
+
+    pub fn scts(&self) -> impl Iterator<Item=&[u8]> {
+        self.scts
+            .as_ref()
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .map(|payload| payload.0.as_slice())
+    }
 }
 
 pub struct ServerKXDetails {
@@ -87,6 +96,10 @@ impl ClientHelloDetails {
             sent_extensions: Vec::new(),
             offered_key_shares: Vec::new(),
         }
+    }
+
+    pub fn server_may_send_sct_list(&self) -> bool {
+        self.sent_extensions.contains(&ExtensionType::SCT)
     }
 
     pub fn has_key_share(&self, group: NamedGroup) -> bool {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -1,6 +1,5 @@
-use crate::anchors;
 use crate::error::TLSError;
-use crate::key;
+use crate::{key, RootCertStore};
 use crate::keylog::{KeyLog, NoKeyLog};
 #[cfg(feature = "logging")]
 use crate::log::trace;
@@ -13,7 +12,7 @@ use crate::msgs::handshake::ClientExtension;
 use crate::msgs::message::Message;
 use crate::session::{MiddleboxCCS, Session, SessionCommon};
 use crate::sign;
-use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
+use crate::suites::SupportedCipherSuite;
 use crate::verify;
 
 use std::fmt;
@@ -85,9 +84,6 @@ pub struct ClientConfig {
     /// List of ciphersuites, in preference order.
     pub ciphersuites: Vec<&'static SupportedCipherSuite>,
 
-    /// Collection of root certificates.
-    pub root_store: anchors::RootCertStore,
-
     /// Which ALPN protocols we include in our client hello.
     /// If empty, no ALPN extension is sent.
     pub alpn_protocols: Vec<Vec<u8>>,
@@ -132,31 +128,46 @@ pub struct ClientConfig {
     pub enable_early_data: bool,
 }
 
-impl Default for ClientConfig {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ClientConfig {
-    /// Make a `ClientConfig` with a default set of ciphersuites,
-    /// no root certificates, no ALPN protocols, and no client auth.
+    /// Make a `ClientConfig`.
     ///
-    /// The default session persistence provider stores up to 32
+    /// The verifier will use the roots in `root_store` and CT logs (if any) in
+    /// `ct_logs`.
+    ///
+    /// `ciphersuites` contains the list of cipher suites to enable. It should
+    /// generally be `DEFAULT_CIPHERSUITES`.
+    ///
+    /// No ALPN protocols will be enabled, and client auth will be supported
+    /// by default. The default session persistence provider stores up to 32
     /// items in memory.
-    pub fn new() -> ClientConfig {
-        ClientConfig::with_ciphersuites(&ALL_CIPHERSUITES)
+    pub fn new(root_store: RootCertStore, ct_logs: &'static [&'static sct::Log],
+               ciphersuites: &[&'static SupportedCipherSuite]) -> Self {
+        let verifier = verify::WebPKIVerifier::new(root_store, ct_logs);
+        Self::new_(Arc::new(verifier), ciphersuites)
     }
 
-    /// Make a `ClientConfig` with a custom set of ciphersuites,
-    /// no root certificates, no ALPN protocols, and no client auth.
+    /// Make a `ClientConfig` with a custom certificate verifier.
     ///
-    /// The default session persistence provider stores up to 32
+    /// `verifier` is the certificate verifier to use.
+    ///
+    /// `ciphersuites` contains the list of cipher suites to enable. It should
+    /// generally be `DEFAULT_CIPHERSUITES`.
+    ///
+    /// No ALPN protocols will be enabled, and client auth will be supported
+    /// by default. The default session persistence provider stores up to 32
     /// items in memory.
-    pub fn with_ciphersuites(ciphersuites: &[&'static SupportedCipherSuite]) -> ClientConfig {
-        ClientConfig {
+    #[cfg(feature = "dangerous_configuration")]
+    pub fn new_dangerous(
+        verifier: Arc<dyn verify::ServerCertVerifier>,
+        ciphersuites: &[&'static SupportedCipherSuite]) -> Self
+    {
+        Self::new_(verifier, ciphersuites)
+    }
+
+    fn new_(verifier: Arc<dyn verify::ServerCertVerifier>,
+            ciphersuites: &[&'static SupportedCipherSuite]) -> Self {
+        Self {
             ciphersuites: ciphersuites.to_vec(),
-            root_store: anchors::RootCertStore::empty(),
             alpn_protocols: Vec::new(),
             session_persistence: handy::ClientSessionMemoryCache::new(32),
             mtu: None,
@@ -164,7 +175,7 @@ impl ClientConfig {
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
             enable_sni: true,
-            verifier: Arc::new(verify::WebPKIVerifier::new(&[])),
+            verifier,
             key_log: Arc::new(NoKeyLog {}),
             enable_early_data: false,
         }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -21,7 +21,6 @@ use std::io::{self, IoSlice};
 use std::mem;
 use std::sync::Arc;
 
-use sct;
 use webpki;
 
 #[macro_use]
@@ -113,11 +112,6 @@ pub struct ClientConfig {
     /// is all supported versions.
     pub versions: Vec<ProtocolVersion>,
 
-    /// Collection of certificate transparency logs.
-    /// If this collection is empty, then certificate transparency
-    /// checking is disabled.
-    pub ct_logs: Option<&'static [&'static sct::Log<'static>]>,
-
     /// Whether to send the Server Name Indication (SNI) extension
     /// during the client handshake.
     ///
@@ -169,9 +163,8 @@ impl ClientConfig {
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
             enable_tickets: true,
             versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
-            ct_logs: None,
             enable_sni: true,
-            verifier: Arc::new(verify::WebPKIVerifier),
+            verifier: Arc::new(verify::WebPKIVerifier::new(&[])),
             key_log: Arc::new(NoKeyLog {}),
             enable_early_data: false,
         }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -565,7 +565,6 @@ impl hs::State for ExpectServerDone {
             .verify_server_cert(
                 end_entity,
                 intermediates,
-                &sess.config.root_store,
                 st.handshake.dns_name.as_ref(),
                 &mut st.server_cert.scts(),
                 &st.server_cert.ocsp_response,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -567,18 +567,11 @@ impl hs::State for ExpectServerDone {
                 intermediates,
                 &sess.config.root_store,
                 st.handshake.dns_name.as_ref(),
+                &mut st.server_cert.scts(),
                 &st.server_cert.ocsp_response,
                 now,
             )
             .map_err(|err| hs::send_cert_error_alert(sess, err))?;
-
-        // 2. Verify any included SCTs.
-        match (st.server_cert.scts.as_ref(), sess.config.ct_logs) {
-            (Some(scts), Some(logs)) => {
-                verify::verify_scts(&st.server_cert.cert_chain[0], now, scts, logs)?;
-            }
-            (_, _) => {}
-        }
 
         // 3.
         // Build up the contents of the signed message.

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -687,7 +687,6 @@ impl hs::State for ExpectCertificateVerify {
             .verify_server_cert(
                 end_entity,
                 intermediates,
-                &sess.config.root_store,
                 self.handshake.dns_name.as_ref(),
                 &mut self.server_cert.scts(),
                 &self.server_cert.ocsp_response,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -92,19 +92,24 @@
 //! ## Getting started
 //! This is the minimum you need to do to make a TLS client connection.
 //!
-//! First, we make a `ClientConfig`.  You're likely to make one of these per process,
-//! and use it for all connections made by that process.
-//!
-//! ```
-//! let mut config = rustls::ClientConfig::new();
-//! ```
-//!
-//! Next we load some root certificates.  These are used to authenticate the server.
+//! First we load some root certificates.  These are used to authenticate the server.
 //! The recommended way is to depend on the `webpki_roots` crate which contains
 //! the Mozilla set of root certificates.
 //!
 //! ```rust,ignore
-//! config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+//! let mut root_store = rustls::RootCertStore::empty();
+//! root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+//! let trusted_ct_logs = &[];
+//! ```
+//!
+//! Next, we make a `ClientConfig`.  You're likely to make one of these per process,
+//! and use it for all connections made by that process.
+//!
+//! ```rust,ignore
+//! let config = rustls::ClientConfig::new(
+//!     root_store,
+//!     trusted_ct_logs,
+//!     rustls::DEFAULT_CIPHERSUITES);
 //! ```
 //!
 //! Now we can make a session.  You need to provide the server's hostname so we
@@ -114,7 +119,13 @@
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
-//! # let mut config = rustls::ClientConfig::new();
+//! # let mut root_store = rustls::RootCertStore::empty();
+//! # root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+//! # let trusted_ct_logs = &[];
+//! # let config = rustls::ClientConfig::new(
+//! #     root_store,
+//! #     trusted_ct_logs,
+//! #     rustls::DEFAULT_CIPHERSUITES);
 //! let rc_config = Arc::new(config);
 //! let example_com = webpki::DNSNameRef::try_from_ascii_str("example.com").unwrap();
 //! let mut client = rustls::ClientSession::new(&rc_config, example_com);
@@ -276,7 +287,7 @@ pub use crate::server::{ClientHello, ProducesTickets, ResolvesServerCert};
 pub use crate::server::{ServerConfig, ServerSession};
 pub use crate::session::Session;
 pub use crate::stream::{Stream, StreamOwned};
-pub use crate::suites::{BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES};
+pub use crate::suites::{BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES, DEFAULT_CIPHERSUITES};
 pub use crate::ticketer::Ticketer;
 pub use crate::verify::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -10,7 +10,7 @@ use crate::msgs::handshake::ServerExtension;
 use crate::msgs::message::Message;
 use crate::session::{MiddleboxCCS, Session, SessionCommon};
 use crate::sign;
-use crate::suites::{SupportedCipherSuite, ALL_CIPHERSUITES};
+use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHERSUITES};
 use crate::verify;
 
 use webpki;
@@ -207,7 +207,7 @@ impl ServerConfig {
     /// default, requiring client authentication, requires additional
     /// configuration that we cannot provide reasonable defaults for.
     pub fn new(client_cert_verifier: Arc<dyn verify::ClientCertVerifier>) -> ServerConfig {
-        ServerConfig::with_ciphersuites(client_cert_verifier, &ALL_CIPHERSUITES)
+        ServerConfig::with_ciphersuites(client_cert_verifier, DEFAULT_CIPHERSUITES)
     }
 
     /// Make a `ServerConfig` with a custom set of ciphersuites,

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -437,7 +437,7 @@ pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite
 };
 
 /// A list of all the cipher suites supported by rustls.
-pub static ALL_CIPHERSUITES: [&SupportedCipherSuite; 9] = [
+pub static ALL_CIPHERSUITES: &[&SupportedCipherSuite] = &[
     // TLS1.3 suites
     &TLS13_AES_256_GCM_SHA384,
     &TLS13_AES_128_GCM_SHA256,
@@ -451,6 +451,12 @@ pub static ALL_CIPHERSUITES: [&SupportedCipherSuite; 9] = [
     &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     &TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
+
+/// The cipher suite configuration that an application should use by default.
+///
+/// This will be `ALL_CIPHERSUITES` sans any supported cipher suites that
+/// shouldn't be enabled by most applications.
+pub static DEFAULT_CIPHERSUITES: &[&SupportedCipherSuite] = ALL_CIPHERSUITES;
 
 // These both O(N^2)!
 pub fn choose_ciphersuite_preferring_client(
@@ -558,14 +564,14 @@ mod test {
         assert!(
             choose_ciphersuite_preferring_client(
                 &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-                &ALL_CIPHERSUITES
+                ALL_CIPHERSUITES
             )
             .is_none()
         );
         assert!(
             choose_ciphersuite_preferring_server(
                 &[CipherSuite::TLS_NULL_WITH_NULL_NULL],
-                &ALL_CIPHERSUITES
+                ALL_CIPHERSUITES
             )
             .is_none()
         );

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -12,7 +12,6 @@ use crate::key::Certificate;
 use crate::log::{debug, trace, warn};
 use crate::msgs::enums::SignatureScheme;
 use crate::msgs::handshake::DigitallySignedStruct;
-use crate::msgs::handshake::SCTList;
 use ring::digest::Digest;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];
@@ -86,12 +85,16 @@ pub trait ServerCertVerifier: Send + Sync {
     /// `intermediates` contains the intermediate certificates the client sent
     /// along with the end-entity certificate; it is in the same order that the
     /// peer sent them and may be empty.
+    ///
+    /// `scts` contains the Signed Certificate Timestamps (SCTs) the server
+    /// sent with the certificate, if any.
     fn verify_server_cert(
         &self,
         end_entity: &Certificate,
         intermediates: &[Certificate],
         roots: &RootCertStore,
         dns_name: webpki::DNSNameRef,
+        scts: &mut dyn Iterator<Item=&[u8]>,
         ocsp_response: &[u8],
         now: SystemTime,
     ) -> Result<ServerCertVerified, TLSError>;
@@ -153,6 +156,16 @@ pub trait ServerCertVerifier: Send + Sync {
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
         WebPKIVerifier::verification_schemes()
+    }
+
+    /// Returns `true` if Rustls should ask the server to send SCTs.
+    ///
+    /// Signed Certificate Timestamps (SCTs) are used for Certificate
+    /// Transparency validation.
+    ///
+    /// The default implementation of this function returns true.
+    fn request_scts(&self) -> bool {
+        true
     }
 }
 
@@ -276,21 +289,26 @@ impl ServerCertVerifier for WebPKIVerifier {
         intermediates: &[Certificate],
         roots: &RootCertStore,
         dns_name: webpki::DNSNameRef,
+        scts: &mut dyn Iterator<Item=&[u8]>,
         ocsp_response: &[u8],
         now: SystemTime,
     ) -> Result<ServerCertVerified, TLSError> {
         let (cert, chain, trustroots) = prepare(end_entity, intermediates, roots)?;
-        let now = webpki::Time::try_from(now).map_err(|_| TLSError::FailedToGetCurrentTime)?;
+        let webpki_now = webpki::Time::try_from(now)
+            .map_err(|_| TLSError::FailedToGetCurrentTime)?;
 
         let cert = cert
             .verify_is_valid_tls_server_cert(
                 SUPPORTED_SIG_ALGS,
                 &webpki::TLSServerTrustAnchors(&trustroots),
                 &chain,
-                now,
+                webpki_now,
             )
             .map_err(TLSError::WebPKIError)
             .map(|_| cert)?;
+
+        // 3. Verify any included SCTs.
+        verify_scts(end_entity, now, scts, &self.ct_logs)?;
 
         if !ocsp_response.is_empty() {
             trace!("Unvalidated OCSP response: {:?}", ocsp_response.to_vec());
@@ -303,9 +321,22 @@ impl ServerCertVerifier for WebPKIVerifier {
 }
 
 /// Default `ServerCertVerifier`, see the trait impl for more information.
-pub struct WebPKIVerifier;
+pub struct WebPKIVerifier {
+    ct_logs: &'static [&'static sct::Log<'static>],
+}
 
 impl WebPKIVerifier {
+    /// Constructs a new `WebPKIVerifier`.
+    ///
+    /// `ct_logs` is the list of logs that are trusted for Certificate
+    /// Transparency. Currently CT log enforcement is opportunistic; see
+    /// https://github.com/ctz/rustls/issues/479.
+    pub fn new(ct_logs: &'static [&'static sct::Log<'static>]) -> Self {
+        Self {
+            ct_logs
+        }
+    }
+
     /// Returns the signature verification methods supported by
     /// webpki.
     pub fn verification_schemes() -> Vec<SignatureScheme> {
@@ -613,20 +644,26 @@ fn unix_time_millis(now: SystemTime) -> Result<u64, TLSError> {
         })
 }
 
-pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[&sct::Log]) -> Result<(), TLSError> {
-    let mut valid_scts = 0;
+fn verify_scts(cert: &Certificate,
+               now: SystemTime,
+               scts: &mut dyn Iterator<Item=&[u8]>, logs: &[&sct::Log])
+    -> Result<(), TLSError>
+{
+    if logs.is_empty() {
+        return Ok(());
+    }
+
     let now = unix_time_millis(now)?;
     let mut last_sct_error = None;
-
     for sct in scts {
         #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-        match sct::verify_sct(&cert.0, &sct.0, now, logs) {
+        match sct::verify_sct(&cert.0, sct, now, logs) {
             Ok(index) => {
                 debug!(
                     "Valid SCT signed by {} on {}",
                     logs[index].operated_by, logs[index].description
                 );
-                valid_scts += 1;
+                return Ok(());
             }
             Err(e) => {
                 if e.should_be_fatal() {
@@ -640,9 +677,9 @@ pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[
 
     /* If we were supplied with some logs, and some SCTs,
      * but couldn't verify any of them, fail the handshake. */
-    if !logs.is_empty() && !scts.is_empty() && valid_scts == 0 {
+    if let Some(last_sct_error) = last_sct_error {
         warn!("No valid SCTs provided");
-        return Err(TLSError::InvalidSCT(last_sct_error.unwrap()));
+        return Err(TLSError::InvalidSCT(last_sct_error));
     }
 
     Ok(())

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -18,8 +18,6 @@ fn duration_nanos(d: Duration) -> u64 {
     ((d.as_secs() as f64) * 1e9 + (d.subsec_nanos() as f64)) as u64
 }
 
-static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier;
-
 #[test]
 fn test_reddit_cert() {
     Context::new(
@@ -192,13 +190,23 @@ impl Context {
     }
 
     fn bench(&self, count: usize) {
+        let verifier = verify::WebPKIVerifier::new(&[]);
+        const SCTS: &[&[u8]] = &[];
+        const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();
 
         let (end_entity, intermediates) = self.chain.split_first().unwrap();
         for _ in 0..count {
             let start = Instant::now();
             let dns_name = webpki::DNSNameRef::try_from_ascii_str(self.domain).unwrap();
-            V.verify_server_cert(end_entity, intermediates, &self.roots, dns_name, &[], self.now)
+            verifier.verify_server_cert(
+                end_entity,
+                intermediates,
+                &self.roots,
+                dns_name,
+                &mut SCTS.iter().copied(),
+                OCSP_RESPONSE,
+                self.now)
                 .unwrap();
             times.push(duration_nanos(Instant::now().duration_since(start)));
         }

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -190,7 +190,7 @@ impl Context {
     }
 
     fn bench(&self, count: usize) {
-        let verifier = verify::WebPKIVerifier::new(&[]);
+        let verifier = verify::WebPKIVerifier::new(self.roots.clone(),&[]);
         const SCTS: &[&[u8]] = &[];
         const OCSP_RESPONSE: &[u8] = &[];
         let mut times = Vec::new();
@@ -202,7 +202,6 @@ impl Context {
             verifier.verify_server_cert(
                 end_entity,
                 intermediates,
-                &self.roots,
                 dns_name,
                 &mut SCTS.iter().copied(),
                 OCSP_RESPONSE,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2907,6 +2907,5 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
 
 #[test]
 fn test_ownedtrustanchor_to_trust_anchor_is_public() {
-    let client_config = make_client_config(KeyType::RSA);
-    let _anchor: webpki::TrustAnchor = client_config.root_store.roots[0].to_trust_anchor();
+    let _ = rustls::OwnedTrustAnchor::to_trust_anchor;
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -5,7 +5,7 @@ use rustls;
 use rustls_pemfile;
 
 use rustls::internal::msgs::{codec::Codec, codec::Reader, message::Message};
-use rustls::ProtocolVersion;
+use rustls::{ProtocolVersion, DEFAULT_CIPHERSUITES};
 use rustls::Session;
 use rustls::TLSError;
 use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore};
@@ -234,12 +234,11 @@ pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfi
 }
 
 pub fn make_client_config(kt: KeyType) -> ClientConfig {
-    let mut cfg = ClientConfig::new();
+    let mut root_store = RootCertStore::empty();
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
-    cfg.root_store
+    root_store
         .add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
-
-    cfg
+    ClientConfig::new(root_store, &[], DEFAULT_CIPHERSUITES)
 }
 
 pub fn make_client_config_with_auth(kt: KeyType) -> ClientConfig {


### PR DESCRIPTION
When an alternate certificate verifier is used, Rustls old CT log and root
configuration was likely irrelevant to it. In particular, a system
certificate verifier will likely have its own settings set at the system
and/or user level. Move those fields out of `ClientConfig` to ensure they
are not used in that situation, and to avoid users wrongly expecting the
custom verifier to use these settings.

Change the API for constructing `ClientConfig` so that one can still
configure the list of CT logs and roots for the default verifier only.

To avoid starting an explosion in the number of `ClientConfig`
constructors, require the user to pass in the desired cipher suites to
each constructor. Document that the new `DEFAULT_CIPHERSUITES` should be
used to select the default values.

Hide the number of cipher suites in `ALL_CIPHERSUITES` from the type by
making it a slice, so that adding a cipher suite to `ALL_CIPHERSUITES` is
no longer an API breaking change.

Pass the SCTs received from the server to the verifier during verification.

Do not do any SCT verification in the handshake, beyond what the
verifier is now expected to do.

Fixes issue #480.