### PR TITLE
Client: Remove `sent_tls13_fake_ccs` from `HandshakeDetails`.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -58,7 +58,6 @@ pub struct HandshakeDetails {
     pub randoms: SessionRandoms,
     pub using_ems: bool,
     pub session_id: SessionID,
-    pub sent_tls13_fake_ccs: bool,
     pub dns_name: webpki::DNSName,
 }
 
@@ -70,7 +69,6 @@ impl HandshakeDetails {
             randoms: SessionRandoms::for_client(),
             using_ems: false,
             session_id: SessionID::empty(),
-            sent_tls13_fake_ccs: false,
             dns_name: host_name,
         }
     }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -168,7 +168,14 @@ impl InitialState {
         }
 
         let hello_details = ClientHelloDetails::new();
-        emit_client_hello_for_retry(sess, self.handshake, hello_details, None, self.extra_exts)
+        let sent_tls13_fake_ccs = false;
+        emit_client_hello_for_retry(
+            sess,
+            self.handshake,
+            sent_tls13_fake_ccs,
+            hello_details,
+            None,
+            self.extra_exts)
     }
 }
 
@@ -184,6 +191,7 @@ struct ExpectServerHello {
     handshake: HandshakeDetails,
     early_key_schedule: Option<KeyScheduleEarly>,
     hello: ClientHelloDetails,
+    sent_tls13_fake_ccs: bool,
 }
 
 struct ExpectServerHelloOrHelloRetryRequest {
@@ -204,6 +212,7 @@ pub fn compatible_suite(
 fn emit_client_hello_for_retry(
     sess: &mut ClientSessionImpl,
     mut handshake: HandshakeDetails,
+    mut sent_tls13_fake_ccs: bool,
     mut hello: ClientHelloDetails,
     retryreq: Option<&HelloRetryRequest>,
     extra_exts: Vec<ClientExtension>,
@@ -351,7 +360,7 @@ fn emit_client_hello_for_retry(
     if retryreq.is_some() {
         // send dummy CCS to fool middleboxes prior
         // to second client hello
-        tls13::emit_fake_ccs(&mut handshake, sess);
+        tls13::emit_fake_ccs(&mut sent_tls13_fake_ccs, sess);
     }
 
     trace!("Sending ClientHello {:#?}", ch);
@@ -362,7 +371,7 @@ fn emit_client_hello_for_retry(
     // Calculate the hash of ClientHello and use it to derive EarlyTrafficSecret
     if sess.early_data.is_enabled() {
         // For middlebox compatibility
-        tls13::emit_fake_ccs(&mut handshake, sess);
+        tls13::emit_fake_ccs(&mut sent_tls13_fake_ccs, sess);
 
         // It is safe to call unwrap() because fill_in_binder is true.
         let resuming_suite = handshake
@@ -404,6 +413,7 @@ fn emit_client_hello_for_retry(
         handshake,
         hello,
         early_key_schedule,
+        sent_tls13_fake_ccs,
     };
 
     if support_tls13 && retryreq.is_none() {
@@ -639,7 +649,7 @@ impl State for ExpectServerHello {
                 &mut self.handshake,
                 &mut self.hello,
             )?;
-            tls13::emit_fake_ccs(&mut self.handshake, sess);
+            tls13::emit_fake_ccs(&mut self.sent_tls13_fake_ccs, sess);
             return Ok(self.into_expect_tls13_encrypted_extensions(key_schedule, hash_at_client_recvd_server_hello));
         }
 
@@ -869,6 +879,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         Ok(emit_client_hello_for_retry(
             sess,
             self.next.handshake,
+            self.next.sent_tls13_fake_ccs,
             self.next.hello,
             Some(&hrr),
             self.extra_exts,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -335,12 +335,12 @@ pub fn prepare_resumption(
     true
 }
 
-pub fn emit_fake_ccs(hs: &mut HandshakeDetails, sess: &mut ClientSessionImpl) {
+pub fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, sess: &mut ClientSessionImpl) {
     if sess.common.is_quic() {
         return;
     }
 
-    if hs.sent_tls13_fake_ccs {
+    if std::mem::replace(sent_tls13_fake_ccs, true) {
         return;
     }
 
@@ -350,7 +350,6 @@ pub fn emit_fake_ccs(hs: &mut HandshakeDetails, sess: &mut ClientSessionImpl) {
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
     };
     sess.common.send_msg(m, false);
-    hs.sent_tls13_fake_ccs = true;
 }
 
 fn validate_encrypted_extensions(


### PR DESCRIPTION
It is only used by the client, so it shouldn't be in `HandshakeDetails`, which
is shared between the client and the server. Further, it is only used for the
initial messages, so there's no need to store it for the whole handshake.

This refactoring enables further refactorings to clarify the state machine. In
particular, this allows us to clear up the unwrapping logic related to
`fill_in_psk_binder`, but this is also useful for other refactorings, including
the ECH implementation.