### PR TITLE
Rename public API types to conform to API guidelines

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -455,7 +455,7 @@ mod danger {
             _dns_name: webpki::DNSNameRef<'_>,
             _ocsp: &[u8],
             _now: std::time::SystemTime,
-        ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+        ) -> Result<rustls::ServerCertVerified, rustls::TlsError> {
             Ok(rustls::ServerCertVerified::assertion())
         }
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -198,7 +198,7 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
         _intermediates: &[rustls::Certificate],
         _sni: Option<&webpki::DNSName>,
         _now: SystemTime,
-    ) -> Result<rustls::ClientCertVerified, rustls::TLSError> {
+    ) -> Result<rustls::ClientCertVerified, rustls::TlsError> {
         Ok(rustls::ClientCertVerified::assertion())
     }
 }
@@ -214,7 +214,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
         _hostname: webpki::DNSNameRef<'_>,
         _ocsp: &[u8],
         _now: SystemTime,
-    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+    ) -> Result<rustls::ServerCertVerified, rustls::TlsError> {
         Ok(rustls::ServerCertVerified::assertion())
     }
 }
@@ -492,49 +492,49 @@ fn quit_err(why: &str) -> ! {
     process::exit(1)
 }
 
-fn handle_err(err: rustls::TLSError) -> ! {
+fn handle_err(err: rustls::TlsError) -> ! {
     use rustls::internal::msgs::enums::{AlertDescription, ContentType};
-    use rustls::TLSError;
+    use rustls::TlsError;
     use std::{thread, time};
 
     println!("TLS error: {:?}", err);
     thread::sleep(time::Duration::from_millis(100));
 
     match err {
-        TLSError::InappropriateHandshakeMessage { .. } | TLSError::InappropriateMessage { .. } => {
+        TlsError::InappropriateHandshakeMessage { .. } | TlsError::InappropriateMessage { .. } => {
             quit(":UNEXPECTED_MESSAGE:")
         }
-        TLSError::AlertReceived(AlertDescription::RecordOverflow) => {
+        TlsError::AlertReceived(AlertDescription::RecordOverflow) => {
             quit(":TLSV1_ALERT_RECORD_OVERFLOW:")
         }
-        TLSError::AlertReceived(AlertDescription::HandshakeFailure) => quit(":HANDSHAKE_FAILURE:"),
-        TLSError::AlertReceived(AlertDescription::ProtocolVersion) => quit(":WRONG_VERSION:"),
-        TLSError::AlertReceived(AlertDescription::InternalError) => {
+        TlsError::AlertReceived(AlertDescription::HandshakeFailure) => quit(":HANDSHAKE_FAILURE:"),
+        TlsError::AlertReceived(AlertDescription::ProtocolVersion) => quit(":WRONG_VERSION:"),
+        TlsError::AlertReceived(AlertDescription::InternalError) => {
             quit(":PEER_ALERT_INTERNAL_ERROR:")
         }
-        TLSError::CorruptMessagePayload(ContentType::Alert) => quit(":BAD_ALERT:"),
-        TLSError::CorruptMessagePayload(ContentType::ChangeCipherSpec) => {
+        TlsError::CorruptMessagePayload(ContentType::Alert) => quit(":BAD_ALERT:"),
+        TlsError::CorruptMessagePayload(ContentType::ChangeCipherSpec) => {
             quit(":BAD_CHANGE_CIPHER_SPEC:")
         }
-        TLSError::CorruptMessagePayload(ContentType::Handshake) => quit(":BAD_HANDSHAKE_MSG:"),
-        TLSError::CorruptMessagePayload(ContentType::Unknown(42)) => quit(":GARBAGE:"),
-        TLSError::CorruptMessage => quit(":GARBAGE:"),
-        TLSError::DecryptError => quit(":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"),
-        TLSError::PeerIncompatibleError(_) => quit(":INCOMPATIBLE:"),
-        TLSError::PeerMisbehavedError(_) => quit(":PEER_MISBEHAVIOUR:"),
-        TLSError::NoCertificatesPresented => quit(":NO_CERTS:"),
-        TLSError::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),
-        TLSError::AlertReceived(AlertDescription::DecompressionFailure) => {
+        TlsError::CorruptMessagePayload(ContentType::Handshake) => quit(":BAD_HANDSHAKE_MSG:"),
+        TlsError::CorruptMessagePayload(ContentType::Unknown(42)) => quit(":GARBAGE:"),
+        TlsError::CorruptMessage => quit(":GARBAGE:"),
+        TlsError::DecryptError => quit(":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"),
+        TlsError::PeerIncompatibleError(_) => quit(":INCOMPATIBLE:"),
+        TlsError::PeerMisbehavedError(_) => quit(":PEER_MISBEHAVIOUR:"),
+        TlsError::NoCertificatesPresented => quit(":NO_CERTS:"),
+        TlsError::AlertReceived(AlertDescription::UnexpectedMessage) => quit(":BAD_ALERT:"),
+        TlsError::AlertReceived(AlertDescription::DecompressionFailure) => {
             quit_err(":SSLV3_ALERT_DECOMPRESSION_FAILURE:")
         }
-        TLSError::WebPKIError(webpki::Error::BadDER, ..) => quit(":CANNOT_PARSE_LEAF_CERT:"),
-        TLSError::WebPKIError(webpki::Error::InvalidSignatureForPublicKey, ..) => {
+        TlsError::WebPKIError(webpki::Error::BadDER, ..) => quit(":CANNOT_PARSE_LEAF_CERT:"),
+        TlsError::WebPKIError(webpki::Error::InvalidSignatureForPublicKey, ..) => {
             quit(":BAD_SIGNATURE:")
         }
-        TLSError::WebPKIError(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey, ..) => {
+        TlsError::WebPKIError(webpki::Error::UnsupportedSignatureAlgorithmForPublicKey, ..) => {
             quit(":WRONG_SIGNATURE_TYPE:")
         }
-        TLSError::PeerSentOversizedRecord => quit(":DATA_LENGTH_TOO_LONG:"),
+        TlsError::PeerSentOversizedRecord => quit(":DATA_LENGTH_TOO_LONG:"),
         _ => {
             println_err!("unhandled error: {:?}", err);
             quit(":FIXME:")

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -7,7 +7,7 @@
 use webpki;
 use webpki_roots;
 
-use rustls::{ClientConfig, ClientSession, Session, TLSError};
+use rustls::{ClientConfig, ClientSession, Session, TlsError};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 enum Verdict {
     Accept,
-    Reject(TLSError),
+    Reject(TlsError),
 }
 
 fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<dyn Error>> {
@@ -62,7 +62,7 @@ fn communicate(host: String, port: u16, config: ClientConfig) -> Result<Verdict,
 
             if let Err(err) = client.process_new_packets() {
                 return match err {
-                    TLSError::WebPKIError(..) | TLSError::AlertReceived(_) => {
+                    TlsError::WebPKIError(..) | TlsError::AlertReceived(_) => {
                         Ok(Verdict::Reject(err))
                     }
                     _ => Err(From::from(format!("{:?}", err))),

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -1,4 +1,4 @@
-use crate::error::TLSError;
+use crate::error::TlsError;
 #[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::msgs::enums::{ContentType, HandshakeType};
@@ -13,11 +13,11 @@ macro_rules! require_handshake_msg(
     match $m.payload {
         MessagePayload::Handshake(ref hsp) => match hsp.payload {
             $payload_type(ref hm) => Ok(hm),
-            _ => Err(TLSError::InappropriateHandshakeMessage {
+            _ => Err(TlsError::InappropriateHandshakeMessage {
                      expect_types: vec![ $handshake_type ],
                      got_type: hsp.typ})
         }
-        _ => Err(TLSError::InappropriateMessage {
+        _ => Err(TlsError::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
                  got_type: $m.typ})
     }
@@ -30,11 +30,11 @@ macro_rules! require_handshake_msg_mut(
     match $m.payload {
         MessagePayload::Handshake(hsp) => match hsp.payload {
             $payload_type(hm) => Ok(hm),
-            _ => Err(TLSError::InappropriateHandshakeMessage {
+            _ => Err(TlsError::InappropriateHandshakeMessage {
                      expect_types: vec![ $handshake_type ],
                      got_type: hsp.typ})
         }
-        _ => Err(TLSError::InappropriateMessage {
+        _ => Err(TlsError::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
                  got_type: $m.typ})
     }
@@ -50,13 +50,13 @@ pub fn check_message(
     m: &Message,
     content_types: &[ContentType],
     handshake_types: &[HandshakeType],
-) -> Result<(), TLSError> {
+) -> Result<(), TlsError> {
     if !content_types.contains(&m.typ) {
         warn!(
             "Received a {:?} message while expecting {:?}",
             m.typ, content_types
         );
-        return Err(TLSError::InappropriateMessage {
+        return Err(TlsError::InappropriateMessage {
             expect_types: content_types.to_vec(),
             got_type: m.typ,
         });
@@ -68,7 +68,7 @@ pub fn check_message(
                 "Received a {:?} handshake message while expecting {:?}",
                 hsp.typ, handshake_types
             );
-            return Err(TLSError::InappropriateHandshakeMessage {
+            return Err(TlsError::InappropriateHandshakeMessage {
                 expect_types: handshake_types.to_vec(),
                 got_type: hsp.typ,
             });

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -1,5 +1,5 @@
 use crate::client;
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::key;
 use crate::msgs::enums::SignatureScheme;
 use crate::sign;
@@ -89,9 +89,9 @@ impl AlwaysResolvesClientCert {
     pub fn new(
         chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
-    ) -> Result<AlwaysResolvesClientCert, TLSError> {
+    ) -> Result<AlwaysResolvesClientCert, TlsError> {
         let key = sign::any_supported_type(priv_key)
-            .map_err(|_| TLSError::General("invalid private key".into()))?;
+            .map_err(|_| TlsError::General("invalid private key".into()))?;
         Ok(AlwaysResolvesClientCert(sign::CertifiedKey::new(
             chain,
             Arc::new(key),

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,6 +1,6 @@
 use crate::check::check_message;
 use crate::client::ClientSessionImpl;
-use crate::error::TLSError;
+use crate::error::TlsError;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::{Payload, PayloadU8};
@@ -227,7 +227,7 @@ impl hs::State for ExpectServerKX {
             .ok_or_else(|| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecodeError);
-                TLSError::CorruptMessagePayload(ContentType::Handshake)
+                TlsError::CorruptMessagePayload(ContentType::Handshake)
             })?;
 
         // Save the signature and signed parameters for later verification.
@@ -293,7 +293,7 @@ fn emit_certverify(
     handshake: &mut HandshakeDetails,
     client_auth: &mut ClientAuthDetails,
     sess: &mut ClientSessionImpl,
-) -> Result<(), TLSError> {
+) -> Result<(), TlsError> {
     let signer = match client_auth.signer.take() {
         None => {
             trace!("Not sending CertificateVerify, no key");
@@ -574,7 +574,7 @@ impl hs::State for ExpectServerDone {
             .server_cert
             .cert_chain
             .split_first()
-            .ok_or(TLSError::NoCertificatesPresented)?;
+            .ok_or(TlsError::NoCertificatesPresented)?;
         let now = std::time::SystemTime::now();
         let certv = sess
             .config
@@ -614,7 +614,7 @@ impl hs::State for ExpectServerDone {
                     sig.scheme.sign(),
                     suite.sign
                 );
-                return Err(TLSError::PeerMisbehavedError(error_message));
+                return Err(TlsError::PeerMisbehavedError(error_message));
             }
 
             sess.config
@@ -631,7 +631,7 @@ impl hs::State for ExpectServerDone {
 
         // 5a.
         let kxd = kx::KeyExchange::client_ecdhe(&st.server_kx.kx_params, &sess.config.kx_groups)
-            .ok_or_else(|| TLSError::PeerMisbehavedError("key exchange failed".to_string()))?;
+            .ok_or_else(|| TlsError::PeerMisbehavedError("key exchange failed".to_string()))?;
 
         // 5b.
         emit_clientkx(&mut st.handshake, sess, &kxd);
@@ -853,7 +853,7 @@ impl hs::State for ExpectFinished {
             .map_err(|_| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecryptError);
-                TLSError::DecryptError
+                TlsError::DecryptError
             })
             .map(|_| verify::FinishedMessageVerified::assertion())?;
 
@@ -900,7 +900,7 @@ impl hs::State for ExpectTraffic {
         output: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), TLSError> {
+    ) -> Result<(), TlsError> {
         self.secrets
             .export_keying_material(output, label, context);
         Ok(())

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for WebPKIOp {
 
 /// rustls reports protocol errors using this type.
 #[derive(Debug, PartialEq, Clone)]
-pub enum TLSError {
+pub enum TlsError {
     /// We received a TLS message that isn't valid right now.
     /// `expect_types` lists the message types we can expect right now.
     /// `got_type` is the type we found.  This error is typically
@@ -115,10 +115,10 @@ fn join<T: fmt::Debug>(items: &[T]) -> String {
         .join(" or ")
 }
 
-impl fmt::Display for TLSError {
+impl fmt::Display for TlsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            TLSError::InappropriateMessage {
+            TlsError::InappropriateMessage {
                 ref expect_types,
                 ref got_type,
             } => write!(
@@ -127,7 +127,7 @@ impl fmt::Display for TLSError {
                 got_type,
                 join::<ContentType>(expect_types)
             ),
-            TLSError::InappropriateHandshakeMessage {
+            TlsError::InappropriateHandshakeMessage {
                 ref expect_types,
                 ref got_type,
             } => write!(
@@ -136,30 +136,30 @@ impl fmt::Display for TLSError {
                 got_type,
                 join::<HandshakeType>(expect_types)
             ),
-            TLSError::CorruptMessagePayload(ref typ) => {
+            TlsError::CorruptMessagePayload(ref typ) => {
                 write!(f, "received corrupt message of type {:?}", typ)
             }
-            TLSError::PeerIncompatibleError(ref why) => write!(f, "peer is incompatible: {}", why),
-            TLSError::PeerMisbehavedError(ref why) => write!(f, "peer misbehaved: {}", why),
-            TLSError::AlertReceived(ref alert) => write!(f, "received fatal alert: {:?}", alert),
-            TLSError::WebPKIError(ref err, ref reason) => write!(f, "certificate error in operation: {}: {:?}", reason, err),
-            TLSError::CorruptMessage => write!(f, "received corrupt message"),
-            TLSError::NoCertificatesPresented => write!(f, "peer sent no certificates"),
-            TLSError::DecryptError => write!(f, "cannot decrypt peer's message"),
-            TLSError::PeerSentOversizedRecord => write!(f, "peer sent excess record size"),
-            TLSError::HandshakeNotComplete => write!(f, "handshake not complete"),
-            TLSError::NoApplicationProtocol => write!(f, "peer doesn't support any known protocol"),
-            TLSError::InvalidSCT(ref err) => write!(f, "invalid certificate timestamp: {:?}", err),
-            TLSError::FailedToGetCurrentTime => write!(f, "failed to get current time"),
-            TLSError::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
-            TLSError::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
+            TlsError::PeerIncompatibleError(ref why) => write!(f, "peer is incompatible: {}", why),
+            TlsError::PeerMisbehavedError(ref why) => write!(f, "peer misbehaved: {}", why),
+            TlsError::AlertReceived(ref alert) => write!(f, "received fatal alert: {:?}", alert),
+            TlsError::WebPKIError(ref err, ref reason) => write!(f, "certificate error in operation: {}: {:?}", reason, err),
+            TlsError::CorruptMessage => write!(f, "received corrupt message"),
+            TlsError::NoCertificatesPresented => write!(f, "peer sent no certificates"),
+            TlsError::DecryptError => write!(f, "cannot decrypt peer's message"),
+            TlsError::PeerSentOversizedRecord => write!(f, "peer sent excess record size"),
+            TlsError::HandshakeNotComplete => write!(f, "handshake not complete"),
+            TlsError::NoApplicationProtocol => write!(f, "peer doesn't support any known protocol"),
+            TlsError::InvalidSCT(ref err) => write!(f, "invalid certificate timestamp: {:?}", err),
+            TlsError::FailedToGetCurrentTime => write!(f, "failed to get current time"),
+            TlsError::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
+            TlsError::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
         }
     }
 }
 
-impl Error for TLSError {}
+impl Error for TlsError {}
 
-impl From<rand::GetRandomFailed> for TLSError {
+impl From<rand::GetRandomFailed> for TlsError {
     fn from(_: rand::GetRandomFailed) -> Self {
         Self::FailedToGetRandomBytes
     }
@@ -169,35 +169,36 @@ impl From<rand::GetRandomFailed> for TLSError {
 mod tests {
     #[test]
     fn smoke() {
-        use super::TLSError;
+        use super::TlsError;
         use super::WebPKIOp;
         use crate::msgs::enums::{AlertDescription, ContentType, HandshakeType};
         use sct;
         use webpki;
 
         let all = vec![
-            TLSError::InappropriateMessage {
+            TlsError::InappropriateMessage {
                 expect_types: vec![ContentType::Alert],
                 got_type: ContentType::Handshake,
             },
-            TLSError::InappropriateHandshakeMessage {
+            TlsError::InappropriateHandshakeMessage {
                 expect_types: vec![HandshakeType::ClientHello, HandshakeType::Finished],
                 got_type: HandshakeType::ServerHello,
             },
-            TLSError::CorruptMessage,
-            TLSError::CorruptMessagePayload(ContentType::Alert),
-            TLSError::NoCertificatesPresented,
-            TLSError::DecryptError,
-            TLSError::PeerIncompatibleError("no tls1.2".to_string()),
-            TLSError::PeerMisbehavedError("inconsistent something".to_string()),
-            TLSError::AlertReceived(AlertDescription::ExportRestriction),
-            TLSError::WebPKIError(webpki::Error::ExtensionValueInvalid, WebPKIOp::ParseEndEntity),
-            TLSError::InvalidSCT(sct::Error::MalformedSCT),
-            TLSError::General("undocumented error".to_string()),
-            TLSError::FailedToGetCurrentTime,
-            TLSError::HandshakeNotComplete,
-            TLSError::PeerSentOversizedRecord,
-            TLSError::NoApplicationProtocol,
+            TlsError::CorruptMessage,
+            TlsError::CorruptMessagePayload(ContentType::Alert),
+            TlsError::NoCertificatesPresented,
+            TlsError::DecryptError,
+            TlsError::PeerIncompatibleError("no tls1.2".to_string()),
+            TlsError::PeerMisbehavedError("inconsistent something".to_string()),
+            TlsError::AlertReceived(AlertDescription::ExportRestriction),
+            TlsError::WebPKIError(webpki::Error::ExtensionValueInvalid, WebPKIOp::ParseEndEntity),
+            TlsError::InvalidSCT(sct::Error::MalformedSCT),
+            TlsError::General("undocumented error".to_string()),
+            TlsError::FailedToGetCurrentTime,
+            TlsError::FailedToGetRandomBytes,
+            TlsError::HandshakeNotComplete,
+            TlsError::PeerSentOversizedRecord,
+            TlsError::NoApplicationProtocol,
         ];
 
         for err in all {

--- a/rustls/src/key_schedule.rs
+++ b/rustls/src/key_schedule.rs
@@ -1,5 +1,5 @@
 use crate::cipher::{Iv, IvLen};
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::msgs::base::PayloadU8;
 use crate::KeyLog;
 /// Key schedule maintenance for TLS1.3
@@ -323,7 +323,7 @@ impl KeyScheduleTraffic {
         out: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), TLSError> {
+    ) -> Result<(), TlsError> {
         self.ks
             .export_keying_material(&self.current_exporter_secret, out, label, context)
     }
@@ -443,7 +443,7 @@ impl KeySchedule {
         out: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), TLSError> {
+    ) -> Result<(), TlsError> {
         let digest_alg = self
             .algorithm
             .hmac_algorithm()
@@ -467,7 +467,7 @@ impl KeySchedule {
             h_context.as_ref(),
             |okm| okm.fill(out),
         )
-        .map_err(|_| TLSError::General("exporting too much".to_string()))
+        .map_err(|_| TlsError::General("exporting too much".to_string()))
     }
 }
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -264,14 +264,14 @@ pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage}
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientSession, WriteEarlyData};
-pub use crate::error::TLSError;
+pub use crate::error::TlsError;
 pub use crate::error::WebPKIOp;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
-pub use crate::server::handy::ResolvesServerCertUsingSNI;
+pub use crate::server::handy::ResolvesServerCertUsingSni;
 pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 pub use crate::server::StoresServerSessions;
 pub use crate::server::{ClientHello, ProducesTickets, ResolvesServerCert};
@@ -333,8 +333,20 @@ pub use crate::client::danger::DangerousClientConfig;
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 pub use crate::verify::{
     ClientCertVerified, ClientCertVerifier, HandshakeSignatureValid, ServerCertVerified,
-    ServerCertVerifier, WebPKIVerifier,
+    ServerCertVerifier, WebPkiVerifier,
 };
 
 /// This is the rustls manual.
 pub mod manual;
+
+#[doc(hidden)]
+#[deprecated(since = "0.20.0", note = "Use ResolvesServerCertUsingSni")]
+pub type ResolvesServerCertUsingSNI = ResolvesServerCertUsingSni;
+#[cfg(feature = "dangerous_configuration")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
+#[doc(hidden)]
+#[deprecated(since = "0.20.0", note = "Use WebPkiVerifier")]
+pub type WebPKIVerifier = WebPkiVerifier;
+#[doc(hidden)]
+#[deprecated(since = "0.20.0", note = "Use TlsError")]
+pub type TLSError = TlsError;

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1,6 +1,6 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use crate::client::{ClientConfig, ClientSession, ClientSessionImpl};
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::key_schedule::hkdf_expand;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
@@ -44,7 +44,7 @@ pub trait QuicExt {
     /// Consume unencrypted TLS handshake data.
     ///
     /// Handshake data obtained from separate encryption levels should be supplied in separate calls.
-    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError>;
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError>;
 
     /// Emit unencrypted TLS handshake data.
     ///
@@ -83,7 +83,7 @@ impl QuicExt for ClientSession {
         ))
     }
 
-    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
         self.imp
             .process_new_handshake_messages()
@@ -123,7 +123,7 @@ impl QuicExt for ServerSession {
         ))
     }
 
-    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TLSError> {
+    fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
         self.imp
             .process_new_handshake_messages()
@@ -260,7 +260,7 @@ impl Keys {
     }
 }
 
-fn read_hs(this: &mut SessionCommon, plaintext: &[u8]) -> Result<(), TLSError> {
+fn read_hs(this: &mut SessionCommon, plaintext: &[u8]) -> Result<(), TlsError> {
     if this
         .handshake_joiner
         .take_message(Message {
@@ -271,7 +271,7 @@ fn read_hs(this: &mut SessionCommon, plaintext: &[u8]) -> Result<(), TLSError> {
         .is_none()
     {
         this.quic.alert = Some(AlertDescription::DecodeError);
-        return Err(TLSError::CorruptMessage);
+        return Err(TlsError::CorruptMessage);
     }
     Ok(())
 }
@@ -335,7 +335,7 @@ pub trait ClientQuicExt {
         quic_version: Version,
         hostname: webpki::DNSNameRef,
         params: Vec<u8>,
-    ) -> Result<ClientSession, TLSError> {
+    ) -> Result<ClientSession, TlsError> {
         assert!(
             config
                 .versions

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,5 +1,5 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::msgs::message::{BorrowMessage, Message};
 
 static SEQ_SOFT_LIMIT: u64 = 0xffff_ffff_ffff_0000u64;
@@ -119,7 +119,7 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub fn decrypt_incoming(&mut self, encr: Message) -> Result<Message, TLSError> {
+    pub fn decrypt_incoming(&mut self, encr: Message) -> Result<Message, TlsError> {
         debug_assert!(self.decrypt_state == DirectionState::Active);
         let seq = self.read_seq;
         self.read_seq += 1;

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -1,4 +1,4 @@
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::key;
 use crate::server;
 use crate::server::ClientHello;
@@ -110,9 +110,9 @@ impl AlwaysResolvesChain {
     pub fn new(
         chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
-    ) -> Result<AlwaysResolvesChain, TLSError> {
+    ) -> Result<AlwaysResolvesChain, TlsError> {
         let key = sign::any_supported_type(priv_key)
-            .map_err(|_| TLSError::General("invalid private key".into()))?;
+            .map_err(|_| TlsError::General("invalid private key".into()))?;
         Ok(AlwaysResolvesChain(sign::CertifiedKey::new(
             chain,
             Arc::new(key),
@@ -128,7 +128,7 @@ impl AlwaysResolvesChain {
         priv_key: &key::PrivateKey,
         ocsp: Vec<u8>,
         scts: Vec<u8>,
-    ) -> Result<AlwaysResolvesChain, TLSError> {
+    ) -> Result<AlwaysResolvesChain, TlsError> {
         let mut r = AlwaysResolvesChain::new(chain, priv_key)?;
         if !ocsp.is_empty() {
             r.0.ocsp = Some(ocsp);
@@ -148,14 +148,14 @@ impl server::ResolvesServerCert for AlwaysResolvesChain {
 
 /// Something that resolves do different cert chains/keys based
 /// on client-supplied server name (via SNI).
-pub struct ResolvesServerCertUsingSNI {
+pub struct ResolvesServerCertUsingSni {
     by_name: collections::HashMap<String, sign::CertifiedKey>,
 }
 
-impl ResolvesServerCertUsingSNI {
+impl ResolvesServerCertUsingSni {
     /// Create a new and empty (i.e., knows no certificates) resolver.
-    pub fn new() -> ResolvesServerCertUsingSNI {
-        ResolvesServerCertUsingSNI {
+    pub fn new() -> ResolvesServerCertUsingSni {
+        ResolvesServerCertUsingSni {
             by_name: collections::HashMap::new(),
         }
     }
@@ -165,9 +165,9 @@ impl ResolvesServerCertUsingSNI {
     /// This function fails if `name` is not a valid DNS name, or if
     /// it's not valid for the supplied certificate, or if the certificate
     /// chain is syntactically faulty.
-    pub fn add(&mut self, name: &str, ck: sign::CertifiedKey) -> Result<(), TLSError> {
+    pub fn add(&mut self, name: &str, ck: sign::CertifiedKey) -> Result<(), TlsError> {
         let checked_name = webpki::DNSNameRef::try_from_ascii_str(name)
-            .map_err(|_| TLSError::General("Bad DNS name".into()))?;
+            .map_err(|_| TlsError::General("Bad DNS name".into()))?;
 
         ck.cross_check_end_entity_cert(Some(checked_name))?;
         self.by_name.insert(name.into(), ck);
@@ -175,7 +175,7 @@ impl ResolvesServerCertUsingSNI {
     }
 }
 
-impl server::ResolvesServerCert for ResolvesServerCertUsingSNI {
+impl server::ResolvesServerCert for ResolvesServerCertUsingSni {
     fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
         if let Some(name) = client_hello.server_name() {
             self.by_name.get(name.into()).cloned()
@@ -287,7 +287,7 @@ mod test {
 
     #[test]
     fn test_resolvesservercertusingsni_requires_sni() {
-        let rscsni = ResolvesServerCertUsingSNI::new();
+        let rscsni = ResolvesServerCertUsingSni::new();
         assert!(
             rscsni
                 .resolve(ClientHello::new(None, &[], None))
@@ -297,7 +297,7 @@ mod test {
 
     #[test]
     fn test_resolvesservercertusingsni_handles_unknown_name() {
-        let rscsni = ResolvesServerCertUsingSNI::new();
+        let rscsni = ResolvesServerCertUsingSni::new();
         let name = webpki::DNSNameRef::try_from_ascii_str("hello.com").unwrap();
         assert!(
             rscsni

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::check_message;
-use crate::error::TLSError;
+use crate::error::TlsError;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
@@ -62,7 +62,7 @@ impl hs::State for ExpectCertificate {
                 debug!("could not determine if client auth is mandatory based on SNI");
                 sess.common
                     .send_fatal_alert(AlertDescription::AccessDenied);
-                TLSError::General("client rejected by client_auth_mandatory".into())
+                TlsError::General("client rejected by client_auth_mandatory".into())
             })?;
 
         trace!("certs {:?}", cert_chain);
@@ -76,7 +76,7 @@ impl hs::State for ExpectCertificate {
                 }
                 sess.common
                     .send_fatal_alert(AlertDescription::CertificateRequired);
-                return Err(TLSError::NoCertificatesPresented);
+                return Err(TlsError::NoCertificatesPresented);
             }
             Some(chain) => chain,
         };
@@ -126,7 +126,7 @@ impl hs::State for ExpectClientKX {
             .ok_or_else(|| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecodeError);
-                TLSError::CorruptMessagePayload(ContentType::Handshake)
+                TlsError::CorruptMessagePayload(ContentType::Handshake)
             })?;
 
         let suite = sess
@@ -390,7 +390,7 @@ impl hs::State for ExpectFinished {
             .map_err(|_| {
                 sess.common
                     .send_fatal_alert(AlertDescription::DecryptError);
-                TLSError::DecryptError
+                TlsError::DecryptError
             })
             .map(|_| verify::FinishedMessageVerified::assertion())?;
 
@@ -454,7 +454,7 @@ impl hs::State for ExpectTraffic {
         output: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), TLSError> {
+    ) -> Result<(), TlsError> {
         self.secrets
             .export_keying_material(output, label, context);
         Ok(())

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -1,5 +1,5 @@
 use crate::cipher;
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, error, warn};
@@ -67,7 +67,7 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
     ///
     /// Success from this function can mean new plaintext is available:
     /// obtain it using `read`.
-    fn process_new_packets(&mut self) -> Result<(), TLSError>;
+    fn process_new_packets(&mut self) -> Result<(), TlsError>;
 
     /// Returns true if the caller should call `read_tls` as soon
     /// as possible.
@@ -140,7 +140,7 @@ pub trait Session: quic::QuicExt + Read + Write + Send + Sync {
         output: &mut [u8],
         label: &[u8],
         context: Option<&[u8]>,
-    ) -> Result<(), TLSError>;
+    ) -> Result<(), TlsError>;
 
     /// Retrieves the ciphersuite agreed with the peer.
     ///
@@ -510,7 +510,7 @@ impl SessionCommon {
         }
     }
 
-    pub fn filter_tls13_ccs(&mut self, msg: &Message) -> Result<MiddleboxCCS, TLSError> {
+    pub fn filter_tls13_ccs(&mut self, msg: &Message) -> Result<MiddleboxCCS, TlsError> {
         // pass message to handshake state machine if any of these are true:
         // - TLS1.2 (where it's part of the state machine),
         // - prior to determining the version (it's illegal as a first message)
@@ -521,7 +521,7 @@ impl SessionCommon {
         }
 
         if self.received_middlebox_ccs {
-            Err(TLSError::PeerMisbehavedError(
+            Err(TlsError::PeerMisbehavedError(
                 "illegal middlebox CCS received".into(),
             ))
         } else {
@@ -530,7 +530,7 @@ impl SessionCommon {
         }
     }
 
-    pub fn decrypt_incoming(&mut self, encr: Message) -> Result<Message, TLSError> {
+    pub fn decrypt_incoming(&mut self, encr: Message) -> Result<Message, TlsError> {
         if self
             .record_layer
             .wants_close_before_decrypt()
@@ -539,7 +539,7 @@ impl SessionCommon {
         }
 
         let rc = self.record_layer.decrypt_incoming(encr);
-        if let Err(TLSError::PeerSentOversizedRecord) = rc {
+        if let Err(TlsError::PeerSentOversizedRecord) = rc {
             self.send_fatal_alert(AlertDescription::RecordOverflow);
         }
         rc
@@ -554,7 +554,7 @@ impl SessionCommon {
         self.sendable_tls.set_limit(limit);
     }
 
-    pub fn process_alert(&mut self, msg: Message) -> Result<(), TLSError> {
+    pub fn process_alert(&mut self, msg: Message) -> Result<(), TlsError> {
         if let MessagePayload::Alert(ref alert) = msg.payload {
             // Reject unknown AlertLevels.
             if let AlertLevel::Unknown(_) = alert.level {
@@ -580,9 +580,9 @@ impl SessionCommon {
             }
 
             error!("TLS alert received: {:#?}", msg);
-            Err(TLSError::AlertReceived(alert.description))
+            Err(TlsError::AlertReceived(alert.description))
         } else {
-            Err(TLSError::CorruptMessagePayload(ContentType::Alert))
+            Err(TlsError::CorruptMessagePayload(ContentType::Alert))
         }
     }
 

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -6,7 +6,7 @@ use webpki;
 
 use crate::anchors::OwnedTrustAnchor;
 use crate::anchors::{DistinguishedNames, RootCertStore};
-use crate::error::TLSError;
+use crate::error::TlsError;
 use crate::error::WebPKIOp;
 use crate::key::Certificate;
 #[cfg(feature = "logging")]
@@ -95,7 +95,7 @@ pub trait ServerCertVerifier: Send + Sync {
         dns_name: webpki::DNSNameRef,
         ocsp_response: &[u8],
         now: SystemTime,
-    ) -> Result<ServerCertVerified, TLSError>;
+    ) -> Result<ServerCertVerified, TlsError>;
 
     /// Verify a signature allegedly by the given server certificate.
     ///
@@ -121,7 +121,7 @@ pub trait ServerCertVerifier: Send + Sync {
         message: &[u8],
         cert: &Certificate,
         dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TLSError> {
+    ) -> Result<HandshakeSignatureValid, TlsError> {
         verify_signed_struct(message, cert, dss)
     }
 
@@ -141,7 +141,7 @@ pub trait ServerCertVerifier: Send + Sync {
         message: &[u8],
         cert: &Certificate,
         dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TLSError> {
+    ) -> Result<HandshakeSignatureValid, TlsError> {
         verify_tls13(message, cert, dss)
     }
 
@@ -153,7 +153,7 @@ pub trait ServerCertVerifier: Send + Sync {
     /// This trait method has a default implementation that reflects the schemes
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        WebPKIVerifier::verification_schemes()
+        WebPkiVerifier::verification_schemes()
     }
 }
 
@@ -202,7 +202,7 @@ pub trait ClientCertVerifier: Send + Sync {
         intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         now: SystemTime,
-    ) -> Result<ClientCertVerified, TLSError>;
+    ) -> Result<ClientCertVerified, TlsError>;
 
     /// Verify a signature allegedly by the given server certificate.
     ///
@@ -228,7 +228,7 @@ pub trait ClientCertVerifier: Send + Sync {
         message: &[u8],
         cert: &Certificate,
         dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TLSError> {
+    ) -> Result<HandshakeSignatureValid, TlsError> {
         verify_signed_struct(message, cert, dss)
     }
 
@@ -249,7 +249,7 @@ pub trait ClientCertVerifier: Send + Sync {
         message: &[u8],
         cert: &Certificate,
         dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, TLSError> {
+    ) -> Result<HandshakeSignatureValid, TlsError> {
         verify_tls13(message, cert, dss)
     }
 
@@ -261,11 +261,11 @@ pub trait ClientCertVerifier: Send + Sync {
     /// This trait method has a default implementation that reflects the schemes
     /// supported by webpki.
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        WebPKIVerifier::verification_schemes()
+        WebPkiVerifier::verification_schemes()
     }
 }
 
-impl ServerCertVerifier for WebPKIVerifier {
+impl ServerCertVerifier for WebPkiVerifier {
     /// Will verify the certificate is valid in the following ways:
     /// - Signed by a  trusted `RootCertStore` CA
     /// - Not Expired
@@ -279,9 +279,9 @@ impl ServerCertVerifier for WebPKIVerifier {
         dns_name: webpki::DNSNameRef,
         ocsp_response: &[u8],
         now: SystemTime,
-    ) -> Result<ServerCertVerified, TLSError> {
+    ) -> Result<ServerCertVerified, TlsError> {
         let (cert, chain, trustroots) = prepare(end_entity, intermediates, roots)?;
-        let now = webpki::Time::try_from(now).map_err(|_| TLSError::FailedToGetCurrentTime)?;
+        let now = webpki::Time::try_from(now).map_err(|_| TlsError::FailedToGetCurrentTime)?;
 
         let cert = cert
             .verify_is_valid_tls_server_cert(
@@ -290,7 +290,7 @@ impl ServerCertVerifier for WebPKIVerifier {
                 &chain,
                 now,
             )
-            .map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ValidateServerCert))
+            .map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ValidateServerCert))
             .map(|_| cert)?;
 
         if !ocsp_response.is_empty() {
@@ -298,15 +298,15 @@ impl ServerCertVerifier for WebPKIVerifier {
         }
 
         cert.verify_is_valid_for_dns_name(dns_name)
-            .map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ValidateForDNSName))
+            .map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ValidateForDNSName))
             .map(|_| ServerCertVerified::assertion())
     }
 }
 
 /// Default `ServerCertVerifier`, see the trait impl for more information.
-pub struct WebPKIVerifier;
+pub struct WebPkiVerifier;
 
-impl WebPKIVerifier {
+impl WebPkiVerifier {
     /// Returns the signature verification methods supported by
     /// webpki.
     pub fn verification_schemes() -> Vec<SignatureScheme> {
@@ -334,9 +334,9 @@ fn prepare<'a, 'b>(
     end_entity: &'a Certificate,
     intermediates: &'a [Certificate],
     roots: &'b RootCertStore,
-) -> Result<CertChainAndRoots<'a, 'b>, TLSError> {
+) -> Result<CertChainAndRoots<'a, 'b>, TlsError> {
     // EE cert must appear first.
-    let cert = webpki::EndEntityCert::from(&end_entity.0).map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
+    let cert = webpki::EndEntityCert::from(&end_entity.0).map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
 
     let intermediates: Vec<&'a [u8]> = intermediates.iter().map(|cert| cert.0.as_ref()).collect();
 
@@ -386,16 +386,16 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
         intermediates: &[Certificate],
         _sni: Option<&webpki::DNSName>,
         now: SystemTime,
-    ) -> Result<ClientCertVerified, TLSError> {
+    ) -> Result<ClientCertVerified, TlsError> {
         let (cert, chain, trustroots) = prepare(end_entity, intermediates, &self.roots)?;
-        let now = webpki::Time::try_from(now).map_err(|_| TLSError::FailedToGetCurrentTime)?;
+        let now = webpki::Time::try_from(now).map_err(|_| TlsError::FailedToGetCurrentTime)?;
         cert.verify_is_valid_tls_client_cert(
             SUPPORTED_SIG_ALGS,
             &webpki::TLSClientTrustAnchors(&trustroots),
             &chain,
             now,
         )
-        .map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ValidateClientCert))
+        .map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ValidateClientCert))
         .map(|_| ClientCertVerified::assertion())
     }
 }
@@ -443,7 +443,7 @@ impl ClientCertVerifier for AllowAnyAnonymousOrAuthenticatedClient {
         intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         now: SystemTime,
-    ) -> Result<ClientCertVerified, TLSError> {
+    ) -> Result<ClientCertVerified, TlsError> {
         self.inner
             .verify_client_cert(end_entity, intermediates, sni, now)
     }
@@ -477,7 +477,7 @@ impl ClientCertVerifier for NoClientAuth {
         _intermediates: &[Certificate],
         _sni: Option<&webpki::DNSName>,
         _now: SystemTime,
-    ) -> Result<ClientCertVerified, TLSError> {
+    ) -> Result<ClientCertVerified, TlsError> {
         unimplemented!();
     }
 }
@@ -497,7 +497,7 @@ static RSA_PSS_SHA256: SignatureAlgorithms = &[&webpki::RSA_PSS_2048_8192_SHA256
 static RSA_PSS_SHA384: SignatureAlgorithms = &[&webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY];
 static RSA_PSS_SHA512: SignatureAlgorithms = &[&webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY];
 
-fn convert_scheme(scheme: SignatureScheme) -> Result<SignatureAlgorithms, TLSError> {
+fn convert_scheme(scheme: SignatureScheme) -> Result<SignatureAlgorithms, TlsError> {
     match scheme {
         // nb. for TLS1.2 the curve is not fixed by SignatureScheme.
         SignatureScheme::ECDSA_NISTP256_SHA256 => Ok(ECDSA_SHA256),
@@ -515,7 +515,7 @@ fn convert_scheme(scheme: SignatureScheme) -> Result<SignatureAlgorithms, TLSErr
 
         _ => {
             let error_msg = format!("received unadvertised sig scheme {:?}", scheme);
-            Err(TLSError::PeerMisbehavedError(error_msg))
+            Err(TlsError::PeerMisbehavedError(error_msg))
         }
     }
 }
@@ -542,18 +542,18 @@ fn verify_signed_struct(
     message: &[u8],
     cert: &Certificate,
     dss: &DigitallySignedStruct,
-) -> Result<HandshakeSignatureValid, TLSError> {
+) -> Result<HandshakeSignatureValid, TlsError> {
     let possible_algs = convert_scheme(dss.scheme)?;
-    let cert = webpki::EndEntityCert::from(&cert.0).map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
+    let cert = webpki::EndEntityCert::from(&cert.0).map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
 
     verify_sig_using_any_alg(&cert, possible_algs, message, &dss.sig.0)
-        .map_err(|e| TLSError::WebPKIError(e, WebPKIOp::VerifySignature))
+        .map_err(|e| TlsError::WebPKIError(e, WebPKIOp::VerifySignature))
         .map(|_| HandshakeSignatureValid::assertion())
 }
 
 fn convert_alg_tls13(
     scheme: SignatureScheme,
-) -> Result<&'static webpki::SignatureAlgorithm, TLSError> {
+) -> Result<&'static webpki::SignatureAlgorithm, TlsError> {
     use crate::msgs::enums::SignatureScheme::*;
 
     match scheme {
@@ -565,7 +565,7 @@ fn convert_alg_tls13(
         RSA_PSS_SHA512 => Ok(&webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY),
         _ => {
             let error_msg = format!("received unsupported sig scheme {:?}", scheme);
-            Err(TLSError::PeerMisbehavedError(error_msg))
+            Err(TlsError::PeerMisbehavedError(error_msg))
         }
     }
 }
@@ -592,29 +592,29 @@ fn verify_tls13(
     msg: &[u8],
     cert: &Certificate,
     dss: &DigitallySignedStruct,
-) -> Result<HandshakeSignatureValid, TLSError> {
+) -> Result<HandshakeSignatureValid, TlsError> {
     let alg = convert_alg_tls13(dss.scheme)?;
 
 
-    let cert = webpki::EndEntityCert::from(&cert.0).map_err(|e| TLSError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
+    let cert = webpki::EndEntityCert::from(&cert.0).map_err(|e| TlsError::WebPKIError(e, WebPKIOp::ParseEndEntity))?;
 
     cert.verify_signature(alg, &msg, &dss.sig.0)
-        .map_err(|e| TLSError::WebPKIError(e, WebPKIOp::VerifySignature))
+        .map_err(|e| TlsError::WebPKIError(e, WebPKIOp::VerifySignature))
         .map(|_| HandshakeSignatureValid::assertion())
 }
 
-fn unix_time_millis(now: SystemTime) -> Result<u64, TLSError> {
+fn unix_time_millis(now: SystemTime) -> Result<u64, TlsError> {
     now
         .duration_since(std::time::UNIX_EPOCH)
         .map(|dur| dur.as_secs())
-        .map_err(|_| TLSError::FailedToGetCurrentTime)
+        .map_err(|_| TlsError::FailedToGetCurrentTime)
         .and_then(|secs| {
             secs.checked_mul(1000)
-                .ok_or(TLSError::FailedToGetCurrentTime)
+                .ok_or(TlsError::FailedToGetCurrentTime)
         })
 }
 
-pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[&sct::Log]) -> Result<(), TLSError> {
+pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[&sct::Log]) -> Result<(), TlsError> {
     let mut valid_scts = 0;
     let now = unix_time_millis(now)?;
     let mut last_sct_error = None;
@@ -631,7 +631,7 @@ pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[
             }
             Err(e) => {
                 if e.should_be_fatal() {
-                    return Err(TLSError::InvalidSCT(e));
+                    return Err(TlsError::InvalidSCT(e));
                 }
                 debug!("SCT ignored because {:?}", e);
                 last_sct_error = Some(e);
@@ -643,7 +643,7 @@ pub fn verify_scts(cert: &Certificate, now: SystemTime, scts: &SCTList, logs: &[
      * but couldn't verify any of them, fail the handshake. */
     if !logs.is_empty() && !scts.is_empty() && valid_scts == 0 {
         warn!("No valid SCTs provided");
-        return Err(TLSError::InvalidSCT(last_sct_error.unwrap()));
+        return Err(TlsError::InvalidSCT(last_sct_error.unwrap()));
     }
 
     Ok(())

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -18,7 +18,7 @@ fn duration_nanos(d: Duration) -> u64 {
     ((d.as_secs() as f64) * 1e9 + (d.subsec_nanos() as f64)) as u64
 }
 
-static V: &'static verify::WebPKIVerifier = &verify::WebPKIVerifier;
+static V: &'static verify::WebPkiVerifier = &verify::WebPkiVerifier;
 
 #[test]
 fn test_reddit_cert() {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -15,7 +15,7 @@ use rustls::sign;
 use rustls::ClientHello;
 use rustls::KeyLog;
 use rustls::Session;
-use rustls::TLSError;
+use rustls::TlsError;
 use rustls::WebPKIOp;
 use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
 use rustls::{ClientConfig, ClientSession, ResolvesClientCert};
@@ -587,7 +587,7 @@ fn client_checks_server_certificate_with_given_name() {
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
                 err,
-                Err(TLSErrorFromPeer::Client(TLSError::WebPKIError(
+                Err(TLSErrorFromPeer::Client(TlsError::WebPKIError(
                     webpki::Error::CertNotValidForName,
                     WebPKIOp::ValidateForDNSName,
                 )))
@@ -658,7 +658,7 @@ fn client_cert_resolve() {
 
             assert_eq!(
                 do_handshake_until_error(&mut client, &mut server),
-                Err(TLSErrorFromPeer::Server(TLSError::NoCertificatesPresented))
+                Err(TLSErrorFromPeer::Server(TlsError::NoCertificatesPresented))
             );
         }
     }
@@ -686,18 +686,18 @@ mod test_clientverifier {
     use rustls::internal::msgs::enums::ContentType;
 
     // Client is authorized!
-    fn ver_ok() -> Result<ClientCertVerified, TLSError> {
+    fn ver_ok() -> Result<ClientCertVerified, TlsError> {
         Ok(rustls::ClientCertVerified::assertion())
     }
 
     // Use when we shouldn't even attempt verification
-    fn ver_unreachable() -> Result<ClientCertVerified, TLSError> {
+    fn ver_unreachable() -> Result<ClientCertVerified, TlsError> {
         unreachable!()
     }
 
     // Verifier that returns an error that we can expect
-    fn ver_err() -> Result<ClientCertVerified, TLSError> {
-        Err(TLSError::General("test err".to_string()))
+    fn ver_err() -> Result<ClientCertVerified, TlsError> {
+        Err(TlsError::General("test err".to_string()))
     }
 
     #[test]
@@ -753,7 +753,7 @@ mod test_clientverifier {
                 let err = do_handshake_until_error(&mut client, &mut server);
                 assert_eq!(
                     err,
-                    Err(TLSErrorFromPeer::Client(TLSError::CorruptMessagePayload(
+                    Err(TLSErrorFromPeer::Client(TlsError::CorruptMessagePayload(
                         ContentType::Handshake
                     )))
                 );
@@ -788,10 +788,10 @@ mod test_clientverifier {
                 assert_eq!(
                     errs,
                     Err(vec![
-                        TLSErrorFromPeer::Server(TLSError::General(
+                        TLSErrorFromPeer::Server(TlsError::General(
                             "client rejected by client_auth_root_subjects".into()
                         )),
-                        TLSErrorFromPeer::Client(TLSError::AlertReceived(
+                        TLSErrorFromPeer::Client(TlsError::AlertReceived(
                             AlertDescription::AccessDenied
                         ))
                     ])
@@ -827,10 +827,10 @@ mod test_clientverifier {
                 assert_eq!(
                     errs,
                     Err(vec![
-                        TLSErrorFromPeer::Server(TLSError::General(
+                        TLSErrorFromPeer::Server(TlsError::General(
                             "client rejected by client_auth_root_subjects".into()
                         )),
-                        TLSErrorFromPeer::Client(TLSError::AlertReceived(
+                        TLSErrorFromPeer::Client(TlsError::AlertReceived(
                             AlertDescription::AccessDenied
                         ))
                     ])
@@ -867,8 +867,8 @@ mod test_clientverifier {
                 assert_eq!(
                     errs,
                     Err(vec![
-                        TLSErrorFromPeer::Server(TLSError::NoCertificatesPresented),
-                        TLSErrorFromPeer::Client(TLSError::AlertReceived(
+                        TLSErrorFromPeer::Server(TlsError::NoCertificatesPresented),
+                        TLSErrorFromPeer::Client(TlsError::AlertReceived(
                             AlertDescription::CertificateRequired
                         ))
                     ])
@@ -903,7 +903,7 @@ mod test_clientverifier {
                 let err = do_handshake_until_error(&mut client, &mut server);
                 assert_eq!(
                     err,
-                    Err(TLSErrorFromPeer::Server(TLSError::General(
+                    Err(TLSErrorFromPeer::Server(TlsError::General(
                         "test err".into()
                     )))
                 );
@@ -938,10 +938,10 @@ mod test_clientverifier {
                 assert_eq!(
                     errs,
                     Err(vec![
-                        TLSErrorFromPeer::Server(TLSError::General(
+                        TLSErrorFromPeer::Server(TlsError::General(
                             "client rejected by client_auth_mandatory".into()
                         )),
-                        TLSErrorFromPeer::Client(TLSError::AlertReceived(
+                        TLSErrorFromPeer::Client(TlsError::AlertReceived(
                             AlertDescription::AccessDenied
                         ))
                     ])
@@ -1146,7 +1146,7 @@ struct OtherSession<'a> {
     pub writevs: Vec<Vec<usize>>,
     fail_ok: bool,
     pub short_writes: bool,
-    pub last_error: Option<rustls::TLSError>,
+    pub last_error: Option<rustls::TlsError>,
 }
 
 impl<'a> OtherSession<'a> {
@@ -1700,7 +1700,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
 #[test]
 fn server_exposes_offered_sni_even_if_resolver_fails() {
     let kt = KeyType::RSA;
-    let resolver = rustls::ResolvesServerCertUsingSNI::new();
+    let resolver = rustls::ResolvesServerCertUsingSni::new();
 
     let mut server_config = make_server_config(kt);
     server_config.cert_resolver = Arc::new(resolver);
@@ -1715,7 +1715,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
         transfer(&mut client, &mut server);
         assert_eq!(
             server.process_new_packets(),
-            Err(TLSError::General(
+            Err(TlsError::General(
                 "no server certificate chain resolved".to_string()
             ))
         );
@@ -1726,8 +1726,8 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 #[test]
 fn sni_resolver_works() {
     let kt = KeyType::RSA;
-    let mut resolver = rustls::ResolvesServerCertUsingSNI::new();
-    let signing_key = sign::RSASigningKey::new(&kt.get_key()).unwrap();
+    let mut resolver = rustls::ResolvesServerCertUsingSni::new();
+    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
     resolver
         .add(
@@ -1751,7 +1751,7 @@ fn sni_resolver_works() {
     let err = do_handshake_until_error(&mut client2, &mut server2);
     assert_eq!(
         err,
-        Err(TLSErrorFromPeer::Server(TLSError::General(
+        Err(TLSErrorFromPeer::Server(TlsError::General(
             "no server certificate chain resolved".into()
         )))
     );
@@ -1760,8 +1760,8 @@ fn sni_resolver_works() {
 #[test]
 fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::RSA;
-    let mut resolver = rustls::ResolvesServerCertUsingSNI::new();
-    let signing_key = sign::RSASigningKey::new(&kt.get_key()).unwrap();
+    let mut resolver = rustls::ResolvesServerCertUsingSni::new();
+    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
 
     assert_eq!(
@@ -1772,7 +1772,7 @@ fn sni_resolver_rejects_wrong_names() {
         )
     );
     assert_eq!(
-        Err(TLSError::General(
+        Err(TlsError::General(
             "The server certificate is not valid for the given name".into()
         )),
         resolver.add(
@@ -1781,7 +1781,7 @@ fn sni_resolver_rejects_wrong_names() {
         )
     );
     assert_eq!(
-        Err(TLSError::General("Bad DNS name".into())),
+        Err(TlsError::General("Bad DNS name".into())),
         resolver.add(
             "not ascii 🦀",
             sign::CertifiedKey::new(kt.get_chain(), signing_key.clone())
@@ -1792,12 +1792,12 @@ fn sni_resolver_rejects_wrong_names() {
 #[test]
 fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::RSA;
-    let mut resolver = rustls::ResolvesServerCertUsingSNI::new();
-    let signing_key = sign::RSASigningKey::new(&kt.get_key()).unwrap();
+    let mut resolver = rustls::ResolvesServerCertUsingSni::new();
+    let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
     let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
 
     assert_eq!(
-        Err(TLSError::General(
+        Err(TlsError::General(
             "No end-entity certificate in certificate chain".into()
         )),
         resolver.add(
@@ -1808,7 +1808,7 @@ fn sni_resolver_rejects_bad_certs() {
 
     let bad_chain = vec![rustls::Certificate(vec![0xa0])];
     assert_eq!(
-        Err(TLSError::General(
+        Err(TlsError::General(
             "End-entity certificate in certificate chain is syntactically invalid".into()
         )),
         resolver.add(
@@ -1825,11 +1825,11 @@ fn do_exporter_test(client_config: ClientConfig, server_config: ServerConfig) {
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
     assert_eq!(
-        Err(TLSError::HandshakeNotComplete),
+        Err(TlsError::HandshakeNotComplete),
         client.export_keying_material(&mut client_secret, b"label", Some(b"context"))
     );
     assert_eq!(
-        Err(TLSError::HandshakeNotComplete),
+        Err(TlsError::HandshakeNotComplete),
         server.export_keying_material(&mut server_secret, b"label", Some(b"context"))
     );
     do_handshake(&mut client, &mut server);
@@ -2528,7 +2528,7 @@ mod test_quic {
     fn step(
         send: &mut dyn Session,
         recv: &mut dyn Session,
-    ) -> Result<Option<quic::Keys>, TLSError> {
+    ) -> Result<Option<quic::Keys>, TlsError> {
         let mut buf = Vec::new();
         let secrets = loop {
             let prev = buf.len();
@@ -2712,7 +2712,7 @@ mod test_quic {
                 step(&mut client, &mut server)
                     .err()
                     .unwrap(),
-                TLSError::NoApplicationProtocol
+                TlsError::NoApplicationProtocol
             );
 
             assert_eq!(
@@ -2984,7 +2984,7 @@ fn test_server_rejects_duplicate_sni_names() {
     transfer_altered(&mut client, duplicate_sni_payload, &mut server);
     assert_eq!(
         server.process_new_packets(),
-        Err(TLSError::PeerMisbehavedError(
+        Err(TlsError::PeerMisbehavedError(
             "ClientHello SNI contains duplicate name types".into()
         ))
     );
@@ -3008,7 +3008,7 @@ fn test_server_rejects_empty_sni_extension() {
     transfer_altered(&mut client, empty_sni_payload, &mut server);
     assert_eq!(
         server.process_new_packets(),
-        Err(TLSError::PeerMisbehavedError(
+        Err(TlsError::PeerMisbehavedError(
             "ClientHello SNI did not contain a hostname".into()
         ))
     );
@@ -3035,7 +3035,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
     transfer_altered(&mut client, different_kx_group, &mut server);
     assert_eq!(
         server.process_new_packets(),
-        Err(TLSError::PeerIncompatibleError(
+        Err(TlsError::PeerIncompatibleError(
             "no kx group overlap with client".into()
         ))
     );

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -7,7 +7,7 @@ use rustls_pemfile;
 use rustls::internal::msgs::{codec::Codec, codec::Reader, message::Message};
 use rustls::ProtocolVersion;
 use rustls::Session;
-use rustls::TLSError;
+use rustls::TlsError;
 use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore};
 use rustls::{Certificate, PrivateKey};
 use rustls::{ClientConfig, ClientSession};
@@ -15,7 +15,7 @@ use rustls::{ServerConfig, ServerSession};
 
 #[cfg(feature = "dangerous_configuration")]
 use rustls::{
-    ClientCertVerified, ClientCertVerifier, DistinguishedNames, SignatureScheme, WebPKIVerifier,
+    ClientCertVerified, ClientCertVerifier, DistinguishedNames, SignatureScheme, WebPkiVerifier,
 };
 
 use webpki;
@@ -318,7 +318,7 @@ impl Iterator for AllClientVersions {
 
 #[cfg(feature = "dangerous_configuration")]
 pub struct MockClientVerifier {
-    pub verified: fn() -> Result<ClientCertVerified, TLSError>,
+    pub verified: fn() -> Result<ClientCertVerified, TlsError>,
     pub subjects: Option<DistinguishedNames>,
     pub mandatory: Option<bool>,
     pub offered_schemes: Option<Vec<SignatureScheme>>,
@@ -347,7 +347,7 @@ impl ClientCertVerifier for MockClientVerifier {
         _intermediates: &[Certificate],
         sni: Option<&webpki::DNSName>,
         _now: std::time::SystemTime,
-    ) -> Result<ClientCertVerified, TLSError> {
+    ) -> Result<ClientCertVerified, TlsError> {
         assert!(sni.is_some());
         (self.verified)()
     }
@@ -356,15 +356,15 @@ impl ClientCertVerifier for MockClientVerifier {
         if let Some(schemes) = &self.offered_schemes {
             schemes.clone()
         } else {
-            WebPKIVerifier::verification_schemes()
+            WebPkiVerifier::verification_schemes()
         }
     }
 }
 
 #[derive(PartialEq, Debug)]
 pub enum TLSErrorFromPeer {
-    Client(TLSError),
-    Server(TLSError),
+    Client(TlsError),
+    Server(TlsError),
 }
 
 pub fn do_handshake_until_error(


### PR DESCRIPTION
The following renames are applied here (these are the only names affected in the public API, as far as I can tell):

- `TLSError` -> `TlsError`
- `ResolvesServerCertUsingSNI` -> `ResolvesServerCertUsingSni`
- `WebPKIVerifier` -> `WebPkiVerifier`
- `sign::RSASigningKey` -> `sign::RsaSigningKey`