### PR TITLE
Client: Implement slightly better eviction logic for session cache.

### DIFF
--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -23,6 +23,7 @@ use rustls::{ServerConfig, ServerSession};
 use rustls_pemfile;
 
 use webpki;
+use std::num::NonZeroUsize;
 
 fn duration_nanos(d: Duration) -> f64 {
     (d.as_secs() as f64) + f64::from(d.subsec_nanos()) / 1e9
@@ -329,7 +330,7 @@ fn make_client_config(
     }
 
     if resume != Resumption::No {
-        cfg.set_persistence(ClientSessionMemoryCache::new(128));
+        cfg.set_persistence(ClientSessionMemoryCache::new(NonZeroUsize::new(128).unwrap()));
     } else {
         cfg.set_persistence(Arc::new(NoClientSessionStorage {}));
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -24,6 +24,7 @@ use std::ops::{Deref, DerefMut};
 use std::process;
 use std::sync::Arc;
 use std::time::SystemTime;
+use std::num::NonZeroUsize;
 
 static BOGO_NACK: i32 = 89;
 
@@ -373,7 +374,7 @@ struct ClientCacheWithoutKxHints(Arc<rustls::ClientSessionMemoryCache>);
 impl ClientCacheWithoutKxHints {
     fn new() -> Arc<ClientCacheWithoutKxHints> {
         Arc::new(ClientCacheWithoutKxHints(
-            rustls::ClientSessionMemoryCache::new(32),
+            rustls::ClientSessionMemoryCache::new(NonZeroUsize::new(32).unwrap()),
         ))
     }
 }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 
 use sct;
 use webpki;
+use std::num::NonZeroUsize;
 
 #[macro_use]
 mod hs;
@@ -164,7 +165,7 @@ impl ClientConfig {
             ciphersuites: ciphersuites.to_vec(),
             root_store: anchors::RootCertStore::empty(),
             alpn_protocols: Vec::new(),
-            session_persistence: handy::ClientSessionMemoryCache::new(32),
+            session_persistence: handy::ClientSessionMemoryCache::new(NonZeroUsize::new(32).unwrap()),
             mtu: None,
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
             enable_tickets: true,


### PR DESCRIPTION
Never evict an unrelated entry from the cache when replacing an entry
with the same key.

Reduce the number of lock acquisitions per insertion from 2 to 1.

Improve the type of the capacity of the cache to guarantee avoidance of
underflows.