### PR TITLE
client: thread transcript through handshake states

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,4 +1,3 @@
-use crate::hash_hs;
 #[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::enums::ExtensionType;
@@ -56,7 +55,6 @@ impl ServerKXDetails {
 
 pub struct HandshakeDetails {
     pub resuming_session: Option<persist::ClientSessionValue>,
-    pub transcript: hash_hs::HandshakeHash,
     pub session_id: SessionID,
     pub dns_name: webpki::DNSName,
 }
@@ -65,7 +63,6 @@ impl HandshakeDetails {
     pub fn new(host_name: webpki::DNSName) -> HandshakeDetails {
         HandshakeDetails {
             resuming_session: None,
-            transcript: hash_hs::HandshakeHash::new(),
             session_id: SessionID::empty(),
             dns_name: host_name,
         }

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -13,8 +13,6 @@ use crate::sign;
 use crate::kx;
 use webpki;
 
-use std::mem;
-
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
     pub ocsp_response: Vec<u8>,
@@ -30,10 +28,6 @@ impl ServerCertDetails {
             ocsp_response,
             scts,
         }
-    }
-
-    pub fn take_chain(&mut self) -> CertificatePayload {
-        mem::replace(&mut self.cert_chain, Vec::new())
     }
 
     pub fn scts(&self) -> impl Iterator<Item=&[u8]> {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -466,27 +466,6 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
     scts.is_empty() || scts.iter().any(|sct| sct.0.is_empty())
 }
 
-impl ExpectServerHello {
-    fn into_expect_tls12_certificate(
-        self,
-        suite: &'static SupportedCipherSuite,
-        may_send_cert_status: bool,
-        must_issue_new_ticket: bool,
-        server_cert_sct_list: Option<SCTList>)
-        -> NextState
-    {
-        Box::new(tls12::ExpectCertificate {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite,
-            may_send_cert_status,
-            must_issue_new_ticket,
-            server_cert_sct_list,
-        })
-    }
-}
-
 impl State for ExpectServerHello {
     fn handle(mut self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         let server_hello =
@@ -581,7 +560,7 @@ impl State for ExpectServerHello {
             }
         }
 
-        let scs = sess.find_cipher_suite(server_hello.cipher_suite)
+        let suite = sess.find_cipher_suite(server_hello.cipher_suite)
             .ok_or_else(|| {
                 sess.common
                     .send_fatal_alert(AlertDescription::HandshakeFailure);
@@ -590,11 +569,11 @@ impl State for ExpectServerHello {
             })?;
 
         debug!("Using ciphersuite {:?}", server_hello.cipher_suite);
-        if !sess.common.set_suite(scs) {
+        if !sess.common.set_suite(suite) {
             return Err(illegal_param(sess, "server varied selected ciphersuite"));
         }
 
-        if !scs.usable_for_version(version)
+        if !suite.usable_for_version(version)
         {
             return Err(illegal_param(
                 sess,
@@ -605,7 +584,7 @@ impl State for ExpectServerHello {
         // Start our handshake hash, and input the server-hello.
         self.handshake
             .transcript
-            .start_hash(scs.get_hash());
+            .start_hash(suite.get_hash());
         self.handshake
             .transcript
             .add_message(&m);
@@ -615,7 +594,7 @@ impl State for ExpectServerHello {
         if sess.common.is_tls13() {
             tls13::validate_server_hello(sess, &server_hello)?;
             let (key_schedule, hash_at_client_recvd_server_hello) = tls13::start_handshake_traffic(
-                scs,
+                suite,
                 sess,
                 self.early_key_schedule.take(),
                 &server_hello,
@@ -678,7 +657,7 @@ impl State for ExpectServerHello {
         }
 
         // Save any sent SCTs for verification against the certificate.
-        let server_cert_list_list =
+        let server_cert_sct_list =
             if let Some(sct_list) = server_hello.get_sct_list() {
             debug!("Server sent {:?} SCTs", sct_list.len());
 
@@ -697,7 +676,7 @@ impl State for ExpectServerHello {
                 debug!("Server agreed to resume");
 
                 // Is the server telling lies about the ciphersuite?
-                if resuming.suite != scs {
+                if resuming.suite != suite {
                     let error_msg = "abbreviated handshake offered, but with varied cs".to_string();
                     return Err(TlsError::PeerMisbehavedError(error_msg));
                 }
@@ -710,7 +689,7 @@ impl State for ExpectServerHello {
 
                 let secrets = SessionSecrets::new_resume(
                     &self.randoms,
-                    scs,
+                    suite,
                     &resuming.master_secret.0,
                 );
                 sess.config.key_log.log(
@@ -750,7 +729,15 @@ impl State for ExpectServerHello {
             }
         }
 
-        Ok(self.into_expect_tls12_certificate(scs, may_send_cert_status, must_issue_new_ticket, server_cert_list_list))
+        Ok(Box::new(tls12::ExpectCertificate {
+            handshake: self.handshake,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            suite,
+            may_send_cert_status,
+            must_issue_new_ticket,
+            server_cert_sct_list,
+        }))
     }
 }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -4,6 +4,7 @@ use crate::check::check_message;
 use crate::{cipher, SupportedCipherSuite};
 use crate::client::ClientSessionImpl;
 use crate::error::TlsError;
+use crate::hash_hs::HandshakeHash;
 use crate::key_schedule::KeyScheduleEarly;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
@@ -117,6 +118,7 @@ fn random_sessionid() -> Result<SessionID, rand::GetRandomFailed> {
 
 struct InitialState {
     handshake: HandshakeDetails,
+    transcript: HandshakeHash,
     extra_exts: Vec<ClientExtension>,
 }
 
@@ -124,6 +126,7 @@ impl InitialState {
     fn new(host_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> InitialState {
         InitialState {
             handshake: HandshakeDetails::new(host_name),
+            transcript: HandshakeHash::new(),
             extra_exts,
         }
     }
@@ -140,8 +143,7 @@ impl InitialState {
             .client_auth_cert_resolver
             .has_certs()
         {
-            self.handshake
-                .transcript
+            self.transcript
                 .set_client_auth_enabled();
         }
 
@@ -176,6 +178,7 @@ impl InitialState {
             self.handshake,
             randoms,
             false,
+            self.transcript,
             sent_tls13_fake_ccs,
             hello_details,
             None,
@@ -196,6 +199,7 @@ struct ExpectServerHello {
     handshake: HandshakeDetails,
     randoms: SessionRandoms,
     using_ems: bool,
+    transcript: HandshakeHash,
     early_key_schedule: Option<KeyScheduleEarly>,
     hello: ClientHelloDetails,
     sent_tls13_fake_ccs: bool,
@@ -221,6 +225,7 @@ fn emit_client_hello_for_retry(
     mut handshake: HandshakeDetails,
     randoms: SessionRandoms,
     using_ems: bool,
+    mut transcript: HandshakeHash,
     mut sent_tls13_fake_ccs: bool,
     mut hello: ClientHelloDetails,
     retryreq: Option<&HelloRetryRequest>,
@@ -352,7 +357,7 @@ fn emit_client_hello_for_retry(
     };
 
     let early_key_schedule = if fill_in_binder {
-        Some(tls13::fill_in_psk_binder(&mut handshake, &mut chp))
+        Some(tls13::fill_in_psk_binder(&mut handshake, &mut transcript, &mut chp))
     } else {
         None
     };
@@ -378,7 +383,7 @@ fn emit_client_hello_for_retry(
 
     trace!("Sending ClientHello {:#?}", ch);
 
-    handshake.transcript.add_message(&ch);
+    transcript.add_message(&ch);
     sess.common.send_msg(ch, false);
 
     // Calculate the hash of ClientHello and use it to derive EarlyTrafficSecret
@@ -393,8 +398,7 @@ fn emit_client_hello_for_retry(
             .map(|resume| resume.suite)
             .unwrap();
 
-        let client_hello_hash = handshake
-            .transcript
+        let client_hello_hash = transcript
             .get_hash_given(resuming_suite.get_hash(), &[]);
         let client_early_traffic_secret = early_key_schedule
             .as_ref()
@@ -426,6 +430,7 @@ fn emit_client_hello_for_retry(
         handshake,
         randoms,
         using_ems,
+        transcript,
         hello,
         early_key_schedule,
         sent_tls13_fake_ccs,
@@ -582,12 +587,8 @@ impl State for ExpectServerHello {
         }
 
         // Start our handshake hash, and input the server-hello.
-        self.handshake
-            .transcript
-            .start_hash(suite.get_hash());
-        self.handshake
-            .transcript
-            .add_message(&m);
+        self.transcript.start_hash(suite.get_hash());
+        self.transcript.add_message(&m);
 
         // For TLS1.3, start message encryption using
         // handshake_traffic_secret.
@@ -599,6 +600,7 @@ impl State for ExpectServerHello {
                 self.early_key_schedule.take(),
                 &server_hello,
                 &mut self.handshake,
+                &mut self.transcript,
                 &mut self.hello,
                 &mut self.randoms,
             )?;
@@ -607,6 +609,7 @@ impl State for ExpectServerHello {
             return Ok(Box::new(tls13::ExpectEncryptedExtensions {
                 handshake: self.handshake,
                 randoms: self.randoms,
+                transcript: self.transcript,
                 key_schedule,
                 hello: self.hello,
                 hash_at_client_recvd_server_hello,
@@ -711,6 +714,7 @@ impl State for ExpectServerHello {
                         secrets,
                         handshake: self.handshake,
                         using_ems: self.using_ems,
+                        transcript: self.transcript,
                         resuming: true,
                         cert_verified,
                         sig_verified,
@@ -720,6 +724,7 @@ impl State for ExpectServerHello {
                         secrets,
                         handshake: self.handshake,
                         using_ems: self.using_ems,
+                        transcript: self.transcript,
                         ticket: ReceivedTicketDetails::new(),
                         resuming: true,
                         cert_verified,
@@ -733,6 +738,7 @@ impl State for ExpectServerHello {
             handshake: self.handshake,
             randoms: self.randoms,
             using_ems: self.using_ems,
+            transcript: self.transcript,
             suite,
             may_send_cert_status,
             must_issue_new_ticket,
@@ -839,15 +845,12 @@ impl ExpectServerHelloOrHelloRetryRequest {
 
         // This is the draft19 change where the transcript became a tree
         self.next
-            .handshake
             .transcript
             .start_hash(cs.get_hash());
         self.next
-            .handshake
             .transcript
             .rollup_for_hrr();
         self.next
-            .handshake
             .transcript
             .add_message(&m);
 
@@ -862,6 +865,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
             self.next.handshake,
             self.next.randoms,
             self.next.using_ems,
+            self.next.transcript,
             self.next.sent_tls13_fake_ccs,
             self.next.hello,
             Some(&hrr),

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -467,23 +467,6 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
 }
 
 impl ExpectServerHello {
-    fn into_expect_tls12_ccs_resume(
-        self,
-        secrets: SessionSecrets,
-        certv: verify::ServerCertVerified,
-        sigv: verify::HandshakeSignatureValid,
-    ) -> NextState {
-        Box::new(tls12::ExpectCCS {
-            secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            ticket: ReceivedTicketDetails::new(),
-            resuming: true,
-            cert_verified: certv,
-            sig_verified: sigv,
-        })
-    }
-
     fn into_expect_tls12_certificate(
         self,
         suite: &'static SupportedCipherSuite,
@@ -754,7 +737,15 @@ impl State for ExpectServerHello {
                         sig_verified,
                     }))
                 } else {
-                    Ok(self.into_expect_tls12_ccs_resume(secrets, cert_verified, sig_verified))
+                    Ok(Box::new(tls12::ExpectCCS {
+                        secrets,
+                        handshake: self.handshake,
+                        using_ems: self.using_ems,
+                        ticket: ReceivedTicketDetails::new(),
+                        resuming: true,
+                        cert_verified,
+                        sig_verified,
+                    }))
                 };
             }
         }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -4,7 +4,7 @@ use crate::check::check_message;
 use crate::{cipher, SupportedCipherSuite};
 use crate::client::ClientSessionImpl;
 use crate::error::TlsError;
-use crate::key_schedule::{KeyScheduleEarly, KeyScheduleHandshake};
+use crate::key_schedule::KeyScheduleEarly;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
@@ -33,7 +33,6 @@ use crate::client::common::HandshakeDetails;
 use crate::client::{tls12, tls13};
 
 use webpki;
-use ring::digest::Digest;
 
 pub type NextState = Box<dyn State + Send + Sync>;
 pub type NextStateOrError = Result<NextState, TlsError>;
@@ -468,20 +467,6 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
 }
 
 impl ExpectServerHello {
-    fn into_expect_tls13_encrypted_extensions(
-        self,
-        key_schedule: KeyScheduleHandshake,
-        hash_at_client_recvd_server_hello: Digest,
-    ) -> NextState {
-        Box::new(tls13::ExpectEncryptedExtensions {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule,
-            hello: self.hello,
-            hash_at_client_recvd_server_hello,
-        })
-    }
-
     fn into_expect_tls12_new_ticket_resume(
         self,
         secrets: SessionSecrets,
@@ -672,7 +657,14 @@ impl State for ExpectServerHello {
                 &mut self.randoms,
             )?;
             tls13::emit_fake_ccs(&mut self.sent_tls13_fake_ccs, sess);
-            return Ok(self.into_expect_tls13_encrypted_extensions(key_schedule, hash_at_client_recvd_server_hello));
+
+            return Ok(Box::new(tls13::ExpectEncryptedExtensions {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                key_schedule,
+                hello: self.hello,
+                hash_at_client_recvd_server_hello,
+            }));
         }
 
         // TLS1.2 only from here-on

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -467,22 +467,6 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
 }
 
 impl ExpectServerHello {
-    fn into_expect_tls12_new_ticket_resume(
-        self,
-        secrets: SessionSecrets,
-        certv: verify::ServerCertVerified,
-        sigv: verify::HandshakeSignatureValid,
-    ) -> NextState {
-        Box::new(tls12::ExpectNewTicket {
-            secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            resuming: true,
-            cert_verified: certv,
-            sig_verified: sigv,
-        })
-    }
-
     fn into_expect_tls12_ccs_resume(
         self,
         secrets: SessionSecrets,
@@ -757,13 +741,20 @@ impl State for ExpectServerHello {
                 // Since we're resuming, we verified the certificate and
                 // proof of possession in the prior session.
                 sess.server_cert_chain = resuming.server_cert_chain.clone();
-                let certv = verify::ServerCertVerified::assertion();
-                let sigv = verify::HandshakeSignatureValid::assertion();
+                let cert_verified = verify::ServerCertVerified::assertion();
+                let sig_verified = verify::HandshakeSignatureValid::assertion();
 
                 return if must_issue_new_ticket {
-                    Ok(self.into_expect_tls12_new_ticket_resume(secrets, certv, sigv))
+                    Ok(Box::new(tls12::ExpectNewTicket {
+                        secrets,
+                        handshake: self.handshake,
+                        using_ems: self.using_ems,
+                        resuming: true,
+                        cert_verified,
+                        sig_verified,
+                    }))
                 } else {
-                    Ok(self.into_expect_tls12_ccs_resume(secrets, certv, sigv))
+                    Ok(self.into_expect_tls12_ccs_resume(secrets, cert_verified, sig_verified))
                 };
             }
         }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -132,20 +132,6 @@ struct ExpectCertificateStatusOrServerKX {
     must_issue_new_ticket: bool,
 }
 
-impl ExpectCertificateStatusOrServerKX {
-    fn into_expect_certificate_status(self) -> hs::NextState {
-        Box::new(ExpectCertificateStatus {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert_sct_list: self.server_cert_sct_list,
-            server_cert_chain: self.server_cert_chain,
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateStatusOrServerKX {
     fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> hs::NextStateOrError {
         check_message(
@@ -168,8 +154,15 @@ impl hs::State for ExpectCertificateStatusOrServerKX {
                 must_issue_new_ticket: self.must_issue_new_ticket,
             }).handle(sess, m)
         } else {
-            self.into_expect_certificate_status()
-                .handle(sess, m)
+            Box::new(ExpectCertificateStatus {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                using_ems: self.using_ems,
+                suite: self.suite,
+                server_cert_sct_list: self.server_cert_sct_list,
+                server_cert_chain: self.server_cert_chain,
+                must_issue_new_ticket: self.must_issue_new_ticket,
+            }).handle(sess, m)
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -665,20 +665,6 @@ pub struct ExpectNewTicket {
     pub sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl ExpectNewTicket {
-    fn into_expect_ccs(self, ticket: ReceivedTicketDetails) -> hs::NextState {
-        Box::new(ExpectCCS {
-            secrets: self.secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            ticket,
-            resuming: self.resuming,
-            cert_verified: self.cert_verified,
-            sig_verified: self.sig_verified,
-        })
-    }
-}
-
 impl hs::State for ExpectNewTicket {
     fn handle(
         mut self: Box<Self>,
@@ -694,8 +680,16 @@ impl hs::State for ExpectNewTicket {
             HandshakeType::NewSessionTicket,
             HandshakePayload::NewSessionTicket
         )?;
-        let recvd = ReceivedTicketDetails::from(nst.ticket.0, nst.lifetime_hint);
-        Ok(self.into_expect_ccs(recvd))
+
+        Ok(Box::new(ExpectCCS {
+            secrets: self.secrets,
+            handshake: self.handshake,
+            using_ems: self.using_ems,
+            ticket: ReceivedTicketDetails::from(nst.ticket.0, nst.lifetime_hint),
+            resuming: self.resuming,
+            cert_verified: self.cert_verified,
+            sig_verified: self.sig_verified,
+        }))
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -421,18 +421,6 @@ struct ExpectServerDoneOrCertReq {
 }
 
 impl ExpectServerDoneOrCertReq {
-    fn into_expect_certificate_req(self) -> hs::NextState {
-        Box::new(ExpectCertificateRequest {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert: self.server_cert,
-            server_kx: self.server_kx,
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-
     fn into_expect_server_done(self) -> hs::NextState {
         Box::new(ExpectServerDone {
             handshake: self.handshake,
@@ -460,8 +448,15 @@ impl hs::State for ExpectServerDoneOrCertReq {
         )
         .is_ok()
         {
-            self.into_expect_certificate_req()
-                .handle(sess, m)
+            Box::new(ExpectCertificateRequest {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                using_ems: self.using_ems,
+                suite: self.suite,
+                server_cert: self.server_cert,
+                server_kx: self.server_kx,
+                must_issue_new_ticket: self.must_issue_new_ticket,
+            }).handle(sess, m)
         } else {
             self.handshake
                 .transcript

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -546,7 +546,7 @@ impl hs::State for ExpectServerDone {
                 .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
                 .map_err(|err| hs::send_cert_error_alert(sess, err))?
         };
-        sess.server_cert_chain = st.server_cert.take_chain();
+        sess.server_cert_chain = st.server_cert.cert_chain;
 
         // 4.
         if let Some(client_auth) = &mut st.client_auth {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -38,18 +38,6 @@ pub struct ExpectCertificate {
 }
 
 impl ExpectCertificate {
-    fn into_expect_certificate_status_or_server_kx(self, server_cert_chain: CertificatePayload) -> hs::NextState {
-        Box::new(ExpectCertificateStatusOrServerKX {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert_sct_list: self.server_cert_sct_list,
-            server_cert_chain,
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-
     fn into_expect_server_kx(self, server_cert_chain: CertificatePayload) -> hs::NextState {
         let server_cert = ServerCertDetails::new(
             server_cert_chain, vec![], self.server_cert_sct_list);
@@ -81,7 +69,15 @@ impl hs::State for ExpectCertificate {
         let server_cert_chain = server_cert_chain.clone();
 
         if self.may_send_cert_status {
-            Ok(self.into_expect_certificate_status_or_server_kx(server_cert_chain))
+            Ok(Box::new(ExpectCertificateStatusOrServerKX {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                using_ems: self.using_ems,
+                suite: self.suite,
+                server_cert_sct_list: self.server_cert_sct_list,
+                server_cert_chain,
+                must_issue_new_ticket: self.must_issue_new_ticket,
+            }))
         } else {
             Ok(self.into_expect_server_kx(server_cert_chain))
         }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -420,21 +420,6 @@ struct ExpectServerDoneOrCertReq {
     must_issue_new_ticket: bool,
 }
 
-impl ExpectServerDoneOrCertReq {
-    fn into_expect_server_done(self) -> hs::NextState {
-        Box::new(ExpectServerDone {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert: self.server_cert,
-            server_kx: self.server_kx,
-            client_auth: None,
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectServerDoneOrCertReq {
     fn handle(
         mut self: Box<Self>,
@@ -461,8 +446,17 @@ impl hs::State for ExpectServerDoneOrCertReq {
             self.handshake
                 .transcript
                 .abandon_client_auth();
-            self.into_expect_server_done()
-                .handle(sess, m)
+
+            Box::new(ExpectServerDone {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                using_ems: self.using_ems,
+                suite: self.suite,
+                server_cert: self.server_cert,
+                server_kx: self.server_kx,
+                client_auth: None,
+                must_issue_new_ticket: self.must_issue_new_ticket,
+            }).handle(sess, m)
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -632,20 +632,6 @@ pub struct ExpectCCS {
     pub sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl ExpectCCS {
-    fn into_expect_finished(self) -> hs::NextState {
-        Box::new(ExpectFinished {
-            secrets: self.secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            ticket: self.ticket,
-            resuming: self.resuming,
-            cert_verified: self.cert_verified,
-            sig_verified: self.sig_verified,
-        })
-    }
-}
-
 impl hs::State for ExpectCCS {
     fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ChangeCipherSpec], &[])?;
@@ -658,7 +644,15 @@ impl hs::State for ExpectCCS {
             .record_layer
             .start_decrypting();
 
-        Ok(self.into_expect_finished())
+        Ok(Box::new(ExpectFinished {
+            secrets: self.secrets,
+            handshake: self.handshake,
+            using_ems: self.using_ems,
+            ticket: self.ticket,
+            resuming: self.resuming,
+            cert_verified: self.cert_verified,
+            sig_verified: self.sig_verified,
+        }))
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -349,21 +349,6 @@ struct ExpectCertificateRequest {
     must_issue_new_ticket: bool,
 }
 
-impl ExpectCertificateRequest {
-    fn into_expect_server_done(self, client_auth: ClientAuthDetails) -> hs::NextState {
-        Box::new(ExpectServerDone {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert: self.server_cert,
-            server_kx: self.server_kx,
-            client_auth: Some(client_auth),
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
@@ -412,7 +397,16 @@ impl hs::State for ExpectCertificateRequest {
             debug!("Client auth requested but no cert/sigscheme available");
         }
 
-        Ok(self.into_expect_server_done(client_auth))
+        Ok(Box::new(ExpectServerDone {
+            handshake: self.handshake,
+            randoms: self.randoms,
+            using_ems: self.using_ems,
+            suite: self.suite,
+            server_cert: self.server_cert,
+            server_kx: self.server_kx,
+            client_auth: Some(client_auth),
+            must_issue_new_ticket: self.must_issue_new_ticket,
+        }))
     }
 }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -37,22 +37,6 @@ pub struct ExpectCertificate {
     pub server_cert_sct_list: Option<SCTList>,
 }
 
-impl ExpectCertificate {
-    fn into_expect_server_kx(self, server_cert_chain: CertificatePayload) -> hs::NextState {
-        let server_cert = ServerCertDetails::new(
-            server_cert_chain, vec![], self.server_cert_sct_list);
-
-        Box::new(ExpectServerKX {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            using_ems: self.using_ems,
-            suite: self.suite,
-            server_cert,
-            must_issue_new_ticket: self.must_issue_new_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
@@ -79,7 +63,17 @@ impl hs::State for ExpectCertificate {
                 must_issue_new_ticket: self.must_issue_new_ticket,
             }))
         } else {
-            Ok(self.into_expect_server_kx(server_cert_chain))
+            let server_cert = ServerCertDetails::new(
+                server_cert_chain, vec![], self.server_cert_sct_list);
+
+            Ok(Box::new(ExpectServerKX {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                using_ems: self.using_ems,
+                suite: self.suite,
+                server_cert,
+                must_issue_new_ticket: self.must_issue_new_ticket,
+            }))
         }
     }
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -97,13 +97,12 @@ impl hs::State for ExpectCertificateStatus {
         self.handshake
             .transcript
             .add_message(&m);
-        let mut status = require_handshake_msg_mut!(
+        let server_cert_ocsp_response = require_handshake_msg_mut!(
             m,
             HandshakeType::CertificateStatus,
             HandshakePayload::CertificateStatus
-        )?;
+        )?.into_inner();
 
-        let server_cert_ocsp_response = status.take_ocsp_response();
         trace!(
             "Server stapled OCSP response is {:?}",
             &server_cert_ocsp_response

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -560,18 +560,6 @@ struct ExpectCertificateOrCertReq {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl ExpectCertificateOrCertReq {
-    fn into_expect_certificate_req(self) -> hs::NextState {
-        Box::new(ExpectCertificateRequest {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            may_send_sct_list: self.may_send_sct_list,
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateOrCertReq {
     fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> hs::NextStateOrError {
         check_message(
@@ -592,8 +580,13 @@ impl hs::State for ExpectCertificateOrCertReq {
                 hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
             }).handle(sess, m)
         } else {
-            self.into_expect_certificate_req()
-                .handle(sess, m)
+            Box::new(ExpectCertificateRequest {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                key_schedule: self.key_schedule,
+                may_send_sct_list: self.may_send_sct_list,
+                hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+            }).handle(sess, m)
         }
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -669,7 +669,7 @@ impl hs::State for ExpectCertificateVerify {
             )
             .map_err(|err| send_cert_error_alert(sess, err))?;
 
-        sess.server_cert_chain = self.server_cert.take_chain();
+        sess.server_cert_chain = self.server_cert.cert_chain;
         self.handshake
             .transcript
             .add_message(&m);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -561,17 +561,6 @@ struct ExpectCertificateOrCertReq {
 }
 
 impl ExpectCertificateOrCertReq {
-    fn into_expect_certificate(self) -> hs::NextState {
-        Box::new(ExpectCertificate {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            may_send_sct_list: self.may_send_sct_list,
-            client_auth: None,
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-
     fn into_expect_certificate_req(self) -> hs::NextState {
         Box::new(ExpectCertificateRequest {
             handshake: self.handshake,
@@ -594,8 +583,14 @@ impl hs::State for ExpectCertificateOrCertReq {
             ],
         )?;
         if m.is_handshake_type(HandshakeType::Certificate) {
-            self.into_expect_certificate()
-                .handle(sess, m)
+            Box::new(ExpectCertificate {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                key_schedule: self.key_schedule,
+                may_send_sct_list: self.may_send_sct_list,
+                client_auth: None,
+                hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+            }).handle(sess, m)
         } else {
             self.into_expect_certificate_req()
                 .handle(sess, m)

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -395,18 +395,6 @@ pub struct ExpectEncryptedExtensions {
     pub hash_at_client_recvd_server_hello: Digest,
 }
 
-impl ExpectEncryptedExtensions {
-    fn into_expect_certificate_or_certreq(self) -> hs::NextState {
-        Box::new(ExpectCertificateOrCertReq {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            may_send_sct_list: self.hello.server_may_send_sct_list(),
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-}
-
 impl hs::State for ExpectEncryptedExtensions {
     fn handle(
         mut self: Box<Self>,
@@ -482,7 +470,13 @@ impl hs::State for ExpectEncryptedExtensions {
                 let msg = "server sent early data extension without resumption".to_string();
                 return Err(TlsError::PeerMisbehavedError(msg));
             }
-            Ok(self.into_expect_certificate_or_certreq())
+            Ok(Box::new(ExpectCertificateOrCertReq {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                key_schedule: self.key_schedule,
+                may_send_sct_list: self.hello.server_may_send_sct_list(),
+                hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+            }))
         }
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -490,19 +490,6 @@ struct ExpectCertificate {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl ExpectCertificate {
-    fn into_expect_certificate_verify(self, server_cert: ServerCertDetails) -> hs::NextState {
-        Box::new(ExpectCertificateVerify {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            server_cert,
-            client_auth: self.client_auth,
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
@@ -554,7 +541,14 @@ impl hs::State for ExpectCertificate {
             }
         }
 
-        Ok(self.into_expect_certificate_verify(server_cert))
+        Ok(Box::new(ExpectCertificateVerify {
+            handshake: self.handshake,
+            randoms: self.randoms,
+            key_schedule: self.key_schedule,
+            server_cert,
+            client_auth: self.client_auth,
+            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+        }))
     }
 }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -697,19 +697,6 @@ struct ExpectCertificateRequest {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl ExpectCertificateRequest {
-    fn into_expect_certificate(self, client_auth: ClientAuthDetails) -> hs::NextState {
-        Box::new(ExpectCertificate {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            may_send_sct_list: self.may_send_sct_list,
-            client_auth: Some(client_auth),
-            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
@@ -780,7 +767,14 @@ impl hs::State for ExpectCertificateRequest {
             debug!("Client auth requested but no cert selected");
         }
 
-        Ok(self.into_expect_certificate(client_auth))
+        Ok(Box::new(ExpectCertificate {
+            handshake: self.handshake,
+            randoms: self.randoms,
+            key_schedule: self.key_schedule,
+            may_send_sct_list: self.may_send_sct_list,
+            client_auth: Some(client_auth),
+            hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
+        }))
     }
 }
 

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -16,7 +16,6 @@ use crate::log::warn;
 use std::collections;
 use std::fmt;
 use std::io::Write;
-use std::mem;
 use webpki;
 
 macro_rules! declare_u8_vec(
@@ -2092,9 +2091,8 @@ impl CertificateStatus {
         }
     }
 
-    pub fn take_ocsp_response(&mut self) -> Vec<u8> {
-        let new = PayloadU24::new(Vec::new());
-        mem::replace(&mut self.ocsp_response, new).0
+    pub fn into_inner(self) -> Vec<u8> {
+        self.ocsp_response.0
     }
 }
 


### PR DESCRIPTION
This contains most of the client-relevant changes from #546, up to the point where the transcript can be threaded through the handshake states. This is useful because at a later point we'll want to split `HandshakeHash` up in two separate types to make the type's internal state more resilient and precise (no unwrapping required).

Most of these are highly mechanical commits (`inline .. -> ..`) that just inline state transition methods (and adjust some variable names to make things more natural). I think this is useful because the reduced indirection makes it easier to follow what is going on and it enables having partial states (this is necessary for the `HandshakeHash` goals).

A few other commits remove/reduce abstractions to take advantage of extracting owned data from the various messages, reusing that instead of cloning it, and flattening the logic required to extract the useful data.