### PR TITLE
Support stable QUIC transport parameters handshake extension

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -11,6 +11,7 @@ use sct;
 use webpki;
 
 use rustls::internal::msgs::enums::ProtocolVersion;
+use rustls::quic;
 use rustls::quic::ClientQuicExt;
 use rustls::quic::ServerQuicExt;
 use rustls::ClientHello;
@@ -1041,6 +1042,7 @@ fn main() {
             } else {
                 rustls::ServerSession::new_quic(
                     scfg.as_ref().unwrap(),
+                    quic::Version::V1,
                     opts.quic_transport_params.clone(),
                 )
             };
@@ -1052,6 +1054,7 @@ fn main() {
             } else {
                 rustls::ClientSession::new_quic(
                     ccfg.as_ref().unwrap(),
+                    quic::Version::V1,
                     dns_name,
                     opts.quic_transport_params.clone(),
                 )

--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -233,10 +233,11 @@ enum_builder! {
         PostHandshakeAuth => 0x0031,
         SignatureAlgorithmsCert => 0x0032,
         KeyShare => 0x0033,
+        TransportParameters => 0x0039,
         NextProtocolNegotiation => 0x3374,
         ChannelId => 0x754f,
         RenegotiationInfo => 0xff01,
-        TransportParameters => 0xffa5
+        TransportParametersDraft => 0xffa5
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -562,6 +562,7 @@ pub enum ClientExtension {
     CertificateStatusRequest(CertificateStatusRequest),
     SignedCertificateTimestampRequest,
     TransportParameters(Vec<u8>),
+    TransportParametersDraft(Vec<u8>),
     EarlyData,
     Unknown(UnknownExtension),
 }
@@ -586,6 +587,7 @@ impl ClientExtension {
             ClientExtension::CertificateStatusRequest(_) => ExtensionType::StatusRequest,
             ClientExtension::SignedCertificateTimestampRequest => ExtensionType::SCT,
             ClientExtension::TransportParameters(_) => ExtensionType::TransportParameters,
+            ClientExtension::TransportParametersDraft(_) => ExtensionType::TransportParametersDraft,
             ClientExtension::EarlyData => ExtensionType::EarlyData,
             ClientExtension::Unknown(ref r) => r.typ,
         }
@@ -614,7 +616,8 @@ impl Codec for ClientExtension {
             ClientExtension::PresharedKey(ref r) => r.encode(&mut sub),
             ClientExtension::Cookie(ref r) => r.encode(&mut sub),
             ClientExtension::CertificateStatusRequest(ref r) => r.encode(&mut sub),
-            ClientExtension::TransportParameters(ref r) => sub.extend_from_slice(r),
+            ClientExtension::TransportParameters(ref r)
+            | ClientExtension::TransportParametersDraft(ref r) => sub.extend_from_slice(r),
             ClientExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 
@@ -676,6 +679,9 @@ impl Codec for ClientExtension {
             ExtensionType::TransportParameters => {
                 ClientExtension::TransportParameters(sub.rest().to_vec())
             }
+            ExtensionType::TransportParametersDraft => {
+                ClientExtension::TransportParametersDraft(sub.rest().to_vec())
+            }
             ExtensionType::EarlyData if !sub.any_left() => ClientExtension::EarlyData,
             _ => ClientExtension::Unknown(UnknownExtension::read(typ, &mut sub)?),
         })
@@ -723,6 +729,7 @@ pub enum ServerExtension {
     SignedCertificateTimestamp(SCTList),
     SupportedVersions(ProtocolVersion),
     TransportParameters(Vec<u8>),
+    TransportParametersDraft(Vec<u8>),
     EarlyData,
     Unknown(UnknownExtension),
 }
@@ -742,6 +749,7 @@ impl ServerExtension {
             ServerExtension::SignedCertificateTimestamp(_) => ExtensionType::SCT,
             ServerExtension::SupportedVersions(_) => ExtensionType::SupportedVersions,
             ServerExtension::TransportParameters(_) => ExtensionType::TransportParameters,
+            ServerExtension::TransportParametersDraft(_) => ExtensionType::TransportParametersDraft,
             ServerExtension::EarlyData => ExtensionType::EarlyData,
             ServerExtension::Unknown(ref r) => r.typ,
         }
@@ -766,7 +774,8 @@ impl Codec for ServerExtension {
             ServerExtension::PresharedKey(r) => r.encode(&mut sub),
             ServerExtension::SignedCertificateTimestamp(ref r) => r.encode(&mut sub),
             ServerExtension::SupportedVersions(ref r) => r.encode(&mut sub),
-            ServerExtension::TransportParameters(ref r) => sub.extend_from_slice(r),
+            ServerExtension::TransportParameters(ref r)
+            | ServerExtension::TransportParametersDraft(ref r) => sub.extend_from_slice(r),
             ServerExtension::Unknown(ref r) => r.encode(&mut sub),
         }
 
@@ -804,6 +813,9 @@ impl Codec for ServerExtension {
             }
             ExtensionType::TransportParameters => {
                 ServerExtension::TransportParameters(sub.rest().to_vec())
+            }
+            ExtensionType::TransportParametersDraft => {
+                ServerExtension::TransportParametersDraft(sub.rest().to_vec())
             }
             ExtensionType::EarlyData => ServerExtension::EarlyData,
             _ => ServerExtension::Unknown(UnknownExtension::read(typ, &mut sub)?),
@@ -933,9 +945,12 @@ impl ClientHelloPayload {
     }
 
     pub fn get_quic_params_extension(&self) -> Option<Vec<u8>> {
-        let ext = self.find_extension(ExtensionType::TransportParameters)?;
+        let ext = self
+            .find_extension(ExtensionType::TransportParameters)
+            .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;
         match *ext {
-            ClientExtension::TransportParameters(ref bytes) => Some(bytes.to_vec()),
+            ClientExtension::TransportParameters(ref bytes)
+            | ClientExtension::TransportParametersDraft(ref bytes) => Some(bytes.to_vec()),
             _ => None,
         }
     }
@@ -1739,9 +1754,12 @@ pub trait HasServerExtensions {
     }
 
     fn get_quic_params_extension(&self) -> Option<Vec<u8>> {
-        let ext = self.find_extension(ExtensionType::TransportParameters)?;
+        let ext = self
+            .find_extension(ExtensionType::TransportParameters)
+            .or_else(|| self.find_extension(ExtensionType::TransportParametersDraft))?;
         match *ext {
-            ServerExtension::TransportParameters(ref bytes) => Some(bytes.to_vec()),
+            ServerExtension::TransportParameters(ref bytes)
+            | ServerExtension::TransportParametersDraft(ref bytes) => Some(bytes.to_vec()),
             _ => None,
         }
     }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2573,8 +2573,8 @@ mod test_quic {
 
         // full handshake
         let mut client =
-            ClientSession::new_quic(&client_config, dns_name("localhost"), client_params.into());
-        let mut server = ServerSession::new_quic(&server_config, server_params.into());
+            ClientSession::new_quic(&client_config, quic::Version::V1, dns_name("localhost"), client_params.into());
+        let mut server = ServerSession::new_quic(&server_config, quic::Version::V1, server_params.into());
         let client_initial = step(&mut client, &mut server).unwrap();
         assert!(client_initial.is_none());
         assert!(client.get_0rtt_keys().is_none());
@@ -2613,13 +2613,13 @@ mod test_quic {
 
         // 0-RTT handshake
         let mut client =
-            ClientSession::new_quic(&client_config, dns_name("localhost"), client_params.into());
+            ClientSession::new_quic(&client_config, quic::Version::V1, dns_name("localhost"), client_params.into());
         assert!(
             client
                 .get_negotiated_ciphersuite()
                 .is_some()
         );
-        let mut server = ServerSession::new_quic(&server_config, server_params.into());
+        let mut server = ServerSession::new_quic(&server_config, quic::Version::V1, server_params.into());
         step(&mut client, &mut server).unwrap();
         assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
         {
@@ -2644,10 +2644,11 @@ mod test_quic {
             client_config.alpn_protocols = vec!["foo".into()];
             let mut client = ClientSession::new_quic(
                 &Arc::new(client_config),
+                quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
             );
-            let mut server = ServerSession::new_quic(&server_config, server_params.into());
+            let mut server = ServerSession::new_quic(&server_config, quic::Version::V1, server_params.into());
             step(&mut client, &mut server).unwrap();
             assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
             assert!(client.get_0rtt_keys().is_some());
@@ -2667,10 +2668,11 @@ mod test_quic {
         // failed handshake
         let mut client = ClientSession::new_quic(
             &client_config,
+            quic::Version::V1,
             dns_name("example.com"),
             client_params.into(),
         );
-        let mut server = ServerSession::new_quic(&server_config, server_params.into());
+        let mut server = ServerSession::new_quic(&server_config, quic::Version::V1, server_params.into());
         step(&mut client, &mut server).unwrap();
         step(&mut server, &mut client)
             .unwrap()
@@ -2700,10 +2702,11 @@ mod test_quic {
 
             let mut client = ClientSession::new_quic(
                 &client_config,
+                quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
             );
-            let mut server = ServerSession::new_quic(&server_config, server_params.into());
+            let mut server = ServerSession::new_quic(&server_config, quic::Version::V1, server_params.into());
 
             assert_eq!(
                 step(&mut client, &mut server)


### PR DESCRIPTION
Preserves the prior extension for backwards-compatibility on the wire,
requiring an API tweak for the application to dictate which version to
be compatible with.