### PR TITLE
server: inline TLS 1.3 state transitions

### DIFF
--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -883,17 +883,6 @@ pub struct ExpectFinished {
 }
 
 impl ExpectFinished {
-    fn into_expect_traffic(
-        fin: verify::FinishedMessageVerified,
-        ks: KeyScheduleTraffic,
-    ) -> hs::NextState {
-        Box::new(ExpectTraffic {
-            key_schedule: ks,
-            want_write_key_update: false,
-            _fin_verified: fin,
-        })
-    }
-
     fn emit_ticket(
         handshake: &mut HandshakeDetails,
         sess: &mut ServerSessionImpl,
@@ -1021,7 +1010,11 @@ impl hs::State for ExpectFinished {
             }
         }
 
-        Ok(Self::into_expect_traffic(fin, key_schedule_traffic))
+        Ok(Box::new(ExpectTraffic {
+            key_schedule: key_schedule_traffic,
+            want_write_key_update: false,
+            _fin_verified: fin,
+        }))
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -717,15 +717,6 @@ pub struct ExpectCertificate {
 }
 
 impl ExpectCertificate {
-    fn into_expect_finished(self) -> hs::NextState {
-        Box::new(ExpectFinished {
-            key_schedule: self.key_schedule,
-            randoms: self.randoms,
-            handshake: self.handshake,
-            send_ticket: self.send_ticket,
-        })
-    }
-
     fn into_expect_certificate_verify(self, cert: ClientCertDetails) -> hs::NextState {
         Box::new(ExpectCertificateVerify {
             handshake: self.handshake,
@@ -780,7 +771,12 @@ impl hs::State for ExpectCertificate {
                     self.handshake
                         .transcript
                         .abandon_client_auth();
-                    return Ok(self.into_expect_finished());
+                    return Ok(Box::new(ExpectFinished {
+                        key_schedule: self.key_schedule,
+                        randoms: self.randoms,
+                        handshake: self.handshake,
+                        send_ticket: self.send_ticket,
+                    }));
                 }
 
                 sess.common

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -802,17 +802,6 @@ pub struct ExpectCertificateVerify {
     send_ticket: bool,
 }
 
-impl ExpectCertificateVerify {
-    fn into_expect_finished(self) -> hs::NextState {
-        Box::new(ExpectFinished {
-            key_schedule: self.key_schedule,
-            handshake: self.handshake,
-            randoms: self.randoms,
-            send_ticket: self.send_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificateVerify {
     fn handle(
         mut self: Box<Self>,
@@ -852,7 +841,12 @@ impl hs::State for ExpectCertificateVerify {
         self.handshake
             .transcript
             .add_message(&m);
-        Ok(self.into_expect_finished())
+        Ok(Box::new(ExpectFinished {
+            key_schedule: self.key_schedule,
+            handshake: self.handshake,
+            randoms: self.randoms,
+            send_ticket: self.send_ticket,
+        }))
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -716,18 +716,6 @@ pub struct ExpectCertificate {
     pub send_ticket: bool,
 }
 
-impl ExpectCertificate {
-    fn into_expect_certificate_verify(self, cert: ClientCertDetails) -> hs::NextState {
-        Box::new(ExpectCertificateVerify {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule: self.key_schedule,
-            client_cert: cert,
-            send_ticket: self.send_ticket,
-        })
-    }
-}
-
 impl hs::State for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
@@ -795,8 +783,14 @@ impl hs::State for ExpectCertificate {
                 Err(err)
             })?;
 
-        let cert = ClientCertDetails::new(cert_chain);
-        Ok(self.into_expect_certificate_verify(cert))
+        let client_cert = ClientCertDetails::new(cert_chain);
+        Ok(Box::new(ExpectCertificateVerify {
+            handshake: self.handshake,
+            randoms: self.randoms,
+            key_schedule: self.key_schedule,
+            client_cert,
+            send_ticket: self.send_ticket,
+        }))
     }
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -84,18 +84,6 @@ impl CompleteClientHelloHandling {
         constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
     }
 
-    fn into_expect_finished(
-        self,
-        key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    ) -> hs::NextState {
-        Box::new(ExpectFinished {
-            handshake: self.handshake,
-            randoms: self.randoms,
-            key_schedule,
-            send_ticket: self.send_ticket,
-        })
-    }
-
     fn emit_server_hello(
         &mut self,
         suite: &'static SupportedCipherSuite,
@@ -711,7 +699,12 @@ impl CompleteClientHelloHandling {
                 send_ticket: self.send_ticket,
             }))
         } else {
-            Ok(self.into_expect_finished(key_schedule_traffic))
+            Ok(Box::new(ExpectFinished {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                key_schedule: key_schedule_traffic,
+                send_ticket: self.send_ticket,
+            }))
         }
     }
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -84,15 +84,6 @@ impl CompleteClientHelloHandling {
         constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
     }
 
-    fn into_expect_retried_client_hello(self) -> hs::NextState {
-        Box::new(hs::ExpectClientHello {
-            handshake: self.handshake,
-            using_ems: false,
-            done_retry: true,
-            send_ticket: self.send_ticket,
-        })
-    }
-
     fn into_expect_certificate(
         self,
         key_schedule: KeyScheduleTrafficWithClientFinishedPending,
@@ -616,7 +607,12 @@ impl CompleteClientHelloHandling {
 
                     self.emit_hello_retry_request(suite, sess, group.name);
                     self.emit_fake_ccs(sess);
-                    return Ok(self.into_expect_retried_client_hello());
+                    return Ok(Box::new(hs::ExpectClientHello {
+                        handshake: self.handshake,
+                        using_ems: false,
+                        done_retry: true,
+                        send_ticket: self.send_ticket,
+                    }));
                 }
 
                 return Err(hs::incompatible(sess, "no kx group overlap with client"));


### PR DESCRIPTION
Somehow missed `server::tls13` in #594.