### PR TITLE
Refactor ClientHello data.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -10,7 +10,6 @@ use crate::msgs::handshake::SessionID;
 use crate::msgs::persist;
 use crate::sign;
 use crate::kx;
-use webpki;
 
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
@@ -56,15 +55,13 @@ impl ServerKXDetails {
 pub struct HandshakeDetails {
     pub resuming_session: Option<persist::ClientSessionValue>,
     pub session_id: SessionID,
-    pub dns_name: webpki::DNSName,
 }
 
 impl HandshakeDetails {
-    pub fn new(host_name: webpki::DNSName) -> HandshakeDetails {
+    pub fn new() -> HandshakeDetails {
         HandshakeDetails {
             resuming_session: None,
             session_id: SessionID::empty(),
-            dns_name: host_name,
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -428,7 +428,7 @@ fn emit_client_hello_for_retry(
 
     let next = ExpectServerHello {
         handshake,
-        dns_name: dns_name.clone(),
+        dns_name,
         randoms,
         using_ems,
         transcript,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -320,7 +320,7 @@ fn emit_client_hello_for_retry<T: 'static + HelloData + Send + Sync>(
         hello_data
             .get_extra_exts()
             .iter()
-            .cloned()
+            .cloned(),
     );
 
     let fill_in_binder = if support_tls13

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -289,7 +289,7 @@ fn emit_client_hello_for_retry<T: 'static + HelloData + Send + Sync>(
             &mut exts,
             &mut hello,
             hello_data.get_hostname(),
-            retryreq
+            retryreq,
         );
     }
 
@@ -316,7 +316,12 @@ fn emit_client_hello_for_retry<T: 'static + HelloData + Send + Sync>(
     }
 
     // Extra extensions must be placed before the PSK extension
-    exts.extend(hello_data.get_extra_exts().iter().cloned());
+    exts.extend(
+        hello_data
+            .get_extra_exts()
+            .iter()
+            .cloned()
+    );
 
     let fill_in_binder = if support_tls13
         && sess.config.enable_tickets

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -121,7 +121,7 @@ struct InitialState<T: HelloData + Send + Sync> {
     hello_data: T,
 }
 
-impl <T: 'static + HelloData + Send + Sync> InitialState<T> {
+impl<T: 'static + HelloData + Send + Sync> InitialState<T> {
     fn new(hello_data: T) -> InitialState<T> {
         InitialState {
             handshake: HandshakeDetails::new(),
@@ -284,7 +284,13 @@ fn emit_client_hello_for_retry<T: 'static + HelloData + Send + Sync>(
     }
 
     if support_tls13 {
-        tls13::choose_kx_groups(sess, &mut exts, &mut hello, hello_data.get_hostname(), retryreq);
+        tls13::choose_kx_groups(
+            sess,
+            &mut exts,
+            &mut hello,
+            hello_data.get_hostname(),
+            retryreq
+        );
     }
 
     if let Some(cookie) = retryreq.and_then(HelloRetryRequest::get_cookie) {
@@ -744,7 +750,7 @@ impl State for ExpectServerHello {
     }
 }
 
-impl <T: 'static + HelloData + Send + Sync> ExpectServerHelloOrHelloRetryRequest<T> {
+impl<T: 'static + HelloData + Send + Sync> ExpectServerHelloOrHelloRetryRequest<T> {
     fn into_expect_server_hello(self) -> NextState {
         Box::new(self.next)
     }
@@ -877,7 +883,7 @@ impl <T: 'static + HelloData + Send + Sync> ExpectServerHelloOrHelloRetryRequest
     }
 }
 
-impl <T: 'static + HelloData + Send + Sync> State for ExpectServerHelloOrHelloRetryRequest<T> {
+impl<T: 'static + HelloData + Send + Sync> State for ExpectServerHelloOrHelloRetryRequest<T> {
     fn handle(self: Box<Self>, sess: &mut ClientSessionImpl, m: Message) -> NextStateOrError {
         check_message(
             &m,

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -428,8 +428,8 @@ impl ClientSessionImpl {
     }
 
     pub fn start_handshake<T: 'static + HelloData + Send + Sync>(
-            &mut self,
-            hello_data: T,
+        &mut self,
+        hello_data: T,
     ) -> Result<(), TlsError> {
         self.state = Some(hs::start_handshake(self, hello_data)?);
         Ok(())

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -198,7 +198,11 @@ impl ClientConfig {
     /// versions *and* at least one ciphersuite for this version is
     /// also configured.
     pub fn supports_version(&self, v: ProtocolVersion) -> bool {
-        self.versions.contains(&v) && self.ciphersuites.iter().any(|cs| cs.usable_for_version(v))
+        self.versions.contains(&v)
+            && self
+                .ciphersuites
+                .iter()
+                .any(|cs| cs.usable_for_version(v))
     }
 
     #[doc(hidden)]
@@ -212,7 +216,8 @@ impl ClientConfig {
     /// preferred, the last is the least preferred.
     pub fn set_protocols(&mut self, protocols: &[Vec<u8>]) {
         self.alpn_protocols.clear();
-        self.alpn_protocols.extend_from_slice(protocols);
+        self.alpn_protocols
+            .extend_from_slice(protocols);
     }
 
     /// Sets persistence layer to `persist`.
@@ -405,7 +410,8 @@ pub struct ClientSessionImpl {
 
 impl fmt::Debug for ClientSessionImpl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("ClientSessionImpl").finish()
+        f.debug_struct("ClientSessionImpl")
+            .finish()
     }
 }
 
@@ -470,7 +476,12 @@ impl ClientSessionImpl {
     }
 
     pub fn process_new_handshake_messages(&mut self) -> Result<(), TlsError> {
-        while let Some(msg) = self.common.handshake_joiner.frames.pop_front() {
+        while let Some(msg) = self
+            .common
+            .handshake_joiner
+            .frames
+            .pop_front()
+        {
             self.process_main_protocol(msg)?;
         }
 
@@ -529,7 +540,12 @@ impl ClientSessionImpl {
             return Err(TlsError::CorruptMessage);
         }
 
-        while let Some(msg) = self.common.message_deframer.frames.pop_front() {
+        while let Some(msg) = self
+            .common
+            .message_deframer
+            .frames
+            .pop_front()
+        {
             let ignore_corrupt_payload = false;
             let result = self
                 .common
@@ -554,7 +570,12 @@ impl ClientSessionImpl {
             return None;
         }
 
-        Some(self.server_cert_chain.iter().cloned().collect())
+        Some(
+            self.server_cert_chain
+                .iter()
+                .cloned()
+                .collect(),
+        )
     }
 
     pub fn get_protocol_version(&self) -> Option<ProtocolVersion> {
@@ -568,7 +589,11 @@ impl ClientSessionImpl {
     pub fn write_early_data(&mut self, data: &[u8]) -> io::Result<usize> {
         self.early_data
             .check_write(data.len())
-            .and_then(|sz| Ok(self.common.send_early_plaintext(&data[..sz])))
+            .and_then(|sz| {
+                Ok(self
+                    .common
+                    .send_early_plaintext(&data[..sz]))
+            })
     }
 
     fn export_keying_material(
@@ -585,7 +610,8 @@ impl ClientSessionImpl {
 
     fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
         let mut st = self.state.take();
-        st.as_mut().map(|st| st.perhaps_write_key_update(self));
+        st.as_mut()
+            .map(|st| st.perhaps_write_key_update(self));
         self.state = st;
 
         self.common.send_some_plaintext(buf)
@@ -700,7 +726,8 @@ impl Session for ClientSession {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), TlsError> {
-        self.imp.export_keying_material(output, label, context)
+        self.imp
+            .export_keying_material(output, label, context)
     }
 
     fn get_negotiated_ciphersuite(&self) -> Option<&'static SupportedCipherSuite> {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -429,8 +429,8 @@ impl ClientSessionImpl {
 
     pub fn start_handshake<T: 'static + HelloData + Send + Sync>(
             &mut self,
-            hello_data: T
-        ) -> Result<(), TlsError> {
+            hello_data: T,
+    ) -> Result<(), TlsError> {
         self.state = Some(hs::start_handshake(self, hello_data)?);
         Ok(())
     }
@@ -679,7 +679,7 @@ impl ClientSession {
     /// hostname of who we want to talk to.
     pub fn new(
         config: &Arc<ClientConfig>,
-        hostname: webpki::DNSNameRef
+        hostname: webpki::DNSNameRef,
     ) -> Result<ClientSession, TlsError> {
         ClientSession::from_hello_data(config, Host::new(hostname))
     }
@@ -689,8 +689,8 @@ impl ClientSession {
     /// contains the data needed for the ClientHello message.
     pub fn from_hello_data<T: 'static + HelloData + Send + Sync>(
         config: &Arc<ClientConfig>,
-        hello_data: T
-    )-> Result<ClientSession, TlsError> {
+        hello_data: T,
+    ) -> Result<ClientSession, TlsError> {
         let mut imp = ClientSessionImpl::new(config);
         imp.start_handshake(hello_data)?;
         Ok(ClientSession { imp })

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -427,8 +427,10 @@ impl ClientSessionImpl {
         }
     }
 
-    pub fn start_handshake<T: 'static + HelloData + Send + Sync>
-        (&mut self, hello_data: T) -> Result<(), TlsError> {
+    pub fn start_handshake<T: 'static + HelloData + Send + Sync>(
+            &mut self,
+            hello_data: T
+        ) -> Result<(), TlsError> {
         self.state = Some(hs::start_handshake(self, hello_data)?);
         Ok(())
     }
@@ -675,14 +677,20 @@ impl ClientSession {
     /// Make a new ClientSession.  `config` controls how
     /// we behave in the TLS protocol, `hostname` is the
     /// hostname of who we want to talk to.
-    pub fn new(config: &Arc<ClientConfig>, hostname: webpki::DNSNameRef) -> Result<ClientSession, TlsError> {
+    pub fn new(
+        config: &Arc<ClientConfig>,
+        hostname: webpki::DNSNameRef
+    ) -> Result<ClientSession, TlsError> {
         ClientSession::from_hello_data(config, Host::new(hostname))
     }
 
     /// Make a new ClientSession.  `config` controls how
     /// we behave in the TLS protocol, `hello_data` is the
     /// contains the data needed for the ClientHello message.
-    pub fn from_hello_data<T: 'static + HelloData + Send + Sync>(config: &Arc<ClientConfig>, hello_data: T)-> Result<ClientSession, TlsError> {
+    pub fn from_hello_data<T: 'static + HelloData + Send + Sync>(
+        config: &Arc<ClientConfig>,
+        hello_data: T
+    )-> Result<ClientSession, TlsError> {
         let mut imp = ClientSessionImpl::new(config);
         imp.start_handshake(hello_data)?;
         Ok(ClientSession { imp })

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1,6 +1,5 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use crate::client::{ClientConfig, ClientSession, ClientSessionImpl};
-use crate::client::{HelloData, Host};
 use crate::error::TlsError;
 use crate::key_schedule::hkdf_expand;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
@@ -65,29 +64,19 @@ pub trait QuicExt {
 
 impl QuicExt for ClientSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp
-            .common
-            .quic
-            .params
-            .as_ref()
-            .map(|v| v.as_ref())
+        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
     }
 
     fn get_0rtt_keys(&self) -> Option<DirectionalKeys> {
         Some(DirectionalKeys::new(
             self.imp.resumption_ciphersuite?,
-            self.imp
-                .common
-                .quic
-                .early_secret
-                .as_ref()?,
+            self.imp.common.quic.early_secret.as_ref()?,
         ))
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
-        self.imp
-            .process_new_handshake_messages()
+        self.imp.process_new_handshake_messages()
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Keys> {
@@ -105,29 +94,19 @@ impl QuicExt for ClientSession {
 
 impl QuicExt for ServerSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp
-            .common
-            .quic
-            .params
-            .as_ref()
-            .map(|v| v.as_ref())
+        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
     }
 
     fn get_0rtt_keys(&self) -> Option<DirectionalKeys> {
         Some(DirectionalKeys::new(
             self.imp.common.get_suite()?,
-            self.imp
-                .common
-                .quic
-                .early_secret
-                .as_ref()?,
+            self.imp.common.quic.early_secret.as_ref()?,
         ))
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
-        self.imp
-            .process_new_handshake_messages()
+        self.imp.process_new_handshake_messages()
     }
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Keys> {
         write_hs(&mut self.imp.common, buf)
@@ -350,9 +329,7 @@ pub trait ClientQuicExt {
         };
         let mut imp = ClientSessionImpl::new(config);
         imp.common.protocol = Protocol::Quic;
-        let mut host = Host::new(hostname);
-        host.push_extra_ext(ext);
-        imp.start_handshake(host)?;
+        imp.start_handshake(hostname.into(), vec![ext])?;
         Ok(ClientSession { imp })
     }
 }
@@ -474,36 +451,20 @@ mod test {
 
         const SERVER_MASK: [u8; 5] = [0x38, 0x16, 0x8a, 0x0c, 0x25];
         assert_eq!(
-            server_keys
-                .local
-                .header
-                .new_mask(SAMPLE)
-                .unwrap(),
+            server_keys.local.header.new_mask(SAMPLE).unwrap(),
             SERVER_MASK
         );
         assert_eq!(
-            client_keys
-                .remote
-                .header
-                .new_mask(SAMPLE)
-                .unwrap(),
+            client_keys.remote.header.new_mask(SAMPLE).unwrap(),
             SERVER_MASK
         );
         const CLIENT_MASK: [u8; 5] = [0xae, 0x96, 0x2e, 0x67, 0xec];
         assert_eq!(
-            server_keys
-                .remote
-                .header
-                .new_mask(SAMPLE)
-                .unwrap(),
+            server_keys.remote.header.new_mask(SAMPLE).unwrap(),
             CLIENT_MASK
         );
         assert_eq!(
-            client_keys
-                .local
-                .header
-                .new_mask(SAMPLE)
-                .unwrap(),
+            client_keys.local.header.new_mask(SAMPLE).unwrap(),
             CLIENT_MASK
         );
 
@@ -516,11 +477,7 @@ mod test {
             0x0d, 0x00, 0x00, 0x00, 0x00, 0x18, 0x41, 0x0a, 0x02, 0x00, 0x00, 0x56,
         ];
         let mut payload = PLAINTEXT;
-        let server_nonce = server_keys
-            .local
-            .packet
-            .iv
-            .nonce_for(PACKET_NUMBER);
+        let server_nonce = server_keys.local.packet.iv.nonce_for(PACKET_NUMBER);
         let tag = server_keys
             .local
             .packet
@@ -529,9 +486,7 @@ mod test {
             .unwrap();
         assert_eq!(
             payload,
-            [
-                0x0d, 0x91, 0x96, 0x31, 0xc0, 0xeb, 0x84, 0xf2, 0x88, 0x59, 0xfe, 0xc0
-            ]
+            [0x0d, 0x91, 0x96, 0x31, 0xc0, 0xeb, 0x84, 0xf2, 0x88, 0x59, 0xfe, 0xc0]
         );
         assert_eq!(
             tag.as_ref(),
@@ -543,11 +498,7 @@ mod test {
 
         let aad = aead::Aad::from(AAD);
         let mut payload = PLAINTEXT;
-        let client_nonce = client_keys
-            .local
-            .packet
-            .iv
-            .nonce_for(PACKET_NUMBER);
+        let client_nonce = client_keys.local.packet.iv.nonce_for(PACKET_NUMBER);
         let tag = client_keys
             .local
             .packet
@@ -556,9 +507,7 @@ mod test {
             .unwrap();
         assert_eq!(
             payload,
-            [
-                0x89, 0x6c, 0x66, 0x91, 0xe0, 0x9f, 0x47, 0x7a, 0x91, 0x42, 0xa4, 0x46
-            ]
+            [0x89, 0x6c, 0x66, 0x91, 0xe0, 0x9f, 0x47, 0x7a, 0x91, 0x42, 0xa4, 0x46]
         );
         assert_eq!(
             tag.as_ref(),
@@ -574,13 +523,9 @@ mod test {
         fn equal_prk(x: &hkdf::Prk, y: &hkdf::Prk) -> bool {
             let mut x_data = [0; 16];
             let mut y_data = [0; 16];
-            let x_okm = x
-                .expand(&[b"info"], &aead::quic::AES_128)
-                .unwrap();
+            let x_okm = x.expand(&[b"info"], &aead::quic::AES_128).unwrap();
             x_okm.fill(&mut x_data[..]).unwrap();
-            let y_okm = y
-                .expand(&[b"info"], &aead::quic::AES_128)
-                .unwrap();
+            let y_okm = y.expand(&[b"info"], &aead::quic::AES_128).unwrap();
             y_okm.fill(&mut y_data[..]).unwrap();
             x_data == y_data
         }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -1,11 +1,11 @@
 /// This module contains optional APIs for implementing QUIC TLS.
 use crate::client::{ClientConfig, ClientSession, ClientSessionImpl};
+use crate::client::{HelloData, Host};
 use crate::error::TlsError;
 use crate::key_schedule::hkdf_expand;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::msgs::message::{Message, MessagePayload};
-use crate::client::{HelloData, Host};
 use crate::server::{ServerConfig, ServerSession, ServerSessionImpl};
 use crate::session::{Protocol, SessionCommon};
 use crate::suites::{BulkAlgorithm, SupportedCipherSuite, TLS13_AES_128_GCM_SHA256};

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -349,7 +349,9 @@ pub trait ClientQuicExt {
         };
         let mut imp = ClientSessionImpl::new(config);
         imp.common.protocol = Protocol::Quic;
-        imp.start_handshake(hostname.into(), vec![ext])?;
+        let mut host = Host::new(hostname);
+        host.push_extra_ext(ext);
+        imp.start_handshake(host)?;
         Ok(ClientSession { imp })
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -5,6 +5,7 @@ use crate::key_schedule::hkdf_expand;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::msgs::handshake::{ClientExtension, ServerExtension};
 use crate::msgs::message::{Message, MessagePayload};
+use crate::client::{HelloData, Host};
 use crate::server::{ServerConfig, ServerSession, ServerSessionImpl};
 use crate::session::{Protocol, SessionCommon};
 use crate::suites::{BulkAlgorithm, SupportedCipherSuite, TLS13_AES_128_GCM_SHA256};

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -64,19 +64,29 @@ pub trait QuicExt {
 
 impl QuicExt for ClientSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
+        self.imp
+            .common
+            .quic
+            .params
+            .as_ref()
+            .map(|v| v.as_ref())
     }
 
     fn get_0rtt_keys(&self) -> Option<DirectionalKeys> {
         Some(DirectionalKeys::new(
             self.imp.resumption_ciphersuite?,
-            self.imp.common.quic.early_secret.as_ref()?,
+            self.imp
+                .common
+                .quic
+                .early_secret
+                .as_ref()?,
         ))
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
-        self.imp.process_new_handshake_messages()
+        self.imp
+            .process_new_handshake_messages()
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Keys> {
@@ -94,19 +104,29 @@ impl QuicExt for ClientSession {
 
 impl QuicExt for ServerSession {
     fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
-        self.imp.common.quic.params.as_ref().map(|v| v.as_ref())
+        self.imp
+            .common
+            .quic
+            .params
+            .as_ref()
+            .map(|v| v.as_ref())
     }
 
     fn get_0rtt_keys(&self) -> Option<DirectionalKeys> {
         Some(DirectionalKeys::new(
             self.imp.common.get_suite()?,
-            self.imp.common.quic.early_secret.as_ref()?,
+            self.imp
+                .common
+                .quic
+                .early_secret
+                .as_ref()?,
         ))
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), TlsError> {
         read_hs(&mut self.imp.common, plaintext)?;
-        self.imp.process_new_handshake_messages()
+        self.imp
+            .process_new_handshake_messages()
     }
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<Keys> {
         write_hs(&mut self.imp.common, buf)
@@ -451,20 +471,36 @@ mod test {
 
         const SERVER_MASK: [u8; 5] = [0x38, 0x16, 0x8a, 0x0c, 0x25];
         assert_eq!(
-            server_keys.local.header.new_mask(SAMPLE).unwrap(),
+            server_keys
+                .local
+                .header
+                .new_mask(SAMPLE)
+                .unwrap(),
             SERVER_MASK
         );
         assert_eq!(
-            client_keys.remote.header.new_mask(SAMPLE).unwrap(),
+            client_keys
+                .remote
+                .header
+                .new_mask(SAMPLE)
+                .unwrap(),
             SERVER_MASK
         );
         const CLIENT_MASK: [u8; 5] = [0xae, 0x96, 0x2e, 0x67, 0xec];
         assert_eq!(
-            server_keys.remote.header.new_mask(SAMPLE).unwrap(),
+            server_keys
+                .remote
+                .header
+                .new_mask(SAMPLE)
+                .unwrap(),
             CLIENT_MASK
         );
         assert_eq!(
-            client_keys.local.header.new_mask(SAMPLE).unwrap(),
+            client_keys
+                .local
+                .header
+                .new_mask(SAMPLE)
+                .unwrap(),
             CLIENT_MASK
         );
 
@@ -477,7 +513,11 @@ mod test {
             0x0d, 0x00, 0x00, 0x00, 0x00, 0x18, 0x41, 0x0a, 0x02, 0x00, 0x00, 0x56,
         ];
         let mut payload = PLAINTEXT;
-        let server_nonce = server_keys.local.packet.iv.nonce_for(PACKET_NUMBER);
+        let server_nonce = server_keys
+            .local
+            .packet
+            .iv
+            .nonce_for(PACKET_NUMBER);
         let tag = server_keys
             .local
             .packet
@@ -486,7 +526,9 @@ mod test {
             .unwrap();
         assert_eq!(
             payload,
-            [0x0d, 0x91, 0x96, 0x31, 0xc0, 0xeb, 0x84, 0xf2, 0x88, 0x59, 0xfe, 0xc0]
+            [
+                0x0d, 0x91, 0x96, 0x31, 0xc0, 0xeb, 0x84, 0xf2, 0x88, 0x59, 0xfe, 0xc0
+            ]
         );
         assert_eq!(
             tag.as_ref(),
@@ -498,7 +540,11 @@ mod test {
 
         let aad = aead::Aad::from(AAD);
         let mut payload = PLAINTEXT;
-        let client_nonce = client_keys.local.packet.iv.nonce_for(PACKET_NUMBER);
+        let client_nonce = client_keys
+            .local
+            .packet
+            .iv
+            .nonce_for(PACKET_NUMBER);
         let tag = client_keys
             .local
             .packet
@@ -507,7 +553,9 @@ mod test {
             .unwrap();
         assert_eq!(
             payload,
-            [0x89, 0x6c, 0x66, 0x91, 0xe0, 0x9f, 0x47, 0x7a, 0x91, 0x42, 0xa4, 0x46]
+            [
+                0x89, 0x6c, 0x66, 0x91, 0xe0, 0x9f, 0x47, 0x7a, 0x91, 0x42, 0xa4, 0x46
+            ]
         );
         assert_eq!(
             tag.as_ref(),
@@ -523,9 +571,13 @@ mod test {
         fn equal_prk(x: &hkdf::Prk, y: &hkdf::Prk) -> bool {
             let mut x_data = [0; 16];
             let mut y_data = [0; 16];
-            let x_okm = x.expand(&[b"info"], &aead::quic::AES_128).unwrap();
+            let x_okm = x
+                .expand(&[b"info"], &aead::quic::AES_128)
+                .unwrap();
             x_okm.fill(&mut x_data[..]).unwrap();
-            let y_okm = y.expand(&[b"info"], &aead::quic::AES_128).unwrap();
+            let y_okm = y
+                .expand(&[b"info"], &aead::quic::AES_128)
+                .unwrap();
             y_okm.fill(&mut y_data[..]).unwrap();
             x_data == y_data
         }


### PR DESCRIPTION
This packages `dns_name` and `extra_exts` together, in anticipation of ECH. Also makes it easier to supply `extra_exts` with `ClientSession::new`.

The trait bounds are a bit repetitive, but I think that problem is waiting on https://github.com/rust-lang/rust/issues/41517. If someone knows of a nicer way to do this, that would be good.