### PR TITLE
Client: Always randomize session ID unless doing legacy resumption.

### DIFF
--- a/bogo/config.json
+++ b/bogo/config.json
@@ -1,6 +1,5 @@
 {
   "DisabledTests": {
-    "TLS13SessionID-TLS13": "FIXME!",
     "SendV2ClientHello-*": "only support TLS1.2",
     "*SSL3*": "",
     "*SSLv3*": "",


### PR DESCRIPTION
This fixes the TLS13SessionID-TLS13 Bogo test, so enable it.

Inline `random_sessionid_for_ticket` into its caller so all the
session ID calculation is in one spot.