### PR TITLE
server: simplify how SigningKey arguments are passed

### DIFF
--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -225,7 +225,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
 }
 
 struct FixedSignatureSchemeSigningKey {
-    key: Arc<Box<dyn rustls::sign::SigningKey>>,
+    key: Arc<dyn rustls::sign::SigningKey>,
     scheme: rustls::SignatureScheme,
 }
 
@@ -253,10 +253,10 @@ struct FixedSignatureSchemeServerCertResolver {
 impl rustls::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
     fn resolve(&self, client_hello: ClientHello) -> Option<rustls::sign::CertifiedKey> {
         let mut certkey = self.resolver.resolve(client_hello)?;
-        certkey.key = Arc::new(Box::new(FixedSignatureSchemeSigningKey {
+        certkey.key = Arc::new(FixedSignatureSchemeSigningKey {
             key: certkey.key.clone(),
             scheme: self.scheme,
-        }));
+        });
         Some(certkey)
     }
 }
@@ -278,10 +278,10 @@ impl rustls::ResolvesClientCert for FixedSignatureSchemeClientCertResolver {
         let mut certkey = self
             .resolver
             .resolve(acceptable_issuers, sigschemes)?;
-        certkey.key = Arc::new(Box::new(FixedSignatureSchemeSigningKey {
+        certkey.key = Arc::new(FixedSignatureSchemeSigningKey {
             key: certkey.key.clone(),
             scheme: self.scheme,
-        }));
+        });
         Some(certkey)
     }
 

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -82,8 +82,7 @@ impl AlwaysResolvesClientCert {
         let key = sign::any_supported_type(priv_key)
             .map_err(|_| Error::General("invalid private key".into()))?;
         Ok(AlwaysResolvesClientCert(sign::CertifiedKey::new(
-            chain,
-            Arc::new(key),
+            chain, key,
         )))
     }
 }

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -103,10 +103,7 @@ impl AlwaysResolvesChain {
     ) -> Result<AlwaysResolvesChain, Error> {
         let key = sign::any_supported_type(priv_key)
             .map_err(|_| Error::General("invalid private key".into()))?;
-        Ok(AlwaysResolvesChain(sign::CertifiedKey::new(
-            chain,
-            Arc::new(key),
-        )))
+        Ok(AlwaysResolvesChain(sign::CertifiedKey::new(chain, key)))
     }
 
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -419,7 +419,7 @@ impl ExpectClientHello {
         sess: &mut ServerSession,
         sigschemes: Vec<SignatureScheme>,
         skxg: &'static kx::SupportedKxGroup,
-        signing_key: &Arc<Box<dyn sign::SigningKey>>,
+        signing_key: &Arc<dyn sign::SigningKey>,
         randoms: &SessionRandoms,
     ) -> Result<kx::KeyExchange, Error> {
         let kx = kx::KeyExchange::start(skxg)

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -31,8 +31,6 @@ use webpki;
 use crate::server::common::{HandshakeDetails, ServerKXDetails};
 use crate::server::{tls12, tls13};
 
-use std::sync::Arc;
-
 pub type NextState = Box<dyn State + Send + Sync>;
 pub type NextStateOrError = Result<NextState, Error>;
 
@@ -419,7 +417,7 @@ impl ExpectClientHello {
         sess: &mut ServerSession,
         sigschemes: Vec<SignatureScheme>,
         skxg: &'static kx::SupportedKxGroup,
-        signing_key: &Arc<dyn sign::SigningKey>,
+        signing_key: &dyn sign::SigningKey,
         randoms: &SessionRandoms,
     ) -> Result<kx::KeyExchange, Error> {
         let kx = kx::KeyExchange::start(skxg)
@@ -906,7 +904,7 @@ impl State for ExpectClientHello {
         if let Some(ocsp_response) = ocsp_response {
             self.emit_cert_status(sess, ocsp_response);
         }
-        let kx = self.emit_server_kx(sess, sigschemes, group, &certkey.key, &randoms)?;
+        let kx = self.emit_server_kx(sess, sigschemes, group, &*certkey.key, &randoms)?;
         let doing_client_auth = self.emit_certificate_req(sess)?;
         self.emit_server_hello_done(sess);
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -49,8 +49,6 @@ use crate::server::hs;
 
 use ring::constant_time;
 
-use std::sync::Arc;
-
 pub struct CompleteClientHelloHandling {
     pub handshake: HandshakeDetails,
     pub randoms: SessionRandoms,
@@ -387,7 +385,7 @@ impl CompleteClientHelloHandling {
     fn emit_certificate_verify_tls13(
         &mut self,
         sess: &mut ServerSession,
-        signing_key: &Arc<dyn sign::SigningKey>,
+        signing_key: &dyn sign::SigningKey,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
         let message = verify::construct_tls13_server_verify_message(
@@ -679,7 +677,7 @@ impl CompleteClientHelloHandling {
         let doing_client_auth = if full_handshake {
             let client_auth = self.emit_certificate_req_tls13(sess)?;
             self.emit_certificate_tls13(sess, &server_key.cert, ocsp_response, sct_list);
-            self.emit_certificate_verify_tls13(sess, &server_key.key, &sigschemes_ext)?;
+            self.emit_certificate_verify_tls13(sess, &*server_key.key, &sigschemes_ext)?;
             client_auth
         } else {
             false

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -387,7 +387,7 @@ impl CompleteClientHelloHandling {
     fn emit_certificate_verify_tls13(
         &mut self,
         sess: &mut ServerSession,
-        signing_key: &Arc<Box<dyn sign::SigningKey>>,
+        signing_key: &Arc<dyn sign::SigningKey>,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
         let message = verify::construct_tls13_server_verify_message(

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -40,7 +40,7 @@ pub struct CertifiedKey {
     pub cert: Vec<key::Certificate>,
 
     /// The certified key.
-    pub key: Arc<Box<dyn SigningKey>>,
+    pub key: Arc<dyn SigningKey>,
 
     /// An optional OCSP response from the certificate issuer,
     /// attesting to its continued validity.
@@ -57,7 +57,7 @@ impl CertifiedKey {
     ///
     /// The cert chain must not be empty. The first certificate in the chain
     /// must be the end-entity certificate.
-    pub fn new(cert: Vec<key::Certificate>, key: Arc<Box<dyn SigningKey>>) -> CertifiedKey {
+    pub fn new(cert: Vec<key::Certificate>, key: Arc<dyn SigningKey>) -> CertifiedKey {
         CertifiedKey {
             cert,
             key,
@@ -127,9 +127,9 @@ impl CertifiedKey {
 
 /// Parse `der` as any supported key encoding/type, returning
 /// the first which works.
-pub fn any_supported_type(der: &key::PrivateKey) -> Result<Box<dyn SigningKey>, ()> {
+pub fn any_supported_type(der: &key::PrivateKey) -> Result<Arc<dyn SigningKey>, ()> {
     if let Ok(rsa) = RsaSigningKey::new(der) {
-        Ok(Box::new(rsa))
+        Ok(Arc::new(rsa))
     } else if let Ok(ecdsa) = any_ecdsa_type(der) {
         Ok(ecdsa)
     } else {
@@ -138,13 +138,13 @@ pub fn any_supported_type(der: &key::PrivateKey) -> Result<Box<dyn SigningKey>, 
 }
 
 /// Parse `der` as any ECDSA key type, returning the first which works.
-pub fn any_ecdsa_type(der: &key::PrivateKey) -> Result<Box<dyn SigningKey>, ()> {
+pub fn any_ecdsa_type(der: &key::PrivateKey) -> Result<Arc<dyn SigningKey>, ()> {
     if let Ok(ecdsa_p256) = ECDSASigningKey::new(
         der,
         SignatureScheme::ECDSA_NISTP256_SHA256,
         &signature::ECDSA_P256_SHA256_ASN1_SIGNING,
     ) {
-        return Ok(Box::new(ecdsa_p256));
+        return Ok(Arc::new(ecdsa_p256));
     }
 
     if let Ok(ecdsa_p384) = ECDSASigningKey::new(
@@ -152,16 +152,16 @@ pub fn any_ecdsa_type(der: &key::PrivateKey) -> Result<Box<dyn SigningKey>, ()> 
         SignatureScheme::ECDSA_NISTP384_SHA384,
         &signature::ECDSA_P384_SHA384_ASN1_SIGNING,
     ) {
-        return Ok(Box::new(ecdsa_p384));
+        return Ok(Arc::new(ecdsa_p384));
     }
 
     Err(())
 }
 
 /// Parse `der` as any EdDSA key type, returning the first which works.
-pub fn any_eddsa_type(der: &key::PrivateKey) -> Result<Box<dyn SigningKey>, ()> {
+pub fn any_eddsa_type(der: &key::PrivateKey) -> Result<Arc<dyn SigningKey>, ()> {
     if let Ok(ed25519) = Ed25519SigningKey::new(der, SignatureScheme::ED25519) {
-        return Ok(Box::new(ed25519));
+        return Ok(Arc::new(ed25519));
     }
 
     // TODO: Add support for Ed448

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1731,7 +1731,7 @@ fn sni_resolver_works() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
     resolver
         .add(
             "localhost",
@@ -1766,7 +1766,7 @@ fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
         Ok(()),
@@ -1798,7 +1798,7 @@ fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::RSA;
     let mut resolver = rustls::ResolvesServerCertUsingSni::new();
     let signing_key = sign::RsaSigningKey::new(&kt.get_key()).unwrap();
-    let signing_key: Arc<Box<dyn sign::SigningKey>> = Arc::new(Box::new(signing_key));
+    let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
         Err(Error::General(


### PR DESCRIPTION
Thinking about this some more, the whole `Box` part of `Arc<Box<T>>`  is completely superfluous, removed it (and carried forward the `any_supported_type()` flattening from the other PR).

(Or is keeping the `any_supported_type()` split separate useful for limited linking of algorithms? It doesn't seem so since they call each other unconditionally, but maybe I'm missing something.)