### PR TITLE
Thread SessionID through the handshake.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -7,7 +7,6 @@ use crate::msgs::handshake::CertificatePayload;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::SCTList;
 use crate::msgs::handshake::ServerExtension;
-use crate::msgs::handshake::SessionID;
 use crate::msgs::persist;
 use crate::sign;
 
@@ -56,14 +55,12 @@ impl ServerKXDetails {
 
 pub struct HandshakeDetails {
     pub resuming_session: Option<persist::ClientSessionValue>,
-    pub session_id: SessionID,
 }
 
 impl HandshakeDetails {
     pub fn new() -> HandshakeDetails {
         HandshakeDetails {
             resuming_session: None,
-            session_id: SessionID::empty(),
         }
     }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -175,7 +175,6 @@ impl InitialState {
         let hello_details = ClientHelloDetails::new();
         let sent_tls13_fake_ccs = false;
         let may_send_sct_list = sess.config.verifier.request_scts();
-
         emit_client_hello_for_retry(
             sess,
             self.handshake,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -345,14 +345,14 @@ fn emit_client_hello_for_retry(
         .map(ClientExtension::get_type)
         .collect();
 
-    let s_id = session_id.unwrap_or(SessionID::empty());
+    let session_id = session_id.unwrap_or(SessionID::empty());
 
     let mut chp = HandshakeMessagePayload {
         typ: HandshakeType::ClientHello,
         payload: HandshakePayload::ClientHello(ClientHelloPayload {
             client_version: ProtocolVersion::TLSv1_2,
             random: Random::from_slice(&randoms.client),
-            session_id: s_id,
+            session_id: session_id,
             cipher_suites: sess.get_cipher_suites(),
             compression_methods: vec![Compression::Null],
             extensions: exts,
@@ -439,7 +439,7 @@ fn emit_client_hello_for_retry(
         using_ems,
         transcript,
         hello,
-        session_id: s_id,
+        session_id: session_id,
         early_key_schedule,
         sent_tls13_fake_ccs,
     };

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -12,7 +12,7 @@ use crate::msgs::enums::{AlertDescription, ProtocolVersion};
 use crate::msgs::enums::{ContentType, HandshakeType};
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::ServerKeyExchangePayload;
-use crate::msgs::handshake::{CertificatePayload, DecomposedSignatureScheme, SCTList};
+use crate::msgs::handshake::{CertificatePayload, DecomposedSignatureScheme, SCTList, SessionID};
 use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -25,7 +25,6 @@ use crate::client::common::{ClientAuthDetails, ReceivedTicketDetails};
 use crate::client::common::{HandshakeDetails, ServerCertDetails, ServerKXDetails};
 use crate::client::hs;
 
-use crate::internal::msgs::handshake::SessionID;
 use ring::constant_time;
 use std::mem;
 use webpki;


### PR DESCRIPTION
Takes `session_id` out of `HandshakeDetails`