### PR TITLE
Ensure SNI extension can be round-tripped

### DIFF
--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -96,6 +96,17 @@ fn can_roundtrip_single_sni() {
 }
 
 #[test]
+fn can_round_trip_mixed_case_sni() {
+    let bytes = [0, 0, 0, 7, 0, 5, 0, 0, 2, 0x4c, 0x6f];
+    let mut rd = Reader::init(&bytes);
+    let ext = ClientExtension::read(&mut rd).unwrap();
+    println!("{:?}", ext);
+
+    assert_eq!(ext.get_type(), ExtensionType::ServerName);
+    assert_eq!(bytes.to_vec(), ext.get_encoding());
+}
+
+#[test]
 fn can_roundtrip_other_sni_name_types() {
     let bytes = [0, 0, 0, 7, 0, 5, 1, 0, 02, 0x6c, 0x6f];
     let mut rd = Reader::init(&bytes);


### PR DESCRIPTION
In 6940729 this was made to use webpki::DNSName as the underlying
storage.  However, that type case smashes to lower case.

This means a handshake where a upper case character is in the SNI
extension fails: we accidentally pretend that the hostname was
all lower case, and the client/server transcripts become out of sync.

Keep SNI hostnames twice in memory: first the raw bytes (used for encoding),
second the validated DNSName.

This addresses #601