### PR TITLE
WIP: ECH Draft-09 serialization code

### DIFF
--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -80,6 +80,10 @@ impl PayloadU16 {
         (slice.len() as u16).encode(bytes);
         bytes.extend_from_slice(slice);
     }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
 }
 
 impl Codec for PayloadU16 {

--- a/rustls/src/msgs/ech_test.rs
+++ b/rustls/src/msgs/ech_test.rs
@@ -1,0 +1,16 @@
+use base64;
+use crate::msgs::codec::{Codec, Reader};
+use crate::msgs::handshake::ECHConfigs;
+
+#[test]
+fn test_echconfig_serialization() {
+    // An ECHConfig record from Cloudflare for
+    let base64_esni = "AEf+CQBDABNjbG91ZGZsYXJlLWVzbmkuY29tACCD91Ovu3frIsjhFKo0I1fPd/a09nzKMrjC9GZV3NvrfQAgAAQAAQABAAAAAA==";
+    let bytes = base64::decode(&base64_esni).unwrap();
+    let records = ECHConfigs::read(&mut Reader::init(&bytes)).unwrap();
+    let name = String::from_utf8(records[0].contents.public_name.clone().into_inner()).unwrap();
+    assert_eq!("cloudflare-esni.com", name.as_str());
+    let mut output = Vec::new();
+    records.encode(&mut output);
+    assert_eq!(base64_esni, base64::encode(&output));
+}

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -790,3 +790,12 @@ enum_builder! {
         OCSP => 0x01
     }
 }
+
+enum_builder! {
+    /// The `ECH` protocol version.
+    @U16
+    EnumName: ECHVersion;
+    EnumVal{
+        V9 => 0xfe09
+    }
+}

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -28,6 +28,9 @@ mod enums_test;
 mod message_test;
 
 #[cfg(test)]
+mod ech_test;
+
+#[cfg(test)]
 mod test {
     #[test]
     fn smoketest() {


### PR DESCRIPTION
In the interest of sharing early and often, here's code that serializes and deserializes ECH draft-09 ECHConfig records. The test record is from a live server at crypto.cloudflare.com. Part of addressing #508.

The next step is to add a little demo Trust-DNS client that pulls this record and parses it. I'll add the SVCB/HTTPS-RR code to Trust-DNS if need be.

After that, I think I'll start prototyping with the rust-hpke crate, since it has the older HPKE code needed for draft-09. I don't really think ring should bother with it, and instead just focus on the newest HPKE draft.

cc @djc @briansmith @ctz 