### PR TITLE
ResolvesServerCert::resolve now returns a Arc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
     pass the end-entity and intermediate certificates separately.  This means rustls deals with the case
     where the certificate chain is empty, rather than leaving that to ServerCertVerifier/ClientCertVerifier
     implementation.
+  - *Breaking API change*: `ResolvesServerCert::resolve` now returns `Option<Arc<CertifiedKey>>` instead of 
+    `Option<CertifiedKey>`.
 * 0.19.0 (2020-11-22):
   - Ensured that `get_peer_certificates` is both better documented, and works
     uniformly for both full-handshake and resumed sessions.

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -251,9 +251,9 @@ struct FixedSignatureSchemeServerCertResolver {
 }
 
 impl rustls::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
-    fn resolve(&self, client_hello: ClientHello) -> Option<rustls::sign::CertifiedKey> {
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<rustls::sign::CertifiedKey>> {
         let mut certkey = self.resolver.resolve(client_hello)?;
-        certkey.key = Arc::new(Box::new(FixedSignatureSchemeSigningKey {
+        Arc::make_mut(&mut certkey).key = Arc::new(Box::new(FixedSignatureSchemeSigningKey {
             key: certkey.key.clone(),
             scheme: self.scheme,
         }));

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -96,13 +96,13 @@ impl server::ProducesTickets for NeverProducesTickets {
 pub struct FailResolveChain {}
 
 impl server::ResolvesServerCert for FailResolveChain {
-    fn resolve(&self, _client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         None
     }
 }
 
 /// Something which always resolves to the same cert chain.
-pub struct AlwaysResolvesChain(sign::CertifiedKey);
+pub struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private
@@ -113,10 +113,10 @@ impl AlwaysResolvesChain {
     ) -> Result<AlwaysResolvesChain, TlsError> {
         let key = sign::any_supported_type(priv_key)
             .map_err(|_| TlsError::General("invalid private key".into()))?;
-        Ok(AlwaysResolvesChain(sign::CertifiedKey::new(
+        Ok(AlwaysResolvesChain(Arc::new(sign::CertifiedKey::new(
             chain,
             Arc::new(key),
-        )))
+        ))))
     }
 
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private
@@ -130,26 +130,31 @@ impl AlwaysResolvesChain {
         scts: Vec<u8>,
     ) -> Result<AlwaysResolvesChain, TlsError> {
         let mut r = AlwaysResolvesChain::new(chain, priv_key)?;
-        if !ocsp.is_empty() {
-            r.0.ocsp = Some(ocsp);
+
+        {
+            let cert = Arc::make_mut(&mut r.0);
+            if !ocsp.is_empty() {
+                cert.ocsp = Some(ocsp);
+            }
+            if !scts.is_empty() {
+                cert.sct_list = Some(scts);
+            }
         }
-        if !scts.is_empty() {
-            r.0.sct_list = Some(scts);
-        }
+
         Ok(r)
     }
 }
 
 impl server::ResolvesServerCert for AlwaysResolvesChain {
-    fn resolve(&self, _client_hello: ClientHello) -> Option<sign::CertifiedKey> {
-        Some(self.0.clone())
+    fn resolve(&self, _client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
+        Some(Arc::clone(&self.0))
     }
 }
 
 /// Something that resolves do different cert chains/keys based
 /// on client-supplied server name (via SNI).
 pub struct ResolvesServerCertUsingSni {
-    by_name: collections::HashMap<String, sign::CertifiedKey>,
+    by_name: collections::HashMap<String, Arc<sign::CertifiedKey>>,
 }
 
 impl ResolvesServerCertUsingSni {
@@ -170,15 +175,15 @@ impl ResolvesServerCertUsingSni {
             .map_err(|_| TlsError::General("Bad DNS name".into()))?;
 
         ck.cross_check_end_entity_cert(Some(checked_name))?;
-        self.by_name.insert(name.into(), ck);
+        self.by_name.insert(name.into(), Arc::new(ck));
         Ok(())
     }
 }
 
 impl server::ResolvesServerCert for ResolvesServerCertUsingSni {
-    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         if let Some(name) = client_hello.server_name() {
-            self.by_name.get(name.into()).cloned()
+            self.by_name.get(name.into()).map(Arc::clone)
         } else {
             // This kind of resolver requires SNI
             None

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -738,7 +738,7 @@ impl State for ExpectClientHello {
             .map(|protos| protos.to_slices());
 
         // Choose a certificate.
-        let mut certkey = {
+        let certkey = {
             let sni_ref = sni
                 .as_ref()
                 .map(webpki::DNSName::as_ref);
@@ -756,13 +756,13 @@ impl State for ExpectClientHello {
                 .config
                 .cert_resolver
                 .resolve(client_hello);
-            let certkey = certkey.ok_or_else(|| {
+            certkey.ok_or_else(|| {
                 sess.common
                     .send_fatal_alert(AlertDescription::AccessDenied);
                 TlsError::General("no server certificate chain resolved".to_string())
-            })?;
-            sign::ActiveCertifiedKey::from_certified_key(certkey)
+            })?
         };
+        let mut certkey = sign::ActiveCertifiedKey::from_certified_key(certkey.as_ref());
 
         // Reduce our supported ciphersuites by the certificate.
         // (no-op for TLS1.3)

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -100,7 +100,7 @@ pub trait ResolvesServerCert: Send + Sync {
     /// ClientHello information.
     ///
     /// Return `None` to abort the handshake.
-    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey>;
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>>;
 }
 
 /// A struct representing the received Client Hello

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -81,16 +81,6 @@ impl CertifiedKey {
         self.ocsp.is_some()
     }
 
-    /// Steal ownership of the OCSP response.
-    pub fn take_ocsp(&mut self) -> Option<Vec<u8>> {
-        mem::replace(&mut self.ocsp, None)
-    }
-
-    /// Steal ownership of the SCT list.
-    pub fn take_sct_list(&mut self) -> Option<Vec<u8>> {
-        mem::replace(&mut self.sct_list, None)
-    }
-
     /// Check the certificate chain for validity:
     /// - it should be non-empty list
     /// - the first certificate should be parsable as a x509v3,
@@ -137,6 +127,59 @@ impl CertifiedKey {
         }
 
         Ok(())
+    }
+}
+
+/// ActiveCertifiedKey wraps CertifiedKey and prevents `ocsp` and `sct_list` from being 
+/// consumed more than once.
+pub(crate) struct ActiveCertifiedKey {
+    key: Arc<CertifiedKey>,
+    ocsp_taken: bool,
+    sct_list_taken: bool,
+}
+
+impl ActiveCertifiedKey {
+    pub fn from_certified_key(key: Arc<CertifiedKey>) -> Self {
+        ActiveCertifiedKey { 
+            key,
+            ocsp_taken: false,
+            sct_list_taken: false,
+        }
+    }
+
+    #[inline]
+    pub fn has_ocsp(&self) -> bool {
+        !self.ocsp_taken && self.key.has_ocsp()
+    }
+
+    /// Get the certificate chain
+    #[inline]
+    pub fn get_cert(&self) -> &[key::Certificate] {
+        &self.key.cert
+    }
+
+    /// Get the signing key
+    #[inline]
+    pub fn get_key(&self) -> &Arc<Box<dyn SigningKey>> {
+        &self.key.key
+    }
+
+    #[inline]
+    pub fn take_ocsp(&mut self) -> Option<&[u8]> {
+        if std::mem::replace(&mut self.ocsp_taken, true) {
+            None
+        } else {
+            self.key.ocsp.as_deref()
+        }
+    }
+
+    #[inline]
+    pub fn take_sct_list(&mut self) -> Option<&[u8]> {
+        if std::mem::replace(&mut self.sct_list_taken, true) {
+            None
+        } else {
+            self.key.sct_list.as_deref()
+        }
     }
 }
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -392,7 +392,7 @@ struct ServerCheckCertResolve {
 }
 
 impl ResolvesServerCert for ServerCheckCertResolve {
-    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         if client_hello.sigschemes().len() == 0 {
             panic!("no signature schemes shared by client");
         }
@@ -543,7 +543,7 @@ fn server_cert_resolve_reduces_sigalgs_for_ecdsa_ciphersuite() {
 struct ServerCheckNoSNI {}
 
 impl ResolvesServerCert for ServerCheckNoSNI {
-    fn resolve(&self, client_hello: ClientHello) -> Option<sign::CertifiedKey> {
+    fn resolve(&self, client_hello: ClientHello) -> Option<Arc<sign::CertifiedKey>> {
         assert!(client_hello.server_name().is_none());
 
         None


### PR DESCRIPTION
This PR does two things:

* `ResolvesServerCert::resolve` was changed to return `Option<Arc<CertifiedKey>>` to prevent a full clone for each call to `resolve`. As a result the clone/to_owned calls are pushed down to the sites where the data is used. In the future the this can be further improved such that no clones are needed.
* `CertifiedKey` encoded some state of the handshake procedure. In particular `take_ocsp` and `take_sct_list` which lived on `CertifiedKey` controlled the encoding of the ocsp and sct data. This state was moved to a new type `ActiveCertifiedKey`.

Closes: #566 