### PR TITLE
Signing bounds

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -225,7 +225,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
 }
 
 struct FixedSignatureSchemeSigningKey {
-    key: Arc<Box<dyn rustls::sign::SigningKey>>,
+    key: Arc<Box<dyn rustls::sign::SigningKey + Send + Sync>>,
     scheme: rustls::SignatureScheme,
 }
 
@@ -233,7 +233,7 @@ impl rustls::sign::SigningKey for FixedSignatureSchemeSigningKey {
     fn choose_scheme(
         &self,
         offered: &[rustls::SignatureScheme],
-    ) -> Option<Box<dyn rustls::sign::Signer>> {
+    ) -> Option<Box<dyn rustls::sign::Signer + Send + Sync>> {
         if offered.contains(&self.scheme) {
             self.key.choose_scheme(&[self.scheme])
         } else {
@@ -246,7 +246,7 @@ impl rustls::sign::SigningKey for FixedSignatureSchemeSigningKey {
 }
 
 struct FixedSignatureSchemeServerCertResolver {
-    resolver: Arc<dyn rustls::ResolvesServerCert>,
+    resolver: Arc<dyn rustls::ResolvesServerCert + Send + Sync>,
     scheme: rustls::SignatureScheme,
 }
 
@@ -262,7 +262,7 @@ impl rustls::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
 }
 
 struct FixedSignatureSchemeClientCertResolver {
-    resolver: Arc<dyn rustls::ResolvesClientCert>,
+    resolver: Arc<dyn rustls::ResolvesClientCert + Send + Sync>,
     scheme: rustls::SignatureScheme,
 }
 

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -159,7 +159,7 @@ impl ReceivedTicketDetails {
 
 pub struct ClientAuthDetails {
     pub cert: Option<CertificatePayload>,
-    pub signer: Option<Box<dyn sign::Signer>>,
+    pub signer: Option<Box<dyn sign::Signer + Send + Sync>>,
     pub auth_context: Option<Vec<u8>>,
 }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -41,7 +41,7 @@ mod tls13;
 /// in the type system to allow implementations freedom in
 /// how to achieve interior mutability.  `Mutex` is a common
 /// choice.
-pub trait StoresClientSessions: Send + Sync {
+pub trait StoresClientSessions {
     /// Stores a new `value` for `key`.  Returns `true`
     /// if the value was stored.
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool;
@@ -53,7 +53,7 @@ pub trait StoresClientSessions: Send + Sync {
 
 /// A trait for the ability to choose a certificate chain and
 /// private key for the purposes of client authentication.
-pub trait ResolvesClientCert: Send + Sync {
+pub trait ResolvesClientCert {
     /// With the server-supplied acceptable issuers in `acceptable_issuers`,
     /// the server's supported signature schemes in `sigschemes`,
     /// return a certificate chain and signing key to authenticate.
@@ -97,13 +97,13 @@ pub struct ClientConfig {
     pub alpn_protocols: Vec<Vec<u8>>,
 
     /// How we store session data or tickets.
-    pub session_persistence: Arc<dyn StoresClientSessions>,
+    pub session_persistence: Arc<dyn StoresClientSessions + Send + Sync>,
 
     /// Our MTU.  If None, we don't limit TLS message sizes.
     pub mtu: Option<usize>,
 
     /// How to decide what client auth certificate/keys to use.
-    pub client_auth_cert_resolver: Arc<dyn ResolvesClientCert>,
+    pub client_auth_cert_resolver: Arc<dyn ResolvesClientCert + Send + Sync>,
 
     /// Whether to support RFC5077 tickets.  You must provide a working
     /// `session_persistence` member for this to have any meaningful
@@ -218,7 +218,7 @@ impl ClientConfig {
     }
 
     /// Sets persistence layer to `persist`.
-    pub fn set_persistence(&mut self, persist: Arc<dyn StoresClientSessions>) {
+    pub fn set_persistence(&mut self, persist: Arc<dyn StoresClientSessions + Send + Sync>) {
         self.session_persistence = persist;
     }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -95,7 +95,7 @@ pub trait ProducesTickets: Send + Sync {
 
 /// How to choose a certificate chain and signing key for use
 /// in server authentication.
-pub trait ResolvesServerCert: Send + Sync {
+pub trait ResolvesServerCert {
     /// Choose a certificate chain and matching key given simplified
     /// ClientHello information.
     ///
@@ -176,7 +176,7 @@ pub struct ServerConfig {
     pub ticketer: Arc<dyn ProducesTickets>,
 
     /// How to choose a server cert and key.
-    pub cert_resolver: Arc<dyn ResolvesServerCert>,
+    pub cert_resolver: Arc<dyn ResolvesServerCert + Send + Sync>,
 
     /// Protocol names we support, most preferred first.
     /// If empty we don't do ALPN at all.

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1728,7 +1728,7 @@ fn sni_resolver_works() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<Box<dyn sign::SigningKey + Send + Sync>> = Arc::new(Box::new(signing_key));
     resolver
         .add(
             "localhost",
@@ -1762,7 +1762,7 @@ fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<Box<dyn sign::SigningKey + Send + Sync>> = Arc::new(Box::new(signing_key));
 
     assert_eq!(
         Ok(()),
@@ -1794,7 +1794,7 @@ fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<Box<dyn sign::SigningKey+ Send + Sync>> = Arc::new(Box::new(signing_key));
 
     assert_eq!(
         Err(TlsError::General(
@@ -2361,7 +2361,7 @@ impl rustls::StoresServerSessions for ServerStorage {
 }
 
 struct ClientStorage {
-    storage: Arc<dyn rustls::StoresClientSessions>,
+    storage: Arc<dyn rustls::StoresClientSessions + Send + Sync>,
     put_count: AtomicUsize,
     get_count: AtomicUsize,
 }


### PR DESCRIPTION
The change here moves the `Send + Sync` trait bounds from our own trait definitions to usage sites that need it. This is a little more verbose, but also more precise. I still think it's an improvement, but definitely a trade-off (also could consider making different trade-offs per trait, maybe `Signer` should be `Send + Sync` everywhere?).