### PR TITLE
Make bogo setup scripts more robust

### DIFF
--- a/bogo/fetch-and-build
+++ b/bogo/fetch-and-build
@@ -2,7 +2,7 @@
 
 set -ex
 
-mkdir bogo
+mkdir -p bogo
 pushd bogo
 
 git init

--- a/bogo/runme
+++ b/bogo/runme
@@ -9,7 +9,7 @@ if [ ! -e ../target/debug/examples/bogo_shim ] ; then
   (cd ../rustls && cargo build --example bogo_shim --features dangerous_configuration,quic)
 fi
 
-if [ ! -e bogo/ ] ; then
+if [ ! -e bogo/ssl/test/runner/runner.test ] ; then
   ./fetch-and-build
   cp -v keys/* bogo/
 fi


### PR DESCRIPTION
I'm still unable to run bogo without test failures on my local machine (macOS). It looks like most of the failures mention `unhandled option "-on-initial-expect-cipher"`, but I'm not sure what's different here from CI.