### PR TITLE
Miscellaneous unwrap() removals

### DIFF
--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -231,7 +231,7 @@ pub struct SessionRandoms {
     pub server: [u8; 32],
 }
 
-static TLS12_DOWNGRADE_SENTINEL: &[u8] = &[0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
+static TLS12_DOWNGRADE_SENTINEL: [u8; 8] = [0x44, 0x4f, 0x57, 0x4e, 0x47, 0x52, 0x44, 0x01];
 
 impl SessionRandoms {
     pub fn for_server() -> Result<SessionRandoms, rand::GetRandomFailed> {
@@ -258,10 +258,7 @@ impl SessionRandoms {
 
     pub fn set_tls12_downgrade_marker(&mut self) {
         assert!(!self.we_are_client);
-        self.server[24..]
-            .as_mut()
-            .write_all(TLS12_DOWNGRADE_SENTINEL)
-            .unwrap();
+        self.server[24..].copy_from_slice(&TLS12_DOWNGRADE_SENTINEL);
     }
 
     pub fn has_tls12_downgrade_marker(&mut self) -> bool {
@@ -272,16 +269,10 @@ impl SessionRandoms {
     }
 }
 
-fn join_randoms(first: &[u8], second: &[u8]) -> [u8; 64] {
+fn join_randoms(first: &[u8; 32], second: &[u8; 32]) -> [u8; 64] {
     let mut randoms = [0u8; 64];
-    randoms
-        .as_mut()
-        .write_all(first)
-        .unwrap();
-    randoms[32..]
-        .as_mut()
-        .write_all(second)
-        .unwrap();
+    randoms[..32].copy_from_slice(first);
+    randoms[32..].copy_from_slice(second);
     randoms
 }
 

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -786,8 +786,7 @@ impl SessionCommon {
             return;
         }
 
-        while !self.sendable_plaintext.is_empty() {
-            let buf = self.sendable_plaintext.take_one();
+        while let Some(buf) = self.sendable_plaintext.pop() {
             self.send_plain(&buf, Limit::No);
         }
     }

--- a/rustls/src/vecbuf.rs
+++ b/rustls/src/vecbuf.rs
@@ -78,8 +78,8 @@ impl ChunkVecBuffer {
 
     /// Take one of the chunks from this object.  This
     /// function panics if the object `is_empty`.
-    pub fn take_one(&mut self) -> Vec<u8> {
-        self.chunks.pop_front().unwrap()
+    pub fn pop(&mut self) -> Option<Vec<u8>> {
+        self.chunks.pop_front()
     }
 
     /// Read data out of this object, writing it into `buf`
@@ -100,13 +100,13 @@ impl ChunkVecBuffer {
     }
 
     fn consume(&mut self, mut used: usize) {
-        while used > 0 && !self.is_empty() {
-            if used >= self.chunks[0].len() {
-                used -= self.chunks[0].len();
-                self.take_one();
+        while let Some(mut buf) = self.chunks.pop_front() {
+            if used < buf.len() {
+                self.chunks
+                    .push_front(buf.split_off(used));
+                break;
             } else {
-                self.chunks[0] = self.chunks[0].split_off(used);
-                used = 0;
+                used -= buf.len();
             }
         }
     }


### PR DESCRIPTION
`copy_from_slice()` is arguably more idiomatic for this common case than using `Write`, and makes the code more compact.  By referring to array sizes explicitly where possible, I've tried to make it easy for the optimizer to reduce/remove any potential bounds checks in the generated code. `copy_from_slice()` itself can still panic if its arguments are not of equal length, but this still seems like an improvement.