### PR TITLE
Store `SupportedCipherSuite` in `ClientSessionValue`.

### DIFF
--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -433,13 +433,7 @@ impl ClientSessionImpl {
     }
 
     pub fn find_cipher_suite(&self, suite: CipherSuite) -> Option<&'static SupportedCipherSuite> {
-        for scs in &self.config.ciphersuites {
-            if scs.suite == suite {
-                return Some(scs);
-            }
-        }
-
-        None
+        self.config.ciphersuites.iter().copied().find(|&scs| scs.suite == suite)
     }
 
     pub fn wants_read(&self) -> bool {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -773,7 +773,7 @@ fn save_session(
     let master_secret = secrets.get_master_secret();
     let mut value = persist::ClientSessionValue::new(
         ProtocolVersion::TLSv1_2,
-        secrets.suite().suite,
+        secrets.suite(),
         &handshake.session_id,
         ticket,
         master_secret,

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -4,6 +4,7 @@ use super::handshake::*;
 use super::persist::*;
 use crate::key::Certificate;
 use webpki::DNSNameRef;
+use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
 
 #[test]
 fn clientsessionkey_is_debug() {
@@ -23,7 +24,7 @@ fn clientsessionkey_cannot_be_read() {
 fn clientsessionvalue_is_debug() {
     let csv = ClientSessionValue::new(
         ProtocolVersion::TLSv1_2,
-        CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         &SessionID::new(&[1u8]),
         vec![],
         vec![1, 2, 3],


### PR DESCRIPTION
Do the mapping to `SupportedCipherSuite` at the time `ClientSessionValue` is
constructed so that we don't have to look it up all the time. This eliminates
some unwrapping.

Simplify the implementation of `find_cipher_suite` to match what is done during
`ClientSessionValue` decoding.