### PR TITLE
Document state machines and simplify client authentication flow

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -152,7 +152,6 @@ impl ReceivedTicketDetails {
 pub struct ClientAuthDetails {
     pub cert: Option<CertificatePayload>,
     pub signer: Option<Box<dyn sign::Signer>>,
-    pub auth_context: Option<Vec<u8>>,
 }
 
 impl ClientAuthDetails {
@@ -160,7 +159,6 @@ impl ClientAuthDetails {
         ClientAuthDetails {
             cert: None,
             signer: None,
-            auth_context: None,
         }
     }
 }

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -173,4 +173,8 @@ impl ClientAuthDetails {
             None => (None, None),
         }
     }
+
+    pub fn is_enabled(&self) -> bool {
+        self.0.is_some()
+    }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -284,13 +284,7 @@ fn emit_certverify(
     sess: &mut ClientSessionImpl,
 ) -> Result<(), TLSError> {
     let signer = match signer {
-        None => {
-            trace!("Not sending CertificateVerify, no key");
-            handshake
-                .transcript
-                .abandon_client_auth();
-            return Ok(());
-        },
+        None => return Ok(()),
         Some(signer) => {
             signer
         }
@@ -393,6 +387,10 @@ impl hs::State for ExpectCertificateRequest {
             .resolve(&canames, &certreq.sigschemes);
 
         let client_auth = ClientAuthDetails::from_key(maybe_certkey, &certreq.sigschemes);
+        if !client_auth.is_enabled() {
+            self.handshake.transcript.abandon_client_auth();
+        }
+
         Ok(Box::new(ExpectServerDone {
             handshake: self.handshake,
             suite: self.suite,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -785,18 +785,7 @@ impl hs::State for ExpectCertificateRequest {
             .client_auth_cert_resolver
             .resolve(&canames, &compat_sigschemes);
 
-        let mut client_auth = ClientAuthDetails::new();
-        if let Some(mut certkey) = maybe_certkey {
-            debug!("Attempting client auth");
-            let maybe_signer = certkey
-                .key
-                .choose_scheme(&compat_sigschemes);
-            client_auth.cert = Some(certkey.take_cert());
-            client_auth.signer = maybe_signer;
-        } else {
-            debug!("Client auth requested but no cert selected");
-        }
-
+        let client_auth = ClientAuthDetails::from_key(maybe_certkey, &compat_sigschemes);
         Ok(Box::new(ExpectCertificate {
             handshake: self.handshake,
             key_schedule: self.key_schedule,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -728,17 +728,6 @@ struct ExpectCertificateRequest {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl ExpectCertificateRequest {
-    fn into_expect_certificate(self, client_auth: ClientAuthDetails) -> hs::NextState {
-        Box::new(ExpectCertificate {
-            handshake: self.handshake,
-            key_schedule: self.key_schedule,
-            client_auth: Some(client_auth),
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
@@ -809,7 +798,12 @@ impl hs::State for ExpectCertificateRequest {
             debug!("Client auth requested but no cert selected");
         }
 
-        Ok(self.into_expect_certificate(client_auth))
+        Ok(Box::new(ExpectCertificate {
+            handshake: self.handshake,
+            key_schedule: self.key_schedule,
+            client_auth: Some(client_auth),
+            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+        }))
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -786,6 +786,10 @@ impl hs::State for ExpectCertificateRequest {
             .resolve(&canames, &compat_sigschemes);
 
         let client_auth = ClientAuthDetails::from_key(maybe_certkey, &compat_sigschemes);
+        if !client_auth.is_enabled() {
+            self.handshake.transcript.abandon_client_auth();
+        }
+
         Ok(Box::new(ExpectCertificate {
             handshake: self.handshake,
             key_schedule: self.key_schedule,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -793,7 +793,6 @@ impl hs::State for ExpectCertificateRequest {
                 .choose_scheme(&compat_sigschemes);
             client_auth.cert = Some(certkey.take_cert());
             client_auth.signer = maybe_signer;
-            client_auth.auth_context = Some(certreq.context.0.clone());
         } else {
             debug!("Client auth requested but no cert selected");
         }
@@ -812,13 +811,8 @@ fn emit_certificate_tls13(
     client_auth: &mut ClientAuthDetails,
     sess: &mut ClientSessionImpl,
 ) {
-    let context = client_auth
-        .auth_context
-        .take()
-        .unwrap_or_else(Vec::new);
-
     let mut cert_payload = CertificatePayloadTLS13 {
-        context: PayloadU8::new(context),
+        context: PayloadU8::new(Vec::new()),
         entries: Vec::new(),
     };
 
@@ -852,7 +846,7 @@ fn emit_certverify_tls13(
         None => {
             debug!("Skipping certverify message (no client scheme/key)");
             return Ok(());
-        } 
+        }
     };
 
     let message =


### PR DESCRIPTION
Tests fixed, scaled back the ambition a bit.

I tried to simplify the flow of the client authentication logic, but it proved a bit harder than expected. Still, I think this makes the invariants a little bit clearer than before.