### PR TITLE
Improved builder-type API for making ServerConfigs

### DIFF
--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -3,13 +3,17 @@
 extern crate rustls;
 extern crate webpki;
 
-use rustls::{ClientConfig, ClientConnection, Connection, RootCertStore, DEFAULT_CIPHERSUITES};
+use rustls::{ConfigBuilder, ClientConnection, Connection, RootCertStore};
 use std::io;
 use std::sync::Arc;
 
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
-    let config = Arc::new(ClientConfig::new(root_store, &[], DEFAULT_CIPHERSUITES));
+    let config = Arc::new(ConfigBuilder::with_safe_defaults()
+        .for_client()
+        .unwrap()
+        .with_root_certificates(root_store, &[])
+        .with_no_client_auth());
     let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
     let mut client = ClientConnection::new(&config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -2,12 +2,22 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{ServerConfig, ServerConnection, Connection, NoClientAuth};
+use rustls::{ServerConfigBuilder, ServerConnection, Connection, ResolvesServerCert};
 use std::io;
 use std::sync::Arc;
 
+struct Fail;
+
+impl ResolvesServerCert for Fail {
+    fn resolve(&self, _client_hello: rustls::ClientHello) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        None
+    }
+}
+
 fuzz_target!(|data: &[u8]| {
-    let config = Arc::new(ServerConfig::new(NoClientAuth::new()));
+    let config = Arc::new(ServerConfigBuilder::with_safe_default_crypto()
+                          .with_no_client_auth()
+                          .with_cert_resolver(Arc::new(Fail)));
     let mut server= ServerConnection::new(&config);
     let _ = server.read_tls(&mut io::Cursor::new(data));
 });

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{ServerConfigBuilder, ServerConnection, Connection, ResolvesServerCert};
+use rustls::{ConfigBuilder, ServerConnection, Connection, ResolvesServerCert};
 use std::io;
 use std::sync::Arc;
 
@@ -15,7 +15,9 @@ impl ResolvesServerCert for Fail {
 }
 
 fuzz_target!(|data: &[u8]| {
-    let config = Arc::new(ServerConfigBuilder::with_safe_default_crypto()
+    let config = Arc::new(ConfigBuilder::with_safe_defaults()
+                          .for_server()
+                          .unwrap()
                           .with_no_client_auth()
                           .with_cert_resolver(Arc::new(Fail)));
     let mut server= ServerConnection::new(&config);

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -389,13 +389,13 @@ fn lookup_suites(suites: &[String]) -> Vec<&'static rustls::SupportedCipherSuite
 }
 
 /// Make a vector of protocol versions named in `versions`
-fn lookup_versions(versions: &[String]) -> Vec<rustls::ProtocolVersion> {
+fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtocolVersion> {
     let mut out = Vec::new();
 
     for vname in versions {
         let version = match vname.as_ref() {
-            "1.2" => rustls::ProtocolVersion::TLSv1_2,
-            "1.3" => rustls::ProtocolVersion::TLSv1_3,
+            "1.2" => &rustls::version::TLS12,
+            "1.3" => &rustls::version::TLS13,
             _ => panic!(
                 "cannot look up version '{}', valid are '1.2' and '1.3'",
                 vname
@@ -504,7 +504,7 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
     }
 
     if !args.flag_protover.is_empty() {
-        config.versions = lookup_versions(&args.flag_protover);
+        config.versions.replace(&lookup_versions(&args.flag_protover));
     }
 
     if args.flag_no_tickets {

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -497,13 +497,13 @@ fn lookup_suites(suites: &[String]) -> Vec<&'static rustls::SupportedCipherSuite
 }
 
 /// Make a vector of protocol versions named in `versions`
-fn lookup_versions(versions: &[String]) -> Vec<rustls::ProtocolVersion> {
+fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtocolVersion> {
     let mut out = Vec::new();
 
     for vname in versions {
         let version = match vname.as_ref() {
-            "1.2" => rustls::ProtocolVersion::TLSv1_2,
-            "1.3" => rustls::ProtocolVersion::TLSv1_3,
+            "1.2" => &rustls::version::TLS12,
+            "1.3" => &rustls::version::TLS13,
             _ => panic!(
                 "cannot look up version '{}', valid are '1.2' and '1.3'",
                 vname
@@ -601,7 +601,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if !args.flag_protover.is_empty() {
-        config.versions = lookup_versions(&args.flag_protover);
+        config.versions.replace(&lookup_versions(&args.flag_protover));
     }
 
     if args.flag_resumption {

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -385,16 +385,16 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
             .collect::<Vec<_>>();
     }
 
-    cfg.versions.clear();
+    cfg.versions.replace(&[]);
 
     if opts.tls12_supported() {
         cfg.versions
-            .push(ProtocolVersion::TLSv1_2);
+            .enable(&rustls::version::TLS12);
     }
 
     if opts.tls13_supported() {
         cfg.versions
-            .push(ProtocolVersion::TLSv1_3);
+            .enable(&rustls::version::TLS13);
     }
 
 
@@ -462,16 +462,16 @@ fn make_client_cfg(opts: &Options) -> Arc<rustls::ClientConfig> {
         );
     }
 
-    cfg.versions.clear();
+    cfg.versions.replace(&[]);
 
     if opts.tls12_supported() {
         cfg.versions
-            .push(ProtocolVersion::TLSv1_2);
+            .enable(&rustls::version::TLS12);
     }
 
     if opts.tls13_supported() {
         cfg.versions
-            .push(ProtocolVersion::TLSv1_3);
+            .enable(&rustls::version::TLS13);
     }
 
     if opts.enable_early_data {

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -7,9 +7,7 @@
 use webpki;
 use webpki_roots;
 
-use rustls::{
-    ClientConfig, ClientConnection, Connection, Error, RootCertStore, DEFAULT_CIPHERSUITES,
-};
+use rustls::{ClientConfig, ClientConnection, ConfigBuilder, Connection, Error, RootCertStore};
 use std::env;
 use std::error::Error as StdError;
 use std::fs::File;
@@ -38,7 +36,11 @@ fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<dyn St
             return Err(From::from("Incorrect number of arguments"));
         }
     };
-    let config = ClientConfig::new(root_store, &[], DEFAULT_CIPHERSUITES);
+    let config = ConfigBuilder::with_safe_defaults()
+        .for_client()
+        .unwrap()
+        .with_root_certificates(root_store, &[])
+        .with_no_client_auth();
 
     let port = args[2].parse()?;
     Ok((args[1].clone(), port, config))

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -18,7 +18,7 @@ fn main() {
     let config = rustls::ClientConfig::new(
         root_store,
         &[],
-        &[&rustls::cipher_suites::TLS13_CHACHA20_POLY1305_SHA256],
+        &[&rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256],
     );
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -58,7 +58,11 @@ fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 
-    let mut config = rustls::ClientConfig::new(root_store, &[], rustls::DEFAULT_CIPHERSUITES);
+    let mut config = rustls::ConfigBuilder::with_safe_defaults()
+        .for_client()
+        .unwrap()
+        .with_root_certificates(root_store, &[])
+        .with_no_client_auth();
 
     // Enable early data.
     config.enable_early_data = true;

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -21,7 +21,11 @@ use rustls::{Connection, RootCertStore};
 fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-    let config = rustls::ClientConfig::new(root_store, &[], rustls::DEFAULT_CIPHERSUITES);
+    let config = rustls::ConfigBuilder::with_safe_defaults()
+        .for_client()
+        .unwrap()
+        .with_root_certificates(root_store, &[])
+        .with_no_client_auth();
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
     let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -1,0 +1,187 @@
+use crate::client::builder::ClientConfigBuilder;
+use crate::error::Error;
+use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
+use crate::msgs::enums::ProtocolVersion;
+use crate::server::builder::ServerConfigBuilder;
+use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHERSUITES};
+use crate::versions;
+
+/// Building a [`ServerConfig`] or [`ClientConfig`] in a linker-friendly way.
+///
+/// Linker-friendly: meaning unused cipher suites, protocol
+/// versions, key exchange mechanisms, etc. can be discarded
+/// by the linker as they'll be unreferenced.
+///
+/// Example, to make a [`ServerConfig`]:
+///
+/// ```
+/// # use rustls::ConfigBuilder;
+/// ConfigBuilder::with_safe_default_cipher_suites()
+///     .with_safe_default_kx_groups()
+///     .with_safe_default_protocol_versions()
+///     .for_server()
+///     .unwrap();
+/// ```
+///
+/// This may be shortened to:
+///
+/// ```
+/// # use rustls::ConfigBuilder;
+/// ConfigBuilder::with_safe_defaults()
+///     .for_server()
+///     .unwrap();
+/// ```
+///
+/// The types used here fit together like this:
+///
+/// 1. You must make a decision on which cipher suites to use, typically
+///    by calling [`ConfigBuilder::with_safe_default_cipher_suites()`].
+/// 2. You now have a [`ConfigBuilderWithSuites`].  You must make a decision
+///    on key exchange groups: typically by calling [`ConfigBuilderWithSuites::with_safe_default_kx_groups()`].
+/// 3. You now have a [`ConfigBuilderWithKxGroups`].  You must make
+///    a decision on which protocol versions to support, typically by calling
+///    [`ConfigBuilderWithKxGroups::with_safe_default_protocol_versions()`].
+/// 4. You now have a [`ConfigBuilderWithVersions`] and need to decide whether to
+///    make a [`ServerConfig`] or [`ClientConfig`] -- call [`ConfigBuilderWithVersions::for_server()`]
+///    or [`ConfigBuilderWithVersions::for_client()`] respectively.
+/// 5. Now see [`ServerConfigBuilder`] or [`ClientConfigBuilder`] for further steps.
+pub struct ConfigBuilder;
+
+impl ConfigBuilder {
+    /// Start building a [`ServerConfig`] or [`ClientConfig`], and accept
+    /// defaults for underlying cryptography.
+    ///
+    /// These are safe defaults, useful for 99% of applications.
+    pub fn with_safe_defaults() -> ConfigBuilderWithVersions {
+        ConfigBuilder::with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_safe_default_protocol_versions()
+    }
+
+    /// Choose a specific set of cipher suites.
+    pub fn with_cipher_suites(
+        cipher_suites: &[&'static SupportedCipherSuite],
+    ) -> ConfigBuilderWithSuites {
+        ConfigBuilderWithSuites {
+            cipher_suites: cipher_suites.to_vec(),
+        }
+    }
+
+    /// Choose the default set of cipher suites.
+    ///
+    /// Note that this default provides only high-quality suites: there is no need
+    /// to filter out low-, export- or NULL-strength cipher suites: rustls does not
+    /// implement these.
+    pub fn with_safe_default_cipher_suites() -> ConfigBuilderWithSuites {
+        Self::with_cipher_suites(DEFAULT_CIPHERSUITES)
+    }
+}
+
+/// A [`ConfigBuilder`] where we know the cipher suites.
+pub struct ConfigBuilderWithSuites {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+}
+
+impl ConfigBuilderWithSuites {
+    /// Choose a specific set of key exchange groups.
+    pub fn with_kx_groups(
+        self,
+        kx_groups: &[&'static SupportedKxGroup],
+    ) -> ConfigBuilderWithKxGroups {
+        ConfigBuilderWithKxGroups {
+            cipher_suites: self.cipher_suites,
+            kx_groups: kx_groups.to_vec(),
+        }
+    }
+
+    /// Choose the default set of key exchange groups.
+    ///
+    /// This is a safe default: rustls doesn't implement any poor-quality groups.
+    pub fn with_safe_default_kx_groups(self) -> ConfigBuilderWithKxGroups {
+        self.with_kx_groups(&ALL_KX_GROUPS)
+    }
+}
+
+/// A [`ConfigBuilder`] where we know the cipher suites and key exchange
+/// groups.
+pub struct ConfigBuilderWithKxGroups {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    kx_groups: Vec<&'static SupportedKxGroup>,
+}
+
+impl ConfigBuilderWithKxGroups {
+    /// Accept the default protocol versions: both TLS1.2 and TLS1.3 are enabled.
+    pub fn with_safe_default_protocol_versions(self) -> ConfigBuilderWithVersions {
+        self.with_protocol_versions(versions::DEFAULT_VERSIONS)
+    }
+
+    /// Use a specific set of protocol versions.
+    pub fn with_protocol_versions(
+        self,
+        versions: &[&'static versions::SupportedProtocolVersion],
+    ) -> ConfigBuilderWithVersions {
+        ConfigBuilderWithVersions {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            versions: versions::EnabledVersions::new(versions),
+        }
+    }
+}
+
+/// A [`ConfigBuilder`] where we know the cipher suites, key exchange groups,
+/// and protocol versions.
+pub struct ConfigBuilderWithVersions {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    kx_groups: Vec<&'static SupportedKxGroup>,
+    versions: versions::EnabledVersions,
+}
+
+impl ConfigBuilderWithVersions {
+    fn validate(&self) -> Result<(), Error> {
+        let mut any_usable_suite = false;
+        for suite in &self.cipher_suites {
+            for version in &[ProtocolVersion::TLSv1_2, ProtocolVersion::TLSv1_3] {
+                if self.versions.contains(*version) && suite.usable_for_version(*version) {
+                    any_usable_suite = true;
+                    break;
+                }
+            }
+        }
+
+        if !any_usable_suite {
+            return Err(Error::General("no usable cipher suites configured".into()));
+        }
+
+        if self.kx_groups.is_empty() {
+            return Err(Error::General("no kx groups configured".into()));
+        }
+
+        Ok(())
+    }
+
+    /// Continue building a `ClientConfig`.
+    ///
+    /// This may fail, if the previous selections are contradictory or
+    /// not useful (for example, if no protocol versions are enabled).
+    pub fn for_client(self) -> Result<ClientConfigBuilder, Error> {
+        self.validate()?;
+        Ok(ClientConfigBuilder {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            versions: self.versions,
+        })
+    }
+
+    /// Continue building a `ServerConfig`.
+    ///
+    /// This may fail, if the previous selections are contradictory or
+    /// not useful (for example, if no protocol versions are enabled).
+    pub fn for_server(self) -> Result<ServerConfigBuilder, Error> {
+        self.validate()?;
+        Ok(ServerConfigBuilder {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            versions: self.versions,
+        })
+    }
+}

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -1,0 +1,144 @@
+use crate::anchors;
+use crate::client::handy;
+use crate::client::{ClientConfig, ResolvesClientCert};
+use crate::error::Error;
+use crate::key;
+use crate::keylog::NoKeyLog;
+use crate::kx::SupportedKxGroup;
+use crate::suites::SupportedCipherSuite;
+use crate::verify;
+use crate::versions;
+
+use std::sync::Arc;
+
+/// Building a [`ClientConfig`] in a linker-friendly way.
+///
+/// Linker-friendly: meaning unused cipher suites, protocol
+/// versions, key exchange mechanisms, etc. can be discarded
+/// by the linker as they'll be unreferenced.
+///
+/// Example:
+///
+/// ```no_run
+/// # use rustls::ConfigBuilder;
+/// # let root_certs = rustls::RootCertStore::empty();
+/// # let trusted_ct_logs = &[];
+/// # let certs = vec![];
+/// # let private_key = rustls::PrivateKey(vec![]);
+/// ConfigBuilder::with_safe_default_cipher_suites()
+///     .with_safe_default_kx_groups()
+///     .with_safe_default_protocol_versions()
+///     .for_client()
+///     .unwrap()
+///     .with_root_certificates(root_certs, trusted_ct_logs)
+///     .with_single_cert(certs, private_key)
+///     .expect("bad certificate/key");
+/// ```
+///
+/// This may be shortened to:
+///
+/// ```
+/// # use rustls::ConfigBuilder;
+/// # let root_certs = rustls::RootCertStore::empty();
+/// # let trusted_ct_logs = &[];
+/// ConfigBuilder::with_safe_defaults()
+///     .for_client()
+///     .unwrap()
+///     .with_root_certificates(root_certs, trusted_ct_logs)
+///     .with_no_client_auth();
+/// ```
+///
+/// # Resulting [`ConfigConfig`] defaults
+/// * [`ClientConfig::mtu`]: the default is `None`: TLS packets are not fragmented to fit in single IP packet.
+/// * [`ClientConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
+/// * [`ClientConfig::key_log`]: key material is not logged.
+pub struct ClientConfigBuilder {
+    pub(crate) cipher_suites: Vec<&'static SupportedCipherSuite>,
+    pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,
+    pub(crate) versions: versions::EnabledVersions,
+}
+
+impl ClientConfigBuilder {
+    /// Choose how to verify client certificates.
+    pub fn with_root_certificates(
+        self,
+        root_store: anchors::RootCertStore,
+        ct_logs: &'static [&'static sct::Log],
+    ) -> ClientConfigBuilderWithCertVerifier {
+        let verifier = Arc::new(verify::WebPkiVerifier::new(root_store, ct_logs));
+
+        ClientConfigBuilderWithCertVerifier {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            versions: self.versions,
+            verifier,
+        }
+    }
+
+    #[cfg(feature = "dangerous_configuration")]
+    pub fn with_custom_certificate_verifier(
+        self,
+        verifier: Arc<dyn verify::ServerCertVerifier>,
+    ) -> ClientConfigBuilderWithCertVerifier {
+        ClientConfigBuilderWithCertVerifier {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            versions: self.versions,
+            verifier,
+        }
+    }
+}
+
+/// A [`ClientConfigBuilder`] where we know the cipher suites, key exchange
+/// groups, enabled versions, and server certificate auth policy.
+pub struct ClientConfigBuilderWithCertVerifier {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    kx_groups: Vec<&'static SupportedKxGroup>,
+    versions: versions::EnabledVersions,
+    verifier: Arc<dyn verify::ServerCertVerifier>,
+}
+
+impl ClientConfigBuilderWithCertVerifier {
+    /// Sets a single certificate chain and matching private key for use
+    /// in client authentication.
+    ///
+    /// `cert_chain` is a vector of DER-encoded certificates.
+    /// `key_der` is a DER-encoded RSA, ECDSA, or Ed25519 private key.
+    ///
+    /// This function fails if `key_der` is invalid.
+    pub fn with_single_cert(
+        self,
+        cert_chain: Vec<key::Certificate>,
+        key_der: key::PrivateKey,
+    ) -> Result<ClientConfig, Error> {
+        let resolver = handy::AlwaysResolvesClientCert::new(cert_chain, &key_der)?;
+        Ok(self.with_client_cert_resolver(Arc::new(resolver)))
+    }
+
+    /// Do not support client auth.
+    pub fn with_no_client_auth(self) -> ClientConfig {
+        self.with_client_cert_resolver(Arc::new(handy::FailResolveClientCert {}))
+    }
+
+    /// Sets a custom [`ResolvesClientCert`].
+    pub fn with_client_cert_resolver(
+        self,
+        client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
+    ) -> ClientConfig {
+        ClientConfig {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            alpn_protocols: Vec::new(),
+            session_storage: handy::ClientSessionMemoryCache::new(256),
+            mtu: None,
+            client_auth_cert_resolver,
+            enable_tickets: true,
+            versions: self.versions,
+            enable_sni: true,
+            verifier: self.verifier,
+            key_log: Arc::new(NoKeyLog {}),
+            enable_early_data: false,
+        }
+    }
+}

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -85,7 +85,7 @@ fn find_session(
 
     let value = cx
         .config
-        .session_persistence
+        .session_storage
         .get(&key_buf)
         .or_else(|| {
             debug!("No cached session for {:?}", dns_name);
@@ -265,7 +265,7 @@ fn emit_client_hello_for_retry(
     ));
     exts.push(ClientExtension::SignatureAlgorithms(
         cx.config
-            .get_verifier()
+            .verifier
             .supported_verify_schemes(),
     ));
     exts.push(ClientExtension::ExtendedMasterSecretRequest);

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -13,6 +13,7 @@ use crate::msgs::handshake::{CertificatePayload, ClientExtension};
 use crate::sign;
 use crate::suites::SupportedCipherSuite;
 use crate::verify;
+use crate::versions;
 use crate::{key, RootCertStore};
 
 #[cfg(feature = "quic")]
@@ -114,7 +115,7 @@ pub struct ClientConfig {
 
     /// Supported versions, in no particular order.  The default
     /// is all supported versions.
-    pub versions: Vec<ProtocolVersion>,
+    pub versions: versions::EnabledVersions,
 
     /// Whether to send the Server Name Indication (SNI) extension
     /// during the client handshake.
@@ -187,7 +188,7 @@ impl ClientConfig {
             mtu: None,
             client_auth_cert_resolver: Arc::new(handy::FailResolveClientCert {}),
             enable_tickets: true,
-            versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
+            versions: versions::EnabledVersions::new(&[&versions::TLS12, &versions::TLS13]),
             enable_sni: true,
             verifier,
             key_log: Arc::new(NoKeyLog {}),
@@ -200,7 +201,7 @@ impl ClientConfig {
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.versions.contains(&v)
+        self.versions.contains(v)
             && self
                 .cipher_suites
                 .iter()

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -705,7 +705,7 @@ impl hs::State for ExpectServerDone {
         let now = std::time::SystemTime::now();
         let cert_verified = cx
             .config
-            .get_verifier()
+            .verifier
             .verify_server_cert(
                 end_entity,
                 intermediates,
@@ -740,7 +740,7 @@ impl hs::State for ExpectServerDone {
             }
 
             cx.config
-                .get_verifier()
+                .verifier
                 .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
                 .map_err(|err| hs::send_cert_error_alert(cx.common, err))?
         };
@@ -962,7 +962,7 @@ fn save_session(
 
     let worked = cx
         .config
-        .session_persistence
+        .session_storage
         .put(key.get_encoding(), value.get_encoding());
 
     if worked {

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -223,7 +223,7 @@ pub(super) fn initial_key_share(
     let key = persist::ClientSessionKey::hint_for_dns_name(dns_name);
     let key_buf = key.get_encoding();
 
-    let maybe_value = config.session_persistence.get(&key_buf);
+    let maybe_value = config.session_storage.get(&key_buf);
 
     let group = maybe_value
         .and_then(|enc| NamedGroup::read_bytes(&enc))
@@ -242,7 +242,7 @@ fn save_kx_hint(config: &ClientConfig, dns_name: webpki::DnsNameRef, group: Name
     let key = persist::ClientSessionKey::hint_for_dns_name(dns_name);
 
     config
-        .session_persistence
+        .session_storage
         .put(key.get_encoding(), group.get_encoding());
 }
 
@@ -644,7 +644,7 @@ impl hs::State for ExpectCertificateVerify {
         let now = std::time::SystemTime::now();
         let cert_verified = cx
             .config
-            .get_verifier()
+            .verifier
             .verify_server_cert(
                 end_entity,
                 intermediates,
@@ -659,7 +659,7 @@ impl hs::State for ExpectCertificateVerify {
         let handshake_hash = self.transcript.get_current_hash();
         let sig_verified = cx
             .config
-            .get_verifier()
+            .verifier
             .verify_tls13_signature(
                 &verify::construct_tls13_server_verify_message(&handshake_hash),
                 &self.server_cert.cert_chain[0],
@@ -1071,7 +1071,7 @@ impl ExpectTraffic {
 
         let worked = cx
             .config
-            .session_persistence
+            .session_storage
             .put(key.get_encoding(), ticket);
 
         if worked {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -106,26 +106,28 @@
 //! and use it for all connections made by that process.
 //!
 //! ```rust,ignore
-//! let config = rustls::ClientConfig::new(
-//!     root_store,
-//!     trusted_ct_logs,
-//!     rustls::DEFAULT_CIPHERSUITES);
+//! let config = rustls::ConfigBuilder::with_safe_defaults()
+//!     .for_client()
+//!     .unwrap()
+//!     .with_root_certificates(root_store, trusted_ct_logs)
+//!     .with_no_client_auth();
 //! ```
 //!
 //! Now we can make a connection.  You need to provide the server's hostname so we
 //! know what to expect to find in the server's certificate.
 //!
-//! ```no_run
+//! ```
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
 //! # let mut root_store = rustls::RootCertStore::empty();
 //! # root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 //! # let trusted_ct_logs = &[];
-//! # let config = rustls::ClientConfig::new(
-//! #     root_store,
-//! #     trusted_ct_logs,
-//! #     rustls::DEFAULT_CIPHERSUITES);
+//! # let config = rustls::ConfigBuilder::with_safe_defaults()
+//! #     .for_client()
+//! #     .unwrap()
+//! #     .with_root_certificates(root_store, trusted_ct_logs)
+//! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);
 //! let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
 //! let mut client = rustls::ClientConnection::new(&rc_config, example_com);
@@ -267,14 +269,15 @@ mod x509;
 #[macro_use]
 mod check;
 mod bs_debug;
+mod builder;
 mod client;
 mod key;
 mod keylog;
 mod kx;
 mod server;
 mod suites;
-mod versions;
 mod ticketer;
+mod versions;
 
 /// Internal classes which may be useful outside the library.
 /// The contents of this section DO NOT form part of the stable interface.
@@ -287,6 +290,9 @@ pub mod internal {
 
 // The public interface is:
 pub use crate::anchors::{DistinguishedNames, OwnedTrustAnchor, RootCertStore};
+pub use crate::builder::{
+    ConfigBuilder, ConfigBuilderWithKxGroups, ConfigBuilderWithSuites, ConfigBuilderWithVersions,
+};
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::StoresClientSessions;
@@ -300,10 +306,7 @@ pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
-pub use crate::server::builder::{
-    ServerConfigBuilder, ServerConfigBuilderWithClientAuth, ServerConfigBuilderWithKxGroups,
-    ServerConfigBuilderWithSuites,
-};
+pub use crate::server::builder::{ServerConfigBuilder, ServerConfigBuilderWithClientAuth};
 pub use crate::server::handy::ResolvesServerCertUsingSni;
 pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 pub use crate::server::StoresServerSessions;
@@ -313,13 +316,11 @@ pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES, DEFAULT_CIPHERSUITES,
 };
-pub use crate::versions::{
-    SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS,
-};
 pub use crate::ticketer::Ticketer;
 pub use crate::verify::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
 };
+pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
 
 /// All defined ciphersuites appear in this module.
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -299,6 +299,10 @@ pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
+pub use crate::server::builder::{
+    ServerConfigBuilder, ServerConfigBuilderWithClientAuth, ServerConfigBuilderWithKxGroups,
+    ServerConfigBuilderWithSuites,
+};
 pub use crate::server::handy::ResolvesServerCertUsingSni;
 pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 pub use crate::server::StoresServerSessions;

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -273,6 +273,7 @@ mod keylog;
 mod kx;
 mod server;
 mod suites;
+mod versions;
 mod ticketer;
 
 /// Internal classes which may be useful outside the library.
@@ -312,6 +313,9 @@ pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES, DEFAULT_CIPHERSUITES,
 };
+pub use crate::versions::{
+    SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS,
+};
 pub use crate::ticketer::Ticketer;
 pub use crate::verify::{
     AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
@@ -320,7 +324,7 @@ pub use crate::verify::{
 /// All defined ciphersuites appear in this module.
 ///
 /// ALL_CIPHERSUITES is provided as an array of all of these values.
-pub mod cipher_suites {
+pub mod cipher_suite {
     pub use crate::suites::TLS13_AES_128_GCM_SHA256;
     pub use crate::suites::TLS13_AES_256_GCM_SHA384;
     pub use crate::suites::TLS13_CHACHA20_POLY1305_SHA256;
@@ -330,6 +334,14 @@ pub mod cipher_suites {
     pub use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
     pub use crate::suites::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384;
     pub use crate::suites::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256;
+}
+
+/// All defined protocol versions appear in this module.
+///
+/// ALL_VERSIONS is a provided as an arry of all of these values.
+pub mod version {
+    pub use crate::versions::TLS12;
+    pub use crate::versions::TLS13;
 }
 
 /// All defined key exchange groups appear in this module.

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -1,0 +1,237 @@
+use crate::error::Error;
+use crate::key;
+use crate::keylog::NoKeyLog;
+use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
+use crate::msgs::enums::ProtocolVersion;
+use crate::server::handy;
+use crate::server::{ResolvesServerCert, ServerConfig};
+use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHERSUITES};
+use crate::verify;
+
+use std::sync::Arc;
+
+/// Building a [`ServerConfig`] in a linker-friendly way.
+///
+/// Linker-friendly: meaning unused cipher suites, protocol
+/// versions, key exchange mechanisms, etc. can be discarded
+/// by the linker as they'll be unreferenced.
+///
+/// Example:
+///
+/// ```ignore
+/// ServerConfigBuilder::new()
+///     .with_safe_default_cipher_suites()
+///     .with_safe_default_kx_groups()
+///     .with_no_client_auth()
+///     .with_single_cert(certs, private_key)
+///     .build();
+/// ```
+///
+/// This may be shortened to:
+///
+/// ```ignore
+/// ServerConfigBuilder::with_safe_default_crypto()
+///     .with_no_client_auth()
+///     .with_single_cert(certs, private_key)
+///     .build();
+/// ```
+///
+/// The types used here fit together like this:
+///
+/// 1. Get a [`ServerConfigBuilder`] with [`ServerConfigBuilder::new()`].
+///    You must make a decision on which cipher suites to use, typically
+///    by calling [`ServerConfigBuilder::with_safe_default_cipher_suites()`].
+/// 2. You now have a [`ServerConfigBuilderWithSuites`].  You must make a decision
+///    on key exchange groups: typically by calling [`ServerConfigBuilderWithSuites::with_safe_default_kx_groups()`].
+/// 3. You now have a [`ServerConfigBuilderWithKxGroups`].  You must make
+///    a decision on how and whether to use client authentication.  Perhaps
+///    you call [`ServerConfigBuilderWithKxGroups::with_no_client_auth()`].
+/// 4. You now have a [`ServerConfigBuilderWithClientAuth`].  You must
+///    now provide server authentication credentials.  If you have just a single
+///    key and certificate chain, you might call [`ServerConfigBuilderWithClientAuth::with_single_cert()`].
+/// 5. You now have a [`ServerConfig`].  This object has a number
+///    of defaults you can change.
+///
+/// # [`ServerConfig`] defaults
+/// * [`ServerConfig::mtu`]: the default is `None`: TLS packets are not fragmented to fit in single IP packet.
+/// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
+/// * [`ServerConfig::versions`]: both TLS1.2 and TLS1.3 are supported.
+/// * [`ServerConfig::key_log`]: key material is not logged.
+pub struct ServerConfigBuilder {}
+
+impl ServerConfigBuilder {
+    /// Start building a [`ServerConfig`].
+    pub fn new() -> ServerConfigBuilder {
+        ServerConfigBuilder {}
+    }
+
+    /// Start building a [`ServerConfig`], and accept defaults for underlying
+    /// cryptography.
+    ///
+    /// These are safe defaults, useful for 99% of applications.
+    ///
+    /// With the returned object, you must still make decisions on
+    /// client authentication and provide server credentials -- rustls
+    /// can't provide useful defaults for these.
+    pub fn with_safe_default_crypto() -> ServerConfigBuilderWithKxGroups {
+        ServerConfigBuilder::new()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+    }
+
+    /// Choose a specific set of cipher suites.
+    pub fn with_cipher_suites(
+        self,
+        cipher_suites: &[&'static SupportedCipherSuite],
+    ) -> ServerConfigBuilderWithSuites {
+        ServerConfigBuilderWithSuites {
+            cipher_suites: cipher_suites.to_vec(),
+        }
+    }
+
+    /// Choose the default set of cipher suites.
+    ///
+    /// Note that this default provides only high-quality suites: there is no need
+    /// to filter out low-, export- or NULL-strength cipher suites: rustls does not
+    /// implement these.
+    pub fn with_safe_default_cipher_suites(self) -> ServerConfigBuilderWithSuites {
+        self.with_cipher_suites(DEFAULT_CIPHERSUITES)
+    }
+}
+
+/// A [`ServerConfigBuilder`] where we know the cipher suites.
+pub struct ServerConfigBuilderWithSuites {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+}
+
+impl ServerConfigBuilderWithSuites {
+    /// Choose a specific set of key exchange groups.
+    pub fn with_kx_groups(
+        self,
+        kx_groups: &[&'static SupportedKxGroup],
+    ) -> ServerConfigBuilderWithKxGroups {
+        ServerConfigBuilderWithKxGroups {
+            cipher_suites: self.cipher_suites,
+            kx_groups: kx_groups.to_vec(),
+        }
+    }
+
+    /// Choose the default set of key exchange groups.
+    ///
+    /// This is a safe default: rustls doesn't implement any poor-quality groups.
+    pub fn with_safe_default_kx_groups(self) -> ServerConfigBuilderWithKxGroups {
+        self.with_kx_groups(&ALL_KX_GROUPS)
+    }
+}
+
+/// A [`ServerConfigBuilder`] where we know the cipher suites and key exchange
+/// groups.
+pub struct ServerConfigBuilderWithKxGroups {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    kx_groups: Vec<&'static SupportedKxGroup>,
+}
+
+/// Reduce typing for the most common case.
+impl Default for ServerConfigBuilderWithKxGroups {
+    fn default() -> Self {
+        ServerConfigBuilder::with_safe_default_crypto()
+    }
+}
+
+impl ServerConfigBuilderWithKxGroups {
+    /// Choose how to verify client certificates.
+    pub fn with_client_cert_verifier(
+        self,
+        client_cert_verifier: Arc<dyn verify::ClientCertVerifier>,
+    ) -> ServerConfigBuilderWithClientAuth {
+        ServerConfigBuilderWithClientAuth {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            verifier: client_cert_verifier,
+        }
+    }
+
+    /// Disable client authentication.
+    pub fn with_no_client_auth(self) -> ServerConfigBuilderWithClientAuth {
+        ServerConfigBuilderWithClientAuth {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            verifier: verify::NoClientAuth::new(),
+        }
+    }
+}
+
+/// A [`ServerConfigBuilder`] where we know the cipher suites, key exchange
+/// groups, and client auth policy.
+pub struct ServerConfigBuilderWithClientAuth {
+    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    kx_groups: Vec<&'static SupportedKxGroup>,
+    verifier: Arc<dyn verify::ClientCertVerifier>,
+}
+
+impl ServerConfigBuilderWithClientAuth {
+    /// Sets a single certificate chain and matching private key.  This
+    /// certificate and key is used for all subsequent connections,
+    /// irrespective of things like SNI hostname.
+    ///
+    /// Note that the end-entity certificate must have the
+    /// [Subject Alternative Name](https://tools.ietf.org/html/rfc6125#section-4.1)
+    /// extension to describe, e.g., the valid DNS name. The `commonName` field is
+    /// disregarded.
+    ///
+    /// `cert_chain` is a vector of DER-encoded certificates.
+    /// `key_der` is a DER-encoded RSA, ECDSA, or Ed25519 private key.
+    ///
+    /// This function fails if `key_der` is invalid.
+    pub fn with_single_cert(
+        self,
+        cert_chain: Vec<key::Certificate>,
+        key_der: key::PrivateKey,
+    ) -> Result<ServerConfig, Error> {
+        let resolver = handy::AlwaysResolvesChain::new(cert_chain, &key_der)?;
+        Ok(self.with_cert_resolver(Arc::new(resolver)))
+    }
+
+    /// Sets a single certificate chain, matching private key, OCSP
+    /// response and SCTs.  This certificate and key is used for all
+    /// subsequent connections, irrespective of things like SNI hostname.
+    ///
+    /// `cert_chain` is a vector of DER-encoded certificates.
+    /// `key_der` is a DER-encoded RSA, ECDSA, or Ed25519 private key.
+    /// `ocsp` is a DER-encoded OCSP response.  Ignored if zero length.
+    /// `scts` is an `SignedCertificateTimestampList` encoding (see RFC6962)
+    /// and is ignored if empty.
+    ///
+    /// This function fails if `key_der` is invalid.
+    pub fn with_single_cert_with_ocsp_and_sct(
+        self,
+        cert_chain: Vec<key::Certificate>,
+        key_der: key::PrivateKey,
+        ocsp: Vec<u8>,
+        scts: Vec<u8>,
+    ) -> Result<ServerConfig, Error> {
+        let resolver =
+            handy::AlwaysResolvesChain::new_with_extras(cert_chain, &key_der, ocsp, scts)?;
+        Ok(self.with_cert_resolver(Arc::new(resolver)))
+    }
+
+    /// Sets a custom [`ResolvesServerCert`].
+    pub fn with_cert_resolver(self, cert_resolver: Arc<dyn ResolvesServerCert>) -> ServerConfig {
+        ServerConfig {
+            cipher_suites: self.cipher_suites,
+            kx_groups: self.kx_groups,
+            verifier: self.verifier,
+            cert_resolver,
+            ignore_client_order: false,
+            mtu: None,
+            session_storage: handy::ServerSessionMemoryCache::new(256),
+            ticketer: Arc::new(handy::NeverProducesTickets {}),
+            alpn_protocols: Vec::new(),
+            versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
+            key_log: Arc::new(NoKeyLog {}),
+            #[cfg(feature = "quic")]
+            max_early_data_size: 0,
+        }
+    }
+}

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -2,11 +2,11 @@ use crate::error::Error;
 use crate::key;
 use crate::keylog::NoKeyLog;
 use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
-use crate::msgs::enums::ProtocolVersion;
 use crate::server::handy;
 use crate::server::{ResolvesServerCert, ServerConfig};
 use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHERSUITES};
 use crate::verify;
+use crate::versions;
 
 use std::sync::Arc;
 
@@ -228,7 +228,7 @@ impl ServerConfigBuilderWithClientAuth {
             session_storage: handy::ServerSessionMemoryCache::new(256),
             ticketer: Arc::new(handy::NeverProducesTickets {}),
             alpn_protocols: Vec::new(),
-            versions: vec![ProtocolVersion::TLSv1_3, ProtocolVersion::TLSv1_2],
+            versions: versions::EnabledVersions::new(&[&versions::TLS12, &versions::TLS13]),
             key_log: Arc::new(NoKeyLog {}),
             #[cfg(feature = "quic")]
             max_early_data_size: 0,

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -81,15 +81,6 @@ impl server::ProducesTickets for NeverProducesTickets {
     }
 }
 
-/// Something which never resolves a certificate.
-pub struct FailResolveChain {}
-
-impl server::ResolvesServerCert for FailResolveChain {
-    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
-        None
-    }
-}
-
 /// Something which always resolves to the same cert chain.
 pub struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
@@ -259,15 +250,6 @@ mod test {
         assert_eq!(0, npt.lifetime());
         assert_eq!(None, npt.encrypt(&[]));
         assert_eq!(None, npt.decrypt(&[]));
-    }
-
-    #[test]
-    fn test_failresolvechain_does_nothing() {
-        let frc = FailResolveChain {};
-        assert!(
-            frc.resolve(ClientHello::new(None, &[], None))
-                .is_none()
-        );
     }
 
     #[test]

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -185,7 +185,7 @@ pub struct ServerConfig {
 
     /// Supported protocol versions, in no particular order.
     /// The default is all supported versions.
-    pub versions: Vec<ProtocolVersion>,
+    pub versions: crate::versions::EnabledVersions,
 
     /// How to verify client certificates.
     verifier: Arc<dyn verify::ClientCertVerifier>,
@@ -206,7 +206,7 @@ impl ServerConfig {
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.versions.contains(&v)
+        self.versions.contains(v)
             && self
                 .cipher_suites
                 .iter()

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -212,11 +212,6 @@ impl ServerConfig {
                 .iter()
                 .any(|cs| cs.usable_for_version(v))
     }
-
-    #[doc(hidden)]
-    pub fn get_verifier(&self) -> &dyn verify::ClientCertVerifier {
-        self.verifier.as_ref()
-    }
 }
 
 /// This represents a single TLS server connection.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -425,7 +425,7 @@ mod client_hello {
         transcript: &mut HandshakeHash,
         cx: &mut ServerContext<'_>,
     ) -> Result<bool, Error> {
-        let client_auth = cx.config.get_verifier();
+        let client_auth = &cx.config.verifier;
 
         if !client_auth.offer_client_auth() {
             return Ok(false);
@@ -641,7 +641,7 @@ impl hs::State for ExpectCertificateVerify {
             let certs = &self.client_cert;
 
             cx.config
-                .get_verifier()
+                .verifier
                 .verify_tls12_signature(&handshake_msgs, &certs[0], sig)
         };
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -557,7 +557,7 @@ mod client_hello {
 
         let schemes = cx
             .config
-            .get_verifier()
+            .verifier
             .supported_verify_schemes();
         cr.extensions
             .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
@@ -795,7 +795,7 @@ impl hs::State for ExpectCertificate {
 
         let now = std::time::SystemTime::now();
         cx.config
-            .get_verifier()
+            .verifier
             .verify_client_cert(end_entity, intermediates, cx.data.get_sni(), now)
             .map_err(|err| {
                 hs::incompatible(&mut cx.common, "certificate invalid");
@@ -838,7 +838,7 @@ impl hs::State for ExpectCertificateVerify {
             let msg = verify::construct_tls13_client_verify_message(&handshake_hash);
 
             cx.config
-                .get_verifier()
+                .verifier
                 .verify_tls13_signature(&msg, &certs[0], sig)
         };
 

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -13,26 +13,19 @@ pub struct SupportedProtocolVersion {
 }
 
 /// TLS1.2
-pub static TLS12: SupportedProtocolVersion =
-    SupportedProtocolVersion {
-        version: ProtocolVersion::TLSv1_2,
-        is_private: ()
-    };
-
-
+pub static TLS12: SupportedProtocolVersion = SupportedProtocolVersion {
+    version: ProtocolVersion::TLSv1_2,
+    is_private: (),
+};
 
 /// TLS1.3
-pub static TLS13: SupportedProtocolVersion =
-    SupportedProtocolVersion {
-        version: ProtocolVersion::TLSv1_3,
-        is_private: (),
-    };
+pub static TLS13: SupportedProtocolVersion = SupportedProtocolVersion {
+    version: ProtocolVersion::TLSv1_3,
+    is_private: (),
+};
 
 /// A list of all the protocol versions supported by rustls.
-pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[
-    &TLS13,
-    &TLS12,
-];
+pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[&TLS13, &TLS12];
 
 /// The version configuration that an application should use by default.
 ///
@@ -61,7 +54,7 @@ impl EnabledVersions {
         match version {
             ProtocolVersion::TLSv1_2 => self.tls12.is_some(),
             ProtocolVersion::TLSv1_3 => self.tls13.is_some(),
-            _ => false
+            _ => false,
         }
     }
 
@@ -70,7 +63,7 @@ impl EnabledVersions {
         match v.version {
             ProtocolVersion::TLSv1_2 => self.tls12 = Some(v),
             ProtocolVersion::TLSv1_3 => self.tls13 = Some(v),
-            _ => {},
+            _ => {}
         }
     }
 

--- a/rustls/src/versions.rs
+++ b/rustls/src/versions.rs
@@ -1,0 +1,86 @@
+use crate::msgs::enums::ProtocolVersion;
+
+/// A TLS protocl version supported by rustls.
+///
+/// All possible instances of this class are provided by the library in
+/// the [`ALL_VERSIONS`] array, as well as individually as [`TLS12`]
+/// and [`TLS13`].
+#[derive(Debug, PartialEq)]
+pub struct SupportedProtocolVersion {
+    /// The TLS enumeration naming this version.
+    pub version: ProtocolVersion,
+    is_private: (),
+}
+
+/// TLS1.2
+pub static TLS12: SupportedProtocolVersion =
+    SupportedProtocolVersion {
+        version: ProtocolVersion::TLSv1_2,
+        is_private: ()
+    };
+
+
+
+/// TLS1.3
+pub static TLS13: SupportedProtocolVersion =
+    SupportedProtocolVersion {
+        version: ProtocolVersion::TLSv1_3,
+        is_private: (),
+    };
+
+/// A list of all the protocol versions supported by rustls.
+pub static ALL_VERSIONS: &[&SupportedProtocolVersion] = &[
+    &TLS13,
+    &TLS12,
+];
+
+/// The version configuration that an application should use by default.
+///
+/// This will be [`ALL_VERSIONS`] for now, but gives space in the future
+/// to remove a version from here and require users to opt-in to older
+/// versions.
+pub static DEFAULT_VERSIONS: &[&SupportedProtocolVersion] = ALL_VERSIONS;
+
+#[derive(Debug, Clone)]
+pub struct EnabledVersions {
+    tls12: Option<&'static SupportedProtocolVersion>,
+    tls13: Option<&'static SupportedProtocolVersion>,
+}
+
+impl EnabledVersions {
+    pub(crate) fn new(versions: &[&'static SupportedProtocolVersion]) -> Self {
+        let mut ev = EnabledVersions {
+            tls12: None,
+            tls13: None,
+        };
+        ev.replace(versions);
+        ev
+    }
+
+    pub(crate) fn contains(&self, version: ProtocolVersion) -> bool {
+        match version {
+            ProtocolVersion::TLSv1_2 => self.tls12.is_some(),
+            ProtocolVersion::TLSv1_3 => self.tls13.is_some(),
+            _ => false
+        }
+    }
+
+    /// Enable the single version `v`.
+    pub fn enable(&mut self, v: &'static SupportedProtocolVersion) {
+        match v.version {
+            ProtocolVersion::TLSv1_2 => self.tls12 = Some(v),
+            ProtocolVersion::TLSv1_3 => self.tls13 = Some(v),
+            _ => {},
+        }
+    }
+
+    /// Replace the set of enabled versions with precisely those present in
+    /// `versions`.  Duplicates are ignored.
+    pub fn replace(&mut self, versions: &[&'static SupportedProtocolVersion]) {
+        self.tls12.take();
+        self.tls13.take();
+        for v in versions {
+            self.enable(v);
+        }
+    }
+}

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -26,7 +26,7 @@ use rustls::{Stream, StreamOwned};
 use rustls::{SupportedCipherSuite, ALL_CIPHERSUITES};
 
 #[cfg(feature = "dangerous_configuration")]
-use rustls::ClientCertVerified;
+use rustls::{ClientCertVerified, ServerConfigBuilder};
 
 use webpki;
 
@@ -749,9 +749,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -777,9 +777,9 @@ mod test_clientverifier {
                 offered_schemes: Some(vec![]),
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -810,9 +810,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -848,9 +848,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -886,9 +886,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -924,9 +924,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);
@@ -956,9 +956,9 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let mut server_config = ServerConfig::new(Arc::new(client_verifier));
-            server_config
-                .set_single_cert(kt.get_chain(), kt.get_key())
+            let server_config = ServerConfigBuilder::with_safe_default_crypto()
+                .with_client_cert_verifier(Arc::new(client_verifier))
+                .with_single_cert(kt.get_chain(), kt.get_key())
                 .unwrap();
 
             let server_config = Arc::new(server_config);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -15,6 +15,7 @@ use rustls::internal::msgs::{codec::Codec, persist::ClientSessionValue};
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
 use rustls::sign;
 use rustls::ClientHello;
+use rustls::ConfigBuilder;
 use rustls::Connection;
 use rustls::Error;
 use rustls::KeyLog;
@@ -26,7 +27,7 @@ use rustls::{Stream, StreamOwned};
 use rustls::{SupportedCipherSuite, ALL_CIPHERSUITES};
 
 #[cfg(feature = "dangerous_configuration")]
-use rustls::{ClientCertVerified, ServerConfigBuilder};
+use rustls::ClientCertVerified;
 
 use webpki;
 
@@ -98,11 +99,15 @@ fn version_test(
     );
 
     if !client_versions.is_empty() {
-        client_config.versions.replace(client_versions);
+        client_config
+            .versions
+            .replace(client_versions);
     }
 
     if !server_versions.is_empty() {
-        server_config.versions.replace(server_versions);
+        server_config
+            .versions
+            .replace(server_versions);
     }
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
@@ -139,18 +144,10 @@ fn versions() {
     );
 
     // client 1.2, server 1.3 -> fail
-    version_test(
-        &[&rustls::version::TLS12],
-        &[&rustls::version::TLS13],
-        None,
-    );
+    version_test(&[&rustls::version::TLS12], &[&rustls::version::TLS13], None);
 
     // client 1.3, server 1.2 -> fail
-    version_test(
-        &[&rustls::version::TLS13],
-        &[&rustls::version::TLS12],
-        None,
-    );
+    version_test(&[&rustls::version::TLS13], &[&rustls::version::TLS12], None);
 
     // client 1.3, server 1.2+1.3 -> 1.3
     version_test(
@@ -171,6 +168,78 @@ fn check_read(reader: &mut dyn io::Read, bytes: &[u8]) {
     let mut buf = vec![0u8; bytes.len() + 1];
     assert_eq!(bytes.len(), reader.read(&mut buf).unwrap());
     assert_eq!(bytes, &buf[..bytes.len()]);
+}
+
+#[test]
+fn config_builder_for_client_rejects_empty_kx_groups() {
+    assert_eq!(
+        ConfigBuilder::with_safe_default_cipher_suites()
+            .with_kx_groups(&[])
+            .with_safe_default_protocol_versions()
+            .for_client()
+            .err(),
+        Some(Error::General("no kx groups configured".into()))
+    );
+}
+
+#[test]
+fn config_builder_for_client_rejects_empty_cipher_suites() {
+    assert_eq!(
+        ConfigBuilder::with_cipher_suites(&[])
+            .with_safe_default_kx_groups()
+            .with_safe_default_protocol_versions()
+            .for_client()
+            .err(),
+        Some(Error::General("no usable cipher suites configured".into()))
+    );
+}
+
+#[test]
+fn config_builder_for_client_rejects_incompatible_cipher_suites() {
+    assert_eq!(
+        ConfigBuilder::with_cipher_suites(&[&rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12])
+            .for_client()
+            .err(),
+        Some(Error::General("no usable cipher suites configured".into()))
+    );
+}
+
+#[test]
+fn config_builder_for_server_rejects_empty_kx_groups() {
+    assert_eq!(
+        ConfigBuilder::with_safe_default_cipher_suites()
+            .with_kx_groups(&[])
+            .with_safe_default_protocol_versions()
+            .for_server()
+            .err(),
+        Some(Error::General("no kx groups configured".into()))
+    );
+}
+
+#[test]
+fn config_builder_for_server_rejects_empty_cipher_suites() {
+    assert_eq!(
+        ConfigBuilder::with_cipher_suites(&[])
+            .with_safe_default_kx_groups()
+            .with_safe_default_protocol_versions()
+            .for_server()
+            .err(),
+        Some(Error::General("no usable cipher suites configured".into()))
+    );
+}
+
+#[test]
+fn config_builder_for_server_rejects_incompatible_cipher_suites() {
+    assert_eq!(
+        ConfigBuilder::with_cipher_suites(&[&rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&[&rustls::version::TLS12])
+            .for_server()
+            .err(),
+        Some(Error::General("no usable cipher suites configured".into()))
+    );
 }
 
 #[test]
@@ -283,11 +352,7 @@ fn client_can_get_server_cert_after_resumption() {
 #[test]
 fn server_can_get_client_cert() {
     for kt in ALL_KEY_TYPES.iter() {
-        let mut client_config = make_client_config(*kt);
-        client_config
-            .set_single_client_cert(kt.get_chain(), kt.get_key())
-            .unwrap();
-
+        let client_config = make_client_config_with_auth(*kt);
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(*kt));
 
         for client_config in AllClientVersions::new(client_config) {
@@ -296,7 +361,7 @@ fn server_can_get_client_cert() {
             do_handshake(&mut client, &mut server);
 
             let certs = server.peer_certificates();
-            assert_eq!(certs, Some(kt.get_chain()));
+            assert_eq!(certs, Some(kt.get_client_chain()));
         }
     }
 }
@@ -304,11 +369,7 @@ fn server_can_get_client_cert() {
 #[test]
 fn server_can_get_client_cert_after_resumption() {
     for kt in ALL_KEY_TYPES.iter() {
-        let mut client_config = make_client_config(*kt);
-        client_config
-            .set_single_client_cert(kt.get_chain(), kt.get_key())
-            .unwrap();
-
+        let client_config = make_client_config_with_auth(*kt);
         let server_config = Arc::new(make_server_config_with_mandatory_client_auth(*kt));
 
         for client_config in AllClientVersions::new(client_config) {
@@ -335,11 +396,7 @@ fn check_read_and_close(reader: &mut dyn io::Read, expect: &[u8]) {
 #[test]
 fn server_close_notify() {
     let kt = KeyType::RSA;
-    let mut client_config = make_client_config(kt);
-    client_config
-        .set_single_client_cert(kt.get_chain(), kt.get_key())
-        .unwrap();
-
+    let client_config = make_client_config_with_auth(kt);
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt));
 
     for client_config in AllClientVersions::new(client_config) {
@@ -377,11 +434,7 @@ fn server_close_notify() {
 #[test]
 fn client_close_notify() {
     let kt = KeyType::RSA;
-    let mut client_config = make_client_config(kt);
-    client_config
-        .set_single_client_cert(kt.get_chain(), kt.get_key())
-        .unwrap();
-
+    let client_config = make_client_config_with_auth(kt);
     let server_config = Arc::new(make_server_config_with_mandatory_client_auth(kt));
 
     for client_config in AllClientVersions::new(client_config) {
@@ -738,6 +791,18 @@ mod test_clientverifier {
         Err(Error::General("test err".to_string()))
     }
 
+    fn server_config_with_verifier(
+        kt: KeyType,
+        client_cert_verifier: MockClientVerifier,
+    ) -> ServerConfig {
+        ConfigBuilder::with_safe_defaults()
+            .for_server()
+            .unwrap()
+            .with_client_cert_verifier(Arc::new(client_cert_verifier))
+            .with_single_cert(kt.get_chain(), kt.get_key())
+            .unwrap()
+    }
+
     #[test]
     // Happy path, we resolve to a root, it is verified OK, should be able to connect
     fn client_verifier_works() {
@@ -749,11 +814,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config_with_auth(*kt);
 
@@ -777,11 +838,7 @@ mod test_clientverifier {
                 offered_schemes: Some(vec![]),
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config_with_auth(*kt);
 
@@ -810,11 +867,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config_with_auth(*kt);
 
@@ -848,11 +901,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config(*kt);
 
@@ -886,11 +935,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config(*kt);
 
@@ -924,11 +969,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config_with_auth(*kt);
 
@@ -956,11 +997,7 @@ mod test_clientverifier {
                 offered_schemes: None,
             };
 
-            let server_config = ServerConfigBuilder::with_safe_default_crypto()
-                .with_client_cert_verifier(Arc::new(client_verifier))
-                .with_single_cert(kt.get_chain(), kt.get_key())
-                .unwrap();
-
+            let server_config = server_config_with_verifier(*kt, client_verifier);
             let server_config = Arc::new(server_config);
             let client_config = make_client_config_with_auth(*kt);
 
@@ -1051,7 +1088,9 @@ mod test_serververifier {
             client_config
                 .dangerous()
                 .set_certificate_verifier(verifier);
-            client_config.versions.replace(&[&rustls::version::TLS12]);
+            client_config
+                .versions
+                .replace(&[&rustls::version::TLS12]);
 
             let server_config = Arc::new(make_server_config(*kt));
 
@@ -1079,7 +1118,9 @@ mod test_serververifier {
             client_config
                 .dangerous()
                 .set_certificate_verifier(verifier);
-            client_config.versions.replace(&[&rustls::version::TLS13]);
+            client_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
 
             let server_config = Arc::new(make_server_config(*kt));
 
@@ -1105,7 +1146,9 @@ mod test_serververifier {
             client_config
                 .dangerous()
                 .set_certificate_verifier(verifier);
-            client_config.versions.replace(&[&rustls::version::TLS13]);
+            client_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
 
             let server_config = Arc::new(make_server_config(*kt));
 
@@ -2111,7 +2154,9 @@ fn test_tls12_exporter() {
     for kt in ALL_KEY_TYPES.iter() {
         let mut client_config = make_client_config(*kt);
         let server_config = make_server_config(*kt);
-        client_config.versions.replace(&[&rustls::version::TLS12]);
+        client_config
+            .versions
+            .replace(&[&rustls::version::TLS12]);
 
         do_exporter_test(client_config, server_config);
     }
@@ -2122,7 +2167,9 @@ fn test_tls13_exporter() {
     for kt in ALL_KEY_TYPES.iter() {
         let mut client_config = make_client_config(*kt);
         let server_config = make_server_config(*kt);
-        client_config.versions.replace(&[&rustls::version::TLS13]);
+        client_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
 
         do_exporter_test(client_config, server_config);
     }
@@ -2186,7 +2233,11 @@ fn find_suite(suite: CipherSuite) -> &'static SupportedCipherSuite {
     panic!("find_suite given unsupported suite");
 }
 
-static TEST_CIPHERSUITES: [(&'static rustls::SupportedProtocolVersion, KeyType, CipherSuite); 9] = [
+static TEST_CIPHERSUITES: [(
+    &'static rustls::SupportedProtocolVersion,
+    KeyType,
+    CipherSuite,
+); 9] = [
     (
         &rustls::version::TLS13,
         KeyType::RSA,
@@ -2258,7 +2309,9 @@ fn negotiated_ciphersuite_client() {
         let scs = find_suite(suite);
         let mut client_config = make_client_config(kt);
         client_config.cipher_suites = vec![scs];
-        client_config.versions.replace(&[version]);
+        client_config
+            .versions
+            .replace(&[version]);
 
         do_suite_test(client_config, make_server_config(kt), scs, version.version);
     }
@@ -2271,7 +2324,9 @@ fn negotiated_ciphersuite_server() {
         let scs = find_suite(suite);
         let mut server_config = make_server_config(kt);
         server_config.cipher_suites = vec![scs];
-        server_config.versions.replace(&[version]);
+        server_config
+            .versions
+            .replace(&[version]);
 
         do_suite_test(make_client_config(kt), server_config, scs, version.version);
     }
@@ -2323,7 +2378,9 @@ fn key_log_for_tls12() {
 
     let kt = KeyType::RSA;
     let mut client_config = make_client_config(kt);
-    client_config.versions.replace(&[&rustls::version::TLS12]);
+    client_config
+        .versions
+        .replace(&[&rustls::version::TLS12]);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
 
@@ -2360,7 +2417,9 @@ fn key_log_for_tls13() {
 
     let kt = KeyType::RSA;
     let mut client_config = make_client_config(kt);
-    client_config.versions.replace(&[&rustls::version::TLS13]);
+    client_config
+        .versions
+        .replace(&[&rustls::version::TLS13]);
     client_config.key_log = client_key_log.clone();
     let client_config = Arc::new(client_config);
 
@@ -2683,7 +2742,9 @@ impl rustls::StoresClientSessions for ClientStorage {
 fn tls13_stateful_resumption() {
     let kt = KeyType::RSA;
     let mut client_config = make_client_config(kt);
-    client_config.versions.replace(&[&rustls::version::TLS13]);
+    client_config
+        .versions
+        .replace(&[&rustls::version::TLS13]);
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(kt);
@@ -2739,7 +2800,9 @@ fn tls13_stateful_resumption() {
 fn tls13_stateless_resumption() {
     let kt = KeyType::RSA;
     let mut client_config = make_client_config(kt);
-    client_config.versions.replace(&[&rustls::version::TLS13]);
+    client_config
+        .versions
+        .replace(&[&rustls::version::TLS13]);
     let client_config = Arc::new(client_config);
 
     let mut server_config = make_server_config(kt);
@@ -2805,7 +2868,7 @@ fn early_data_is_available_on_resumption() {
     client_config.enable_early_data = true;
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.session_persistence = storage.clone();
+    client_config.session_storage = storage.clone();
 
     let client_config = Arc::new(client_config);
 
@@ -2902,11 +2965,15 @@ mod test_quic {
 
         let kt = KeyType::RSA;
         let mut client_config = make_client_config(kt);
-        client_config.versions.replace(&[&rustls::version::TLS13]);
+        client_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
         client_config.enable_early_data = true;
         let client_config = Arc::new(client_config);
         let mut server_config = make_server_config(kt);
-        server_config.versions.replace(&[&rustls::version::TLS13]);
+        server_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
         server_config.max_early_data_size = 0xffffffff;
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
@@ -3061,12 +3128,16 @@ mod test_quic {
 
         for &kt in ALL_KEY_TYPES.iter() {
             let mut client_config = make_client_config(kt);
-            client_config.versions.replace(&[&rustls::version::TLS13]);
+            client_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
             client_config.alpn_protocols = vec!["bar".into()];
             let client_config = Arc::new(client_config);
 
             let mut server_config = make_server_config(kt);
-            server_config.versions.replace(&[&rustls::version::TLS13]);
+            server_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
             server_config.alpn_protocols = vec!["foo".into()];
             let server_config = Arc::new(server_config);
 
@@ -3098,7 +3169,9 @@ mod test_quic {
     #[test]
     fn test_quic_no_tls13_error() {
         let mut client_config = make_client_config(KeyType::ED25519);
-        client_config.versions.replace(&[&rustls::version::TLS12]);
+        client_config
+            .versions
+            .replace(&[&rustls::version::TLS12]);
         client_config.alpn_protocols = vec!["foo".into()];
         let client_config = Arc::new(client_config);
 
@@ -3113,7 +3186,9 @@ mod test_quic {
         );
 
         let mut server_config = make_server_config(KeyType::ED25519);
-        server_config.versions.replace(&[&rustls::version::TLS12]);
+        server_config
+            .versions
+            .replace(&[&rustls::version::TLS12]);
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
@@ -3130,7 +3205,9 @@ mod test_quic {
     #[test]
     fn test_quic_invalid_early_data_size() {
         let mut server_config = make_server_config(KeyType::ED25519);
-        server_config.versions.replace(&[&rustls::version::TLS13]);
+        server_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
         server_config.alpn_protocols = vec!["foo".into()];
 
         let cases = [
@@ -3158,7 +3235,9 @@ mod test_quic {
     #[test]
     fn test_quic_server_no_params_received() {
         let mut server_config = make_server_config(KeyType::ED25519);
-        server_config.versions.replace(&[&rustls::version::TLS13]);
+        server_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
@@ -3227,7 +3306,9 @@ mod test_quic {
     #[test]
     fn test_quic_server_no_tls12() {
         let mut server_config = make_server_config(KeyType::ED25519);
-        server_config.versions.replace(&[&rustls::version::TLS13]);
+        server_config
+            .versions
+            .replace(&[&rustls::version::TLS13]);
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
@@ -3296,11 +3377,15 @@ mod test_quic {
     fn test_quic_exporter() {
         for &kt in ALL_KEY_TYPES.iter() {
             let mut client_config = make_client_config(kt);
-            client_config.versions.replace(&[&rustls::version::TLS13]);
+            client_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
             client_config.alpn_protocols = vec!["bar".into()];
 
             let mut server_config = make_server_config(kt);
-            server_config.versions.replace(&[&rustls::version::TLS13]);
+            server_config
+                .versions
+                .replace(&[&rustls::version::TLS13]);
             server_config.alpn_protocols = vec!["foo".into()];
 
             do_exporter_test(client_config, server_config);
@@ -3375,7 +3460,7 @@ fn test_client_sends_helloretryrequest() {
     client_config.kx_groups = vec![&rustls::kx_group::SECP384R1, &rustls::kx_group::X25519];
 
     let storage = Arc::new(ClientStorage::new());
-    client_config.session_persistence = storage.clone();
+    client_config.session_storage = storage.clone();
 
     // but server only accepts x25519, so a HRR is required
     let mut server_config = make_server_config(KeyType::RSA);
@@ -3436,13 +3521,13 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     //   into kx group cache.
     let mut client_config_1 = make_client_config(KeyType::RSA);
     client_config_1.kx_groups = vec![&rustls::kx_group::X25519];
-    client_config_1.session_persistence = shared_storage.clone();
+    client_config_1.session_storage = shared_storage.clone();
 
     // second, client only supports secp-384 and so kx group cache
     //   contains an unusable value.
     let mut client_config_2 = make_client_config(KeyType::RSA);
     client_config_2.kx_groups = vec![&rustls::kx_group::SECP384R1];
-    client_config_2.session_persistence = shared_storage.clone();
+    client_config_2.session_storage = shared_storage.clone();
 
     let server_config = make_server_config(KeyType::RSA);
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -12,7 +12,7 @@ use rustls::Error;
 use rustls::{AllowAnyAuthenticatedClient, RootCertStore};
 use rustls::{Certificate, PrivateKey};
 use rustls::{ClientConfig, ClientConnection};
-use rustls::{ProtocolVersion, DEFAULT_CIPHERSUITES};
+use rustls::DEFAULT_CIPHERSUITES;
 use rustls::{ServerConfig, ServerConfigBuilder, ServerConnection};
 
 #[cfg(feature = "dangerous_configuration")]
@@ -320,11 +320,11 @@ impl Iterator for AllClientVersions {
 
         match self.index {
             1 => {
-                config.versions = vec![ProtocolVersion::TLSv1_2];
+                config.versions.replace(&[&rustls::version::TLS12]);
                 Some(config)
             }
             2 => {
-                config.versions = vec![ProtocolVersion::TLSv1_3];
+                config.versions.replace(&[&rustls::version::TLS13]);
                 Some(config)
             }
             _ => None,


### PR DESCRIPTION
The purpose of this is:

- making it impossible for people to arrive at #514, which is a usability issue
- keep it possible to discard ciphersuites/kx groups at link time
- avoiding a huge growth in ServerConfig constructors