### PR TITLE
Refactor ExpectClientKX to inline methods to avoid unwrapping state

### DIFF
--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -30,16 +30,12 @@ impl HandshakeDetails {
 }
 
 pub struct ServerKXDetails {
-    pub kx: Option<kx::KeyExchange>,
+    pub kx: kx::KeyExchange,
 }
 
 impl ServerKXDetails {
     pub fn new(kx: kx::KeyExchange) -> ServerKXDetails {
-        ServerKXDetails { kx: Some(kx) }
-    }
-
-    pub fn take_kx(&mut self) -> kx::KeyExchange {
-        self.kx.take().unwrap()
+        ServerKXDetails { kx }
     }
 }
 


### PR DESCRIPTION
Based on the idea presented by @briansmith [in this comment](https://github.com/ctz/rustls/pull/536#discussion_r581680900). This lets `self` be taken apart by value instead of relying on `Option::take`.