### PR TITLE
Install llvm 12 for coverage build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,11 +61,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install LLVM11
+      - name: Install LLVM12
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
-          sudo apt-get install -y clang-11
+          sudo apt-add-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main'
+          sudo apt-get install -y clang-12
 
       - name: Install rust toolchain
         uses: actions-rs/toolchain@v1

--- a/admin/llvm-gcov
+++ b/admin/llvm-gcov
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-llvm-cov-11 gcov $*
+llvm-cov-12 gcov $*


### PR DESCRIPTION
Rust nightly seem to have moved to LLVM 12 recently.