### PR TITLE
server: move handshake data into states

### DIFF
--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -3,8 +3,6 @@ use crate::key;
 use crate::kx;
 use crate::msgs::handshake::SessionID;
 
-use std::mem;
-
 pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
     pub session_id: SessionID,
@@ -36,9 +34,5 @@ pub struct ClientCertDetails {
 impl ClientCertDetails {
     pub fn new(chain: Vec<key::Certificate>) -> ClientCertDetails {
         ClientCertDetails { cert_chain: chain }
-    }
-
-    pub fn take_chain(&mut self) -> Vec<key::Certificate> {
-        mem::take(&mut self.cert_chain)
     }
 }

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -1,5 +1,4 @@
 use crate::hash_hs;
-use crate::kx;
 use crate::msgs::handshake::SessionID;
 
 pub struct HandshakeDetails {
@@ -13,15 +12,5 @@ impl HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
             session_id: SessionID::empty(),
         }
-    }
-}
-
-pub struct ServerKxDetails {
-    pub kx: kx::KeyExchange,
-}
-
-impl ServerKxDetails {
-    pub fn new(kx: kx::KeyExchange) -> ServerKxDetails {
-        ServerKxDetails { kx }
     }
 }

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -1,7 +1,7 @@
 use crate::hash_hs;
 use crate::key;
 use crate::kx;
-use crate::msgs::handshake::{ServerExtension, SessionID};
+use crate::msgs::handshake::SessionID;
 
 use ring::digest;
 use std::mem;
@@ -10,16 +10,14 @@ pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
     pub hash_at_server_fin: Option<digest::Digest>,
     pub session_id: SessionID,
-    pub extra_exts: Vec<ServerExtension>,
 }
 
 impl HandshakeDetails {
-    pub fn new(extra_exts: Vec<ServerExtension>) -> HandshakeDetails {
+    pub fn new() -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
             hash_at_server_fin: None,
             session_id: SessionID::empty(),
-            extra_exts,
         }
     }
 }

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -3,12 +3,10 @@ use crate::key;
 use crate::kx;
 use crate::msgs::handshake::SessionID;
 
-use ring::digest;
 use std::mem;
 
 pub struct HandshakeDetails {
     pub transcript: hash_hs::HandshakeHash,
-    pub hash_at_server_fin: Option<digest::Digest>,
     pub session_id: SessionID,
 }
 
@@ -16,7 +14,6 @@ impl HandshakeDetails {
     pub fn new() -> HandshakeDetails {
         HandshakeDetails {
             transcript: hash_hs::HandshakeHash::new(),
-            hash_at_server_fin: None,
             session_id: SessionID::empty(),
         }
     }

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -1,5 +1,4 @@
 use crate::hash_hs;
-use crate::key;
 use crate::kx;
 use crate::msgs::handshake::SessionID;
 
@@ -24,15 +23,5 @@ pub struct ServerKxDetails {
 impl ServerKxDetails {
     pub fn new(kx: kx::KeyExchange) -> ServerKxDetails {
         ServerKxDetails { kx }
-    }
-}
-
-pub struct ClientCertDetails {
-    pub cert_chain: Vec<key::Certificate>,
-}
-
-impl ClientCertDetails {
-    pub fn new(chain: Vec<key::Certificate>) -> ClientCertDetails {
-        ClientCertDetails { cert_chain: chain }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -8,7 +8,7 @@ use crate::msgs::codec::Codec;
 use crate::msgs::enums::{AlertDescription, ExtensionType};
 use crate::msgs::enums::{CipherSuite, Compression, ECPointFormat};
 use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
-use crate::msgs::handshake::{ClientExtension, HandshakeMessagePayload};
+use crate::msgs::handshake::ClientExtension;
 use crate::msgs::handshake::{ClientHelloPayload, ServerExtension, SessionID};
 use crate::msgs::handshake::{ConvertProtocolNameList, ConvertServerNameList};
 use crate::msgs::handshake::{ECPointFormatList, SupportedPointFormats};
@@ -329,22 +329,6 @@ impl ExpectClientHello {
         }
 
         ech
-    }
-
-    fn emit_server_hello_done(&mut self, conn: &mut ServerConnection) {
-        let m = Message {
-            typ: ContentType::Handshake,
-            version: ProtocolVersion::TLSv1_2,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
-                typ: HandshakeType::ServerHelloDone,
-                payload: HandshakePayload::ServerHelloDone,
-            }),
-        };
-
-        self.handshake
-            .transcript
-            .add_message(&m);
-        conn.common.send_msg(m, false);
     }
 
     fn start_resumption(
@@ -744,7 +728,7 @@ impl State for ExpectClientHello {
             &randoms,
         )?;
         let doing_client_auth = tls12::emit_certificate_req(&mut self.handshake, conn)?;
-        self.emit_server_hello_done(conn);
+        tls12::emit_server_hello_done(&mut self.handshake, conn);
 
         let server_kx = ServerKxDetails::new(kx);
         if doing_client_auth {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -19,7 +19,7 @@ use crate::server::{ClientHello, ServerConfig, ServerConnection};
 use crate::suites;
 use crate::SupportedCipherSuite;
 
-use crate::server::common::{HandshakeDetails, ServerKxDetails};
+use crate::server::common::HandshakeDetails;
 use crate::server::{tls12, tls13};
 
 pub type NextState = Box<dyn State + Send + Sync>;
@@ -723,7 +723,7 @@ impl State for ExpectClientHello {
         if let Some(ocsp_response) = ocsp_response {
             tls12::emit_cert_status(&mut self.handshake, conn, ocsp_response);
         }
-        let kx = tls12::emit_server_kx(
+        let server_kx = tls12::emit_server_kx(
             &mut self.handshake,
             conn,
             sigschemes,
@@ -734,7 +734,6 @@ impl State for ExpectClientHello {
         let doing_client_auth = tls12::emit_certificate_req(&mut self.handshake, conn)?;
         tls12::emit_server_hello_done(&mut self.handshake, conn);
 
-        let server_kx = ServerKxDetails::new(kx);
         if doing_client_auth {
             Ok(Box::new(tls12::ExpectCertificate {
                 handshake: self.handshake,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,17 +1,14 @@
+use crate::conn::ConnectionRandoms;
 #[cfg(feature = "quic")]
 use crate::conn::Protocol;
-use crate::conn::{ConnectionRandoms, ConnectionSecrets};
 use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-use crate::msgs::codec::Codec;
 use crate::msgs::enums::{AlertDescription, ExtensionType};
-use crate::msgs::enums::{CipherSuite, Compression, ECPointFormat};
+use crate::msgs::enums::{CipherSuite, Compression};
 use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
-use crate::msgs::handshake::ClientExtension;
-use crate::msgs::handshake::{ClientHelloPayload, ServerExtension, SessionID};
+use crate::msgs::handshake::{ClientHelloPayload, ServerExtension};
 use crate::msgs::handshake::{ConvertProtocolNameList, ConvertServerNameList};
-use crate::msgs::handshake::{ECPointFormatList, SupportedPointFormats};
 use crate::msgs::handshake::{HandshakePayload, SupportedSignatureSchemes};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
@@ -90,7 +87,10 @@ pub fn can_resume(
 
 // Require an exact match for the purpose of comparing SNI DNS Names from two
 // client hellos, even though a case-insensitive comparison might also be OK.
-fn same_dns_name_or_both_none(a: Option<&webpki::DNSName>, b: Option<&webpki::DNSName>) -> bool {
+pub(super) fn same_dns_name_or_both_none(
+    a: Option<&webpki::DNSName>,
+    b: Option<&webpki::DNSName>,
+) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => {
             let a: &str = a.as_ref().into();
@@ -331,66 +331,6 @@ impl ExpectClientHello {
 
         ech
     }
-
-    fn start_resumption(
-        mut self,
-        conn: &mut ServerConnection,
-        client_hello: &ClientHelloPayload,
-        suite: &'static SupportedCipherSuite,
-        sni: Option<&webpki::DNSName>,
-        id: &SessionID,
-        resumedata: persist::ServerSessionValue,
-        randoms: &ConnectionRandoms,
-    ) -> NextStateOrError {
-        debug!("Resuming session");
-
-        if resumedata.extended_ms && !self.using_ems {
-            return Err(illegal_param(conn, "refusing to resume without ems"));
-        }
-
-        self.handshake.session_id = *id;
-        self.send_ticket = tls12::emit_server_hello(
-            &mut self.handshake,
-            conn,
-            suite,
-            self.using_ems,
-            &mut None,
-            &mut None,
-            client_hello,
-            Some(&resumedata),
-            randoms,
-            self.extra_exts,
-        )?;
-
-        let secrets = ConnectionSecrets::new_resume(&randoms, suite, &resumedata.master_secret.0);
-        conn.config.key_log.log(
-            "CLIENT_RANDOM",
-            &secrets.randoms.client,
-            &secrets.master_secret,
-        );
-        conn.common
-            .start_encryption_tls12(&secrets);
-        conn.client_cert_chain = resumedata.client_cert_chain;
-
-        if self.send_ticket {
-            tls12::emit_ticket(&secrets, &mut self.handshake, self.using_ems, conn);
-        }
-        tls12::emit_ccs(conn);
-        conn.common
-            .record_layer
-            .start_encrypting();
-        tls12::emit_finished(&secrets, &mut self.handshake, conn);
-
-        assert!(same_dns_name_or_both_none(sni, conn.get_sni()));
-
-        Ok(Box::new(tls12::ExpectCcs {
-            secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            resuming: true,
-            send_ticket: self.send_ticket,
-        }))
-    }
 }
 
 impl State for ExpectClientHello {
@@ -570,7 +510,7 @@ impl State for ExpectClientHello {
             .write_slice(&mut randoms.client);
 
         if conn.common.is_tls13() {
-            return tls13::CompleteClientHelloHandling {
+            tls13::CompleteClientHelloHandling {
                 handshake: self.handshake,
                 suite,
                 randoms,
@@ -578,181 +518,25 @@ impl State for ExpectClientHello {
                 send_ticket: self.send_ticket,
                 extra_exts: self.extra_exts,
             }
-            .handle_client_hello(suite, conn, &certkey, &m);
-        }
-
-        // -- TLS1.2 only from hereon in --
-        self.handshake
-            .transcript
-            .add_message(&m);
-
-        if client_hello.ems_support_offered() {
-            self.using_ems = true;
-        }
-
-        let groups_ext = client_hello
-            .get_namedgroups_extension()
-            .ok_or_else(|| incompatible(conn, "client didn't describe groups"))?;
-        let ecpoints_ext = client_hello
-            .get_ecpoints_extension()
-            .ok_or_else(|| incompatible(conn, "client didn't describe ec points"))?;
-
-        trace!("namedgroups {:?}", groups_ext);
-        trace!("ecpoints {:?}", ecpoints_ext);
-
-        if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
-            conn.common
-                .send_fatal_alert(AlertDescription::IllegalParameter);
-            return Err(Error::PeerIncompatibleError(
-                "client didn't support uncompressed ec points".to_string(),
-            ));
-        }
-
-        // -- If TLS1.3 is enabled, signal the downgrade in the server random
-        if tls13_enabled {
-            randoms.set_tls12_downgrade_marker();
-        }
-
-        // -- Check for resumption --
-        // We can do this either by (in order of preference):
-        // 1. receiving a ticket that decrypts
-        // 2. receiving a sessionid that is in our cache
-        //
-        // If we receive a ticket, the sessionid won't be in our
-        // cache, so don't check.
-        //
-        // If either works, we end up with a ServerSessionValue
-        // which is passed to start_resumption and concludes
-        // our handling of the ClientHello.
-        //
-        let mut ticket_received = false;
-
-        if let Some(ClientExtension::SessionTicketOffer(ref ticket)) =
-            client_hello.get_ticket_extension()
-        {
-            ticket_received = true;
-            debug!("Ticket received");
-
-            if let Some(resume) = conn
-                .config
-                .ticketer
-                .decrypt(&ticket.0)
-                .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-                .and_then(|resumedata| can_resume(suite, &sni, self.using_ems, resumedata))
-            {
-                return self.start_resumption(
-                    conn,
-                    client_hello,
-                    suite,
-                    sni.as_ref(),
-                    &client_hello.session_id,
-                    resume,
-                    &randoms,
-                );
-            } else {
-                debug!("Ticket didn't decrypt");
-            }
-        }
-
-        // If we're not offered a ticket or a potential session ID,
-        // allocate a session ID.
-        if self.handshake.session_id.is_empty() && !ticket_received {
-            self.handshake.session_id = SessionID::random()?;
-        }
-
-        // Perhaps resume?  If we received a ticket, the sessionid
-        // does not correspond to a real session.
-        if !client_hello.session_id.is_empty() && !ticket_received {
-            if let Some(resume) = conn
-                .config
-                .session_storage
-                .get(&client_hello.session_id.get_encoding())
-                .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
-                .and_then(|resumedata| can_resume(suite, &conn.sni, self.using_ems, resumedata))
-            {
-                return self.start_resumption(
-                    conn,
-                    client_hello,
-                    suite,
-                    sni.as_ref(),
-                    &client_hello.session_id,
-                    resume,
-                    &randoms,
-                );
-            }
-        }
-
-        // Now we have chosen a ciphersuite, we can make kx decisions.
-        let sigschemes = suite.resolve_sig_schemes(&sigschemes_ext);
-
-        if sigschemes.is_empty() {
-            return Err(incompatible(conn, "no supported sig scheme"));
-        }
-
-        let group = conn
-            .config
-            .kx_groups
-            .iter()
-            .find(|skxg| groups_ext.contains(&skxg.name))
-            .cloned()
-            .ok_or_else(|| incompatible(conn, "no supported group"))?;
-
-        let ecpoint = ECPointFormatList::supported()
-            .iter()
-            .find(|format| ecpoints_ext.contains(format))
-            .cloned()
-            .ok_or_else(|| incompatible(conn, "no supported point format"))?;
-
-        debug_assert_eq!(ecpoint, ECPointFormat::Uncompressed);
-
-        let (mut ocsp_response, mut sct_list) =
-            (certkey.ocsp.as_deref(), certkey.sct_list.as_deref());
-        self.send_ticket = tls12::emit_server_hello(
-            &mut self.handshake,
-            conn,
-            suite,
-            self.using_ems,
-            &mut ocsp_response,
-            &mut sct_list,
-            client_hello,
-            None,
-            &randoms,
-            self.extra_exts,
-        )?;
-        tls12::emit_certificate(&mut self.handshake, conn, &certkey.cert);
-        if let Some(ocsp_response) = ocsp_response {
-            tls12::emit_cert_status(&mut self.handshake, conn, ocsp_response);
-        }
-        let server_kx = tls12::emit_server_kx(
-            &mut self.handshake,
-            conn,
-            sigschemes,
-            group,
-            &*certkey.key,
-            &randoms,
-        )?;
-        let doing_client_auth = tls12::emit_certificate_req(&mut self.handshake, conn)?;
-        tls12::emit_server_hello_done(&mut self.handshake, conn);
-
-        if doing_client_auth {
-            Ok(Box::new(tls12::ExpectCertificate {
-                handshake: self.handshake,
-                randoms,
-                suite,
-                using_ems: self.using_ems,
-                server_kx,
-                send_ticket: self.send_ticket,
-            }))
+            .handle_client_hello(suite, conn, &certkey, &m)
         } else {
-            Ok(Box::new(tls12::ExpectClientKx {
+            tls12::CompleteClientHelloHandling {
                 handshake: self.handshake,
-                randoms,
                 suite,
                 using_ems: self.using_ems,
-                server_kx,
-                client_cert: None,
+                randoms,
                 send_ticket: self.send_ticket,
-            }))
+                extra_exts: self.extra_exts,
+            }
+            .handle_client_hello(
+                conn,
+                &certkey,
+                &m,
+                client_hello,
+                sigschemes_ext,
+                sni,
+                tls13_enabled,
+            )
         }
     }
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -22,7 +22,7 @@ use crate::sign;
 use crate::verify;
 use crate::SupportedCipherSuite;
 
-use crate::server::common::{HandshakeDetails, ServerKxDetails};
+use crate::server::common::HandshakeDetails;
 use crate::server::hs;
 
 use ring::constant_time;
@@ -221,7 +221,7 @@ pub struct ExpectCertificate {
     pub randoms: ConnectionRandoms,
     pub suite: &'static SupportedCipherSuite,
     pub using_ems: bool,
-    pub server_kx: ServerKxDetails,
+    pub server_kx: kx::KeyExchange,
     pub send_ticket: bool,
 }
 
@@ -299,7 +299,7 @@ pub struct ExpectClientKx {
     pub randoms: ConnectionRandoms,
     pub suite: &'static SupportedCipherSuite,
     pub using_ems: bool,
-    pub server_kx: ServerKxDetails,
+    pub server_kx: kx::KeyExchange,
     pub client_cert: Option<Vec<Certificate>>,
     pub send_ticket: bool,
 }
@@ -323,7 +323,6 @@ impl hs::State for ExpectClientKx {
         // resulting premaster secret.
         let kxd = self
             .server_kx
-            .kx
             .server_complete(&client_kx.0)
             .ok_or_else(|| {
                 conn.common

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -8,12 +8,12 @@ use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertDescription, SignatureScheme};
+use crate::msgs::enums::{AlertDescription, ClientCertificateType, SignatureScheme};
 use crate::msgs::enums::{Compression, ContentType, HandshakeType, ProtocolVersion};
+use crate::msgs::handshake::{CertificateRequestPayload, NewSessionTicketPayload, Random};
 use crate::msgs::handshake::{CertificateStatus, DigitallySignedStruct, ECDHEServerKeyExchange};
 use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, ServerHelloPayload};
 use crate::msgs::handshake::{HandshakePayload, ServerECDHParams, ServerKeyExchangePayload};
-use crate::msgs::handshake::{NewSessionTicketPayload, Random};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::server::ServerConnection;
@@ -149,6 +149,51 @@ pub(super) fn emit_server_kx(
     handshake.transcript.add_message(&m);
     conn.common.send_msg(m, false);
     Ok(kx)
+}
+
+pub(super) fn emit_certificate_req(
+    handshake: &mut HandshakeDetails,
+    conn: &mut ServerConnection,
+) -> Result<bool, Error> {
+    let client_auth = conn.config.get_verifier();
+
+    if !client_auth.offer_client_auth() {
+        return Ok(false);
+    }
+
+    let verify_schemes = client_auth.supported_verify_schemes();
+
+    let names = client_auth
+        .client_auth_root_subjects(conn.get_sni())
+        .ok_or_else(|| {
+            debug!("could not determine root subjects based on SNI");
+            conn.common
+                .send_fatal_alert(AlertDescription::AccessDenied);
+            Error::General("client rejected by client_auth_root_subjects".into())
+        })?;
+
+    let cr = CertificateRequestPayload {
+        certtypes: vec![
+            ClientCertificateType::RSASign,
+            ClientCertificateType::ECDSASign,
+        ],
+        sigschemes: verify_schemes,
+        canames: names,
+    };
+
+    let m = Message {
+        typ: ContentType::Handshake,
+        version: ProtocolVersion::TLSv1_2,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::CertificateRequest,
+            payload: HandshakePayload::CertificateRequest(cr),
+        }),
+    };
+
+    trace!("Sending CertificateRequest {:?}", m);
+    handshake.transcript.add_message(&m);
+    conn.common.send_msg(m, false);
+    Ok(true)
 }
 
 // --- Process client's Certificate for client auth ---

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -7,10 +7,10 @@ use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
 use crate::msgs::enums::AlertDescription;
-use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
-use crate::msgs::handshake::HandshakeMessagePayload;
+use crate::msgs::enums::{Compression, ContentType, HandshakeType, ProtocolVersion};
 use crate::msgs::handshake::HandshakePayload;
-use crate::msgs::handshake::NewSessionTicketPayload;
+use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, ServerHelloPayload};
+use crate::msgs::handshake::{NewSessionTicketPayload, Random};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::server::ServerConnection;
@@ -20,6 +20,51 @@ use crate::server::common::{ClientCertDetails, HandshakeDetails, ServerKxDetails
 use crate::server::hs;
 
 use ring::constant_time;
+
+pub(super) fn emit_server_hello(
+    handshake: &mut HandshakeDetails,
+    conn: &mut ServerConnection,
+    suite: &'static SupportedCipherSuite,
+    using_ems: bool,
+    ocsp_response: &mut Option<&[u8]>,
+    sct_list: &mut Option<&[u8]>,
+    hello: &ClientHelloPayload,
+    resumedata: Option<&persist::ServerSessionValue>,
+    randoms: &ConnectionRandoms,
+) -> Result<bool, Error> {
+    let mut ep = hs::ExtensionProcessing::new();
+    ep.process_common(
+        conn,
+        suite,
+        ocsp_response,
+        sct_list,
+        hello,
+        resumedata,
+        &handshake,
+    )?;
+    ep.process_tls12(conn, hello, using_ems);
+
+    let sh = Message {
+        typ: ContentType::Handshake,
+        version: ProtocolVersion::TLSv1_2,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::ServerHello,
+            payload: HandshakePayload::ServerHello(ServerHelloPayload {
+                legacy_version: ProtocolVersion::TLSv1_2,
+                random: Random::from_slice(&randoms.server),
+                session_id: handshake.session_id,
+                cipher_suite: suite.suite,
+                compression_method: Compression::Null,
+                extensions: ep.exts,
+            }),
+        }),
+    };
+
+    trace!("sending server hello {:?}", sh);
+    handshake.transcript.add_message(&sh);
+    conn.common.send_msg(sh, false);
+    Ok(ep.send_ticket)
+}
 
 // --- Process client's Certificate for client auth ---
 pub struct ExpectCertificate {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -196,6 +196,23 @@ pub(super) fn emit_certificate_req(
     Ok(true)
 }
 
+pub(super) fn emit_server_hello_done(
+    handshake: &mut HandshakeDetails,
+    conn: &mut ServerConnection,
+) {
+    let m = Message {
+        typ: ContentType::Handshake,
+        version: ProtocolVersion::TLSv1_2,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::ServerHelloDone,
+            payload: HandshakePayload::ServerHelloDone,
+        }),
+    };
+
+    handshake.transcript.add_message(&m);
+    conn.common.send_msg(m, false);
+}
+
 // --- Process client's Certificate for client auth ---
 pub struct ExpectCertificate {
     pub handshake: HandshakeDetails,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,6 +1,7 @@
 use crate::check::check_message;
 use crate::conn::{ConnectionRandoms, ConnectionSecrets};
 use crate::error::Error;
+use crate::key::Certificate;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
@@ -64,6 +65,24 @@ pub(super) fn emit_server_hello(
     handshake.transcript.add_message(&sh);
     conn.common.send_msg(sh, false);
     Ok(ep.send_ticket)
+}
+
+pub(super) fn emit_certificate(
+    handshake: &mut HandshakeDetails,
+    conn: &mut ServerConnection,
+    cert_chain: &[Certificate],
+) {
+    let c = Message {
+        typ: ContentType::Handshake,
+        version: ProtocolVersion::TLSv1_2,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::Certificate,
+            payload: HandshakePayload::Certificate(cert_chain.to_owned()),
+        }),
+    };
+
+    handshake.transcript.add_message(&c);
+    conn.common.send_msg(c, false);
 }
 
 // --- Process client's Certificate for client auth ---

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -412,7 +412,7 @@ impl hs::State for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        conn.client_cert_chain = Some(self.client_cert.take_chain());
+        conn.client_cert_chain = Some(self.client_cert.cert_chain);
 
         self.handshake
             .transcript

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -198,7 +198,10 @@ pub(super) fn emit_certificate_req(
     Ok(true)
 }
 
-pub(super) fn emit_server_hello_done(handshake: &mut HandshakeDetails, conn: &mut ServerConnection) {
+pub(super) fn emit_server_hello_done(
+    handshake: &mut HandshakeDetails,
+    conn: &mut ServerConnection,
+) {
     let m = Message {
         typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -8,20 +8,11 @@ use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::ECPointFormat;
-use crate::msgs::enums::{AlertDescription, ClientCertificateType, SignatureScheme};
-use crate::msgs::enums::{Compression, ContentType, HandshakeType, ProtocolVersion};
-use crate::msgs::handshake::{CertificateRequestPayload, NewSessionTicketPayload, Random};
-use crate::msgs::handshake::{CertificateStatus, DigitallySignedStruct, ECDHEServerKeyExchange};
-use crate::msgs::handshake::{ClientExtension, SessionID};
-use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, ServerHelloPayload};
-use crate::msgs::handshake::{ECPointFormatList, SupportedPointFormats};
-use crate::msgs::handshake::{HandshakePayload, ServerECDHParams};
-use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
+use crate::msgs::enums::{AlertDescription, ContentType, HandshakeType, ProtocolVersion};
+use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload, NewSessionTicketPayload};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::server::ServerConnection;
-use crate::sign;
 use crate::verify;
 use crate::SupportedCipherSuite;
 
@@ -30,450 +21,468 @@ use crate::server::hs;
 
 use ring::constant_time;
 
-pub(super) struct CompleteClientHelloHandling {
-    pub handshake: HandshakeDetails,
-    pub suite: &'static SupportedCipherSuite,
-    pub using_ems: bool,
-    pub randoms: ConnectionRandoms,
-    pub send_ticket: bool,
-    pub extra_exts: Vec<ServerExtension>,
-}
+pub(super) use client_hello::CompleteClientHelloHandling;
 
-impl CompleteClientHelloHandling {
-    pub fn handle_client_hello(
-        mut self,
-        sess: &mut ServerConnection,
-        server_key: &sign::CertifiedKey,
-        chm: &Message,
-        client_hello: &ClientHelloPayload,
-        sigschemes_ext: Vec<SignatureScheme>,
-        sni: Option<webpki::DNSName>,
-        tls13_enabled: bool,
-    ) -> hs::NextStateOrError {
-        // -- TLS1.2 only from hereon in --
-        self.handshake
-            .transcript
-            .add_message(&chm);
+mod client_hello {
+    use crate::msgs::enums::ECPointFormat;
+    use crate::msgs::enums::{ClientCertificateType, Compression, SignatureScheme};
+    use crate::msgs::handshake::{CertificateRequestPayload, Random};
+    use crate::msgs::handshake::{
+        CertificateStatus, DigitallySignedStruct, ECDHEServerKeyExchange,
+    };
+    use crate::msgs::handshake::{ClientExtension, SessionID};
+    use crate::msgs::handshake::{ClientHelloPayload, ServerHelloPayload};
+    use crate::msgs::handshake::{ECPointFormatList, ServerECDHParams, SupportedPointFormats};
+    use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
+    use crate::sign;
 
-        if client_hello.ems_support_offered() {
-            self.using_ems = true;
-        }
+    use super::*;
 
-        let groups_ext = client_hello
-            .get_namedgroups_extension()
-            .ok_or_else(|| hs::incompatible(sess, "client didn't describe groups"))?;
-        let ecpoints_ext = client_hello
-            .get_ecpoints_extension()
-            .ok_or_else(|| hs::incompatible(sess, "client didn't describe ec points"))?;
+    pub(in crate::server) struct CompleteClientHelloHandling {
+        pub(in crate::server) handshake: HandshakeDetails,
+        pub(in crate::server) suite: &'static SupportedCipherSuite,
+        pub(in crate::server) using_ems: bool,
+        pub(in crate::server) randoms: ConnectionRandoms,
+        pub(in crate::server) send_ticket: bool,
+        pub(in crate::server) extra_exts: Vec<ServerExtension>,
+    }
 
-        trace!("namedgroups {:?}", groups_ext);
-        trace!("ecpoints {:?}", ecpoints_ext);
+    impl CompleteClientHelloHandling {
+        pub(in crate::server) fn handle_client_hello(
+            mut self,
+            conn: &mut ServerConnection,
+            server_key: &sign::CertifiedKey,
+            chm: &Message,
+            client_hello: &ClientHelloPayload,
+            sigschemes_ext: Vec<SignatureScheme>,
+            sni: Option<webpki::DNSName>,
+            tls13_enabled: bool,
+        ) -> hs::NextStateOrError {
+            // -- TLS1.2 only from hereon in --
+            self.handshake
+                .transcript
+                .add_message(&chm);
 
-        if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
-            sess.common
-                .send_fatal_alert(AlertDescription::IllegalParameter);
-            return Err(Error::PeerIncompatibleError(
-                "client didn't support uncompressed ec points".to_string(),
-            ));
-        }
+            if client_hello.ems_support_offered() {
+                self.using_ems = true;
+            }
 
-        // -- If TLS1.3 is enabled, signal the downgrade in the server random
-        if tls13_enabled {
-            self.randoms
-                .set_tls12_downgrade_marker();
-        }
+            let groups_ext = client_hello
+                .get_namedgroups_extension()
+                .ok_or_else(|| hs::incompatible(conn, "client didn't describe groups"))?;
+            let ecpoints_ext = client_hello
+                .get_ecpoints_extension()
+                .ok_or_else(|| hs::incompatible(conn, "client didn't describe ec points"))?;
 
-        // -- Check for resumption --
-        // We can do this either by (in order of preference):
-        // 1. receiving a ticket that decrypts
-        // 2. receiving a sessionid that is in our cache
-        //
-        // If we receive a ticket, the sessionid won't be in our
-        // cache, so don't check.
-        //
-        // If either works, we end up with a ServerSessionValue
-        // which is passed to start_resumption and concludes
-        // our handling of the ClientHello.
-        //
-        let mut ticket_received = false;
+            trace!("namedgroups {:?}", groups_ext);
+            trace!("ecpoints {:?}", ecpoints_ext);
 
-        if let Some(ClientExtension::SessionTicketOffer(ticket)) =
-            client_hello.get_ticket_extension()
-        {
-            ticket_received = true;
-            debug!("Ticket received");
+            if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
+                conn.common
+                    .send_fatal_alert(AlertDescription::IllegalParameter);
+                return Err(Error::PeerIncompatibleError(
+                    "client didn't support uncompressed ec points".to_string(),
+                ));
+            }
 
-            if let Some(resume) = sess
-                .config
-                .ticketer
-                .decrypt(&ticket.0)
-                .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-                .and_then(|resumedata| {
-                    hs::can_resume(self.suite, &sess.sni, self.using_ems, resumedata)
-                })
+            // -- If TLS1.3 is enabled, signal the downgrade in the server random
+            if tls13_enabled {
+                self.randoms
+                    .set_tls12_downgrade_marker();
+            }
+
+            // -- Check for resumption --
+            // We can do this either by (in order of preference):
+            // 1. receiving a ticket that decrypts
+            // 2. receiving a connionid that is in our cache
+            //
+            // If we receive a ticket, the connionid won't be in our
+            // cache, so don't check.
+            //
+            // If either works, we end up with a ServerConnectionValue
+            // which is passed to start_resumption and concludes
+            // our handling of the ClientHello.
+            //
+            let mut ticket_received = false;
+
+            if let Some(ClientExtension::SessionTicketOffer(ref ticket)) =
+                client_hello.get_ticket_extension()
             {
-                return self.start_resumption(
-                    sess,
-                    client_hello,
-                    sni.as_ref(),
-                    &client_hello.session_id,
-                    resume,
-                );
+                ticket_received = true;
+                debug!("Ticket received");
+
+                if let Some(resume) = conn
+                    .config
+                    .ticketer
+                    .decrypt(&ticket.0)
+                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+                    .and_then(|resumedata| {
+                        hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
+                    })
+                {
+                    return self.start_resumption(
+                        conn,
+                        client_hello,
+                        sni.as_ref(),
+                        &client_hello.session_id,
+                        resume,
+                    );
+                } else {
+                    debug!("Ticket didn't decrypt");
+                }
+            }
+
+            // If we're not offered a ticket or a potential connion ID,
+            // allocate a connion ID.
+            if self.handshake.session_id.is_empty() && !ticket_received {
+                self.handshake.session_id = SessionID::random()?;
+            }
+
+            // Perhaps resume?  If we received a ticket, the connionid
+            // does not correspond to a real connion.
+            if !client_hello.session_id.is_empty() && !ticket_received {
+                if let Some(resume) = conn
+                    .config
+                    .session_storage
+                    .get(&client_hello.session_id.get_encoding())
+                    .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
+                    .and_then(|resumedata| {
+                        hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
+                    })
+                {
+                    return self.start_resumption(
+                        conn,
+                        client_hello,
+                        sni.as_ref(),
+                        &client_hello.session_id,
+                        resume,
+                    );
+                }
+            }
+
+            // Now we have chosen a ciphersuite, we can make kx decisions.
+            let sigschemes = self
+                .suite
+                .resolve_sig_schemes(&sigschemes_ext);
+
+            if sigschemes.is_empty() {
+                return Err(hs::incompatible(conn, "no supported sig scheme"));
+            }
+
+            let group = conn
+                .config
+                .kx_groups
+                .iter()
+                .find(|skxg| groups_ext.contains(&skxg.name))
+                .cloned()
+                .ok_or_else(|| hs::incompatible(conn, "no supported group"))?;
+
+            let ecpoint = ECPointFormatList::supported()
+                .iter()
+                .find(|format| ecpoints_ext.contains(format))
+                .cloned()
+                .ok_or_else(|| hs::incompatible(conn, "no supported point format"))?;
+
+            debug_assert_eq!(ecpoint, ECPointFormat::Uncompressed);
+
+            let (mut ocsp_response, mut sct_list) =
+                (server_key.ocsp.as_deref(), server_key.sct_list.as_deref());
+            self.send_ticket = emit_server_hello(
+                &mut self.handshake,
+                conn,
+                self.suite,
+                self.using_ems,
+                &mut ocsp_response,
+                &mut sct_list,
+                client_hello,
+                None,
+                &self.randoms,
+                self.extra_exts,
+            )?;
+            emit_certificate(&mut self.handshake, conn, &server_key.cert);
+            if let Some(ocsp_response) = ocsp_response {
+                emit_cert_status(&mut self.handshake, conn, ocsp_response);
+            }
+            let server_kx = emit_server_kx(
+                &mut self.handshake,
+                conn,
+                sigschemes,
+                group,
+                &*server_key.key,
+                &self.randoms,
+            )?;
+            let doing_client_auth = emit_certificate_req(&mut self.handshake, conn)?;
+            emit_server_hello_done(&mut self.handshake, conn);
+
+            if doing_client_auth {
+                Ok(Box::new(ExpectCertificate {
+                    handshake: self.handshake,
+                    randoms: self.randoms,
+                    suite: self.suite,
+                    using_ems: self.using_ems,
+                    server_kx,
+                    send_ticket: self.send_ticket,
+                }))
             } else {
-                debug!("Ticket didn't decrypt");
+                Ok(Box::new(ExpectClientKx {
+                    handshake: self.handshake,
+                    randoms: self.randoms,
+                    suite: self.suite,
+                    using_ems: self.using_ems,
+                    server_kx,
+                    client_cert: None,
+                    send_ticket: self.send_ticket,
+                }))
             }
         }
 
-        // If we're not offered a ticket or a potential session ID,
-        // allocate a session ID.
-        if self.handshake.session_id.is_empty() && !ticket_received {
-            self.handshake.session_id = SessionID::random()?;
-        }
+        fn start_resumption(
+            mut self,
+            conn: &mut ServerConnection,
+            client_hello: &ClientHelloPayload,
+            sni: Option<&webpki::DNSName>,
+            id: &SessionID,
+            resumedata: persist::ServerSessionValue,
+        ) -> hs::NextStateOrError {
+            debug!("Resuming connion");
 
-        // Perhaps resume?  If we received a ticket, the sessionid
-        // does not correspond to a real session.
-        if !client_hello.session_id.is_empty() && !ticket_received {
-            if let Some(resume) = sess
-                .config
-                .session_storage
-                .get(&client_hello.session_id.get_encoding())
-                .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
-                .and_then(|resumedata| {
-                    hs::can_resume(self.suite, &sess.sni, self.using_ems, resumedata)
-                })
-            {
-                return self.start_resumption(
-                    sess,
-                    client_hello,
-                    sni.as_ref(),
-                    &client_hello.session_id,
-                    resume,
-                );
+            if resumedata.extended_ms && !self.using_ems {
+                return Err(hs::illegal_param(conn, "refusing to resume without ems"));
             }
-        }
 
-        // Now we have chosen a ciphersuite, we can make kx decisions.
-        let sigschemes = self
-            .suite
-            .resolve_sig_schemes(&sigschemes_ext);
+            self.handshake.session_id = *id;
+            self.send_ticket = emit_server_hello(
+                &mut self.handshake,
+                conn,
+                self.suite,
+                self.using_ems,
+                &mut None,
+                &mut None,
+                client_hello,
+                Some(&resumedata),
+                &self.randoms,
+                self.extra_exts,
+            )?;
 
-        if sigschemes.is_empty() {
-            return Err(hs::incompatible(sess, "no supported sig scheme"));
-        }
-
-        let group = sess
-            .config
-            .kx_groups
-            .iter()
-            .find(|skxg| groups_ext.contains(&skxg.name))
-            .cloned()
-            .ok_or_else(|| hs::incompatible(sess, "no supported group"))?;
-
-        let ecpoint = ECPointFormatList::supported()
-            .iter()
-            .find(|format| ecpoints_ext.contains(format))
-            .cloned()
-            .ok_or_else(|| hs::incompatible(sess, "no supported point format"))?;
-
-        debug_assert_eq!(ecpoint, ECPointFormat::Uncompressed);
-
-        let (mut ocsp_response, mut sct_list) =
-            (server_key.ocsp.as_deref(), server_key.sct_list.as_deref());
-        self.send_ticket = emit_server_hello(
-            &mut self.handshake,
-            sess,
-            self.suite,
-            self.using_ems,
-            &mut ocsp_response,
-            &mut sct_list,
-            client_hello,
-            None,
-            &self.randoms,
-            self.extra_exts,
-        )?;
-        emit_certificate(&mut self.handshake, sess, &server_key.cert);
-        if let Some(ocsp_response) = ocsp_response {
-            emit_cert_status(&mut self.handshake, sess, ocsp_response);
-        }
-        let server_kx = emit_server_kx(
-            &mut self.handshake,
-            sess,
-            sigschemes,
-            group,
-            &*server_key.key,
-            &self.randoms,
-        )?;
-        let doing_client_auth = emit_certificate_req(&mut self.handshake, sess)?;
-        emit_server_hello_done(&mut self.handshake, sess);
-
-        if doing_client_auth {
-            Ok(Box::new(ExpectCertificate {
-                handshake: self.handshake,
-                randoms: self.randoms,
-                suite: self.suite,
-                using_ems: self.using_ems,
-                server_kx,
-                send_ticket: self.send_ticket,
-            }))
-        } else {
-            Ok(Box::new(ExpectClientKx {
-                handshake: self.handshake,
-                randoms: self.randoms,
-                suite: self.suite,
-                using_ems: self.using_ems,
-                server_kx,
-                client_cert: None,
-                send_ticket: self.send_ticket,
-            }))
-        }
-    }
-
-    fn start_resumption(
-        mut self,
-        sess: &mut ServerConnection,
-        client_hello: &ClientHelloPayload,
-        sni: Option<&webpki::DNSName>,
-        id: &SessionID,
-        resumedata: persist::ServerSessionValue,
-    ) -> hs::NextStateOrError {
-        debug!("Resuming session");
-
-        if resumedata.extended_ms && !self.using_ems {
-            return Err(hs::illegal_param(sess, "refusing to resume without ems"));
-        }
-
-        self.handshake.session_id = *id;
-        self.send_ticket = emit_server_hello(
-            &mut self.handshake,
-            sess,
-            self.suite,
-            self.using_ems,
-            &mut None,
-            &mut None,
-            client_hello,
-            Some(&resumedata),
-            &self.randoms,
-            self.extra_exts,
-        )?;
-
-        let secrets =
-            ConnectionSecrets::new_resume(&self.randoms, self.suite, &resumedata.master_secret.0);
-        sess.config.key_log.log(
-            "CLIENT_RANDOM",
-            &secrets.randoms.client,
-            &secrets.master_secret,
-        );
-        sess.common
-            .start_encryption_tls12(&secrets);
-        sess.client_cert_chain = resumedata.client_cert_chain;
-
-        if self.send_ticket {
-            emit_ticket(&secrets, &mut self.handshake, self.using_ems, sess);
-        }
-        emit_ccs(sess);
-        sess.common
-            .record_layer
-            .start_encrypting();
-        emit_finished(&secrets, &mut self.handshake, sess);
-
-        assert!(hs::same_dns_name_or_both_none(sni, sess.get_sni()));
-
-        Ok(Box::new(ExpectCcs {
-            secrets,
-            handshake: self.handshake,
-            using_ems: self.using_ems,
-            resuming: true,
-            send_ticket: self.send_ticket,
-        }))
-    }
-}
-
-pub(super) fn emit_server_hello(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-    suite: &'static SupportedCipherSuite,
-    using_ems: bool,
-    ocsp_response: &mut Option<&[u8]>,
-    sct_list: &mut Option<&[u8]>,
-    hello: &ClientHelloPayload,
-    resumedata: Option<&persist::ServerSessionValue>,
-    randoms: &ConnectionRandoms,
-    extra_exts: Vec<ServerExtension>,
-) -> Result<bool, Error> {
-    let mut ep = hs::ExtensionProcessing::new();
-    ep.process_common(
-        conn,
-        suite,
-        ocsp_response,
-        sct_list,
-        hello,
-        resumedata,
-        extra_exts,
-    )?;
-    ep.process_tls12(conn, hello, using_ems);
-
-    let sh = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ServerHello,
-            payload: HandshakePayload::ServerHello(ServerHelloPayload {
-                legacy_version: ProtocolVersion::TLSv1_2,
-                random: Random::from_slice(&randoms.server),
-                session_id: handshake.session_id,
-                cipher_suite: suite.suite,
-                compression_method: Compression::Null,
-                extensions: ep.exts,
-            }),
-        }),
-    };
-
-    trace!("sending server hello {:?}", sh);
-    handshake.transcript.add_message(&sh);
-    conn.common.send_msg(sh, false);
-    Ok(ep.send_ticket)
-}
-
-pub(super) fn emit_certificate(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-    cert_chain: &[Certificate],
-) {
-    let c = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Certificate,
-            payload: HandshakePayload::Certificate(cert_chain.to_owned()),
-        }),
-    };
-
-    handshake.transcript.add_message(&c);
-    conn.common.send_msg(c, false);
-}
-
-pub(super) fn emit_cert_status(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-    ocsp: &[u8],
-) {
-    let st = CertificateStatus::new(ocsp.to_owned());
-
-    let c = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateStatus,
-            payload: HandshakePayload::CertificateStatus(st),
-        }),
-    };
-
-    handshake.transcript.add_message(&c);
-    conn.common.send_msg(c, false);
-}
-
-pub(super) fn emit_server_kx(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-    sigschemes: Vec<SignatureScheme>,
-    skxg: &'static kx::SupportedKxGroup,
-    signing_key: &dyn sign::SigningKey,
-    randoms: &ConnectionRandoms,
-) -> Result<kx::KeyExchange, Error> {
-    let kx = kx::KeyExchange::start(skxg)
-        .ok_or_else(|| Error::PeerMisbehavedError("key exchange failed".to_string()))?;
-    let secdh = ServerECDHParams::new(skxg.name, kx.pubkey.as_ref());
-
-    let mut msg = Vec::new();
-    msg.extend(&randoms.client);
-    msg.extend(&randoms.server);
-    secdh.encode(&mut msg);
-
-    let signer = signing_key
-        .choose_scheme(&sigschemes)
-        .ok_or_else(|| Error::General("incompatible signing key".to_string()))?;
-    let sigscheme = signer.get_scheme();
-    let sig = signer.sign(&msg)?;
-
-    let skx = ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
-        params: secdh,
-        dss: DigitallySignedStruct::new(sigscheme, sig),
-    });
-
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ServerKeyExchange,
-            payload: HandshakePayload::ServerKeyExchange(skx),
-        }),
-    };
-
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, false);
-    Ok(kx)
-}
-
-pub(super) fn emit_certificate_req(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-) -> Result<bool, Error> {
-    let client_auth = conn.config.get_verifier();
-
-    if !client_auth.offer_client_auth() {
-        return Ok(false);
-    }
-
-    let verify_schemes = client_auth.supported_verify_schemes();
-
-    let names = client_auth
-        .client_auth_root_subjects(conn.get_sni())
-        .ok_or_else(|| {
-            debug!("could not determine root subjects based on SNI");
+            let secrets = ConnectionSecrets::new_resume(
+                &self.randoms,
+                self.suite,
+                &resumedata.master_secret.0,
+            );
+            conn.config.key_log.log(
+                "CLIENT_RANDOM",
+                &secrets.randoms.client,
+                &secrets.master_secret,
+            );
             conn.common
-                .send_fatal_alert(AlertDescription::AccessDenied);
-            Error::General("client rejected by client_auth_root_subjects".into())
-        })?;
+                .start_encryption_tls12(&secrets);
+            conn.client_cert_chain = resumedata.client_cert_chain;
 
-    let cr = CertificateRequestPayload {
-        certtypes: vec![
-            ClientCertificateType::RSASign,
-            ClientCertificateType::ECDSASign,
-        ],
-        sigschemes: verify_schemes,
-        canames: names,
-    };
+            if self.send_ticket {
+                emit_ticket(&secrets, &mut self.handshake, self.using_ems, conn);
+            }
+            emit_ccs(conn);
+            conn.common
+                .record_layer
+                .start_encrypting();
+            emit_finished(&secrets, &mut self.handshake, conn);
 
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateRequest,
-            payload: HandshakePayload::CertificateRequest(cr),
-        }),
-    };
+            assert!(hs::same_dns_name_or_both_none(sni, conn.get_sni()));
 
-    trace!("Sending CertificateRequest {:?}", m);
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, false);
-    Ok(true)
-}
+            Ok(Box::new(ExpectCcs {
+                secrets,
+                handshake: self.handshake,
+                using_ems: self.using_ems,
+                resuming: true,
+                send_ticket: self.send_ticket,
+            }))
+        }
+    }
 
-pub(super) fn emit_server_hello_done(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-) {
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ServerHelloDone,
-            payload: HandshakePayload::ServerHelloDone,
-        }),
-    };
+    fn emit_server_hello(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        suite: &'static SupportedCipherSuite,
+        using_ems: bool,
+        ocsp_response: &mut Option<&[u8]>,
+        sct_list: &mut Option<&[u8]>,
+        hello: &ClientHelloPayload,
+        resumedata: Option<&persist::ServerSessionValue>,
+        randoms: &ConnectionRandoms,
+        extra_exts: Vec<ServerExtension>,
+    ) -> Result<bool, Error> {
+        let mut ep = hs::ExtensionProcessing::new();
+        ep.process_common(
+            conn,
+            suite,
+            ocsp_response,
+            sct_list,
+            hello,
+            resumedata,
+            extra_exts,
+        )?;
+        ep.process_tls12(conn, hello, using_ems);
 
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, false);
+        let sh = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::ServerHello,
+                payload: HandshakePayload::ServerHello(ServerHelloPayload {
+                    legacy_version: ProtocolVersion::TLSv1_2,
+                    random: Random::from_slice(&randoms.server),
+                    session_id: handshake.session_id,
+                    cipher_suite: suite.suite,
+                    compression_method: Compression::Null,
+                    extensions: ep.exts,
+                }),
+            }),
+        };
+
+        trace!("sending server hello {:?}", sh);
+        handshake.transcript.add_message(&sh);
+        conn.common.send_msg(sh, false);
+        Ok(ep.send_ticket)
+    }
+
+    fn emit_certificate(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        cert_chain: &[Certificate],
+    ) {
+        let c = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::Certificate,
+                payload: HandshakePayload::Certificate(cert_chain.to_owned()),
+            }),
+        };
+
+        handshake.transcript.add_message(&c);
+        conn.common.send_msg(c, false);
+    }
+
+    fn emit_cert_status(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        ocsp: &[u8],
+    ) {
+        let st = CertificateStatus::new(ocsp.to_owned());
+
+        let c = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::CertificateStatus,
+                payload: HandshakePayload::CertificateStatus(st),
+            }),
+        };
+
+        handshake.transcript.add_message(&c);
+        conn.common.send_msg(c, false);
+    }
+
+    fn emit_server_kx(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        sigschemes: Vec<SignatureScheme>,
+        skxg: &'static kx::SupportedKxGroup,
+        signing_key: &dyn sign::SigningKey,
+        randoms: &ConnectionRandoms,
+    ) -> Result<kx::KeyExchange, Error> {
+        let kx = kx::KeyExchange::start(skxg)
+            .ok_or_else(|| Error::PeerMisbehavedError("key exchange failed".to_string()))?;
+        let secdh = ServerECDHParams::new(skxg.name, kx.pubkey.as_ref());
+
+        let mut msg = Vec::new();
+        msg.extend(&randoms.client);
+        msg.extend(&randoms.server);
+        secdh.encode(&mut msg);
+
+        let signer = signing_key
+            .choose_scheme(&sigschemes)
+            .ok_or_else(|| Error::General("incompatible signing key".to_string()))?;
+        let sigscheme = signer.get_scheme();
+        let sig = signer.sign(&msg)?;
+
+        let skx = ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {
+            params: secdh,
+            dss: DigitallySignedStruct::new(sigscheme, sig),
+        });
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::ServerKeyExchange,
+                payload: HandshakePayload::ServerKeyExchange(skx),
+            }),
+        };
+
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, false);
+        Ok(kx)
+    }
+
+    fn emit_certificate_req(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+    ) -> Result<bool, Error> {
+        let client_auth = conn.config.get_verifier();
+
+        if !client_auth.offer_client_auth() {
+            return Ok(false);
+        }
+
+        let verify_schemes = client_auth.supported_verify_schemes();
+
+        let names = client_auth
+            .client_auth_root_subjects(conn.get_sni())
+            .ok_or_else(|| {
+                debug!("could not determine root subjects based on SNI");
+                conn.common
+                    .send_fatal_alert(AlertDescription::AccessDenied);
+                Error::General("client rejected by client_auth_root_subjects".into())
+            })?;
+
+        let cr = CertificateRequestPayload {
+            certtypes: vec![
+                ClientCertificateType::RSASign,
+                ClientCertificateType::ECDSASign,
+            ],
+            sigschemes: verify_schemes,
+            canames: names,
+        };
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::CertificateRequest,
+                payload: HandshakePayload::CertificateRequest(cr),
+            }),
+        };
+
+        trace!("Sending CertificateRequest {:?}", m);
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, false);
+        Ok(true)
+    }
+
+    fn emit_server_hello_done(handshake: &mut HandshakeDetails, conn: &mut ServerConnection) {
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::ServerHelloDone,
+                payload: HandshakePayload::ServerHelloDone,
+            }),
+        };
+
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, false);
+    }
 }
 
 // --- Process client's Certificate for client auth ---
@@ -718,7 +727,7 @@ impl hs::State for ExpectCcs {
 }
 
 // --- Process client's Finished ---
-fn get_server_session_value_tls12(
+fn get_server_connion_value_tls12(
     secrets: &ConnectionSecrets,
     using_ems: bool,
     conn: &ServerConnection,
@@ -751,7 +760,7 @@ pub fn emit_ticket(
 ) {
     // If we can't produce a ticket for some reason, we can't
     // report an error. Send an empty one.
-    let plain = get_server_session_value_tls12(secrets, using_ems, conn).get_encoding();
+    let plain = get_server_connion_value_tls12(secrets, using_ems, conn).get_encoding();
     let ticket = conn
         .config
         .ticketer
@@ -841,9 +850,9 @@ impl hs::State for ExpectFinished {
                 })
                 .map(|_| verify::FinishedMessageVerified::assertion())?;
 
-        // Save session, perhaps
+        // Save connion, perhaps
         if !self.resuming && !self.handshake.session_id.is_empty() {
-            let value = get_server_session_value_tls12(&self.secrets, self.using_ems, conn);
+            let value = get_server_connion_value_tls12(&self.secrets, self.using_ems, conn);
 
             let worked = conn.config.session_storage.put(
                 self.handshake.session_id.get_encoding(),

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -8,11 +8,14 @@ use crate::log::{debug, trace};
 use crate::msgs::base::Payload;
 use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
+use crate::msgs::enums::ECPointFormat;
 use crate::msgs::enums::{AlertDescription, ClientCertificateType, SignatureScheme};
 use crate::msgs::enums::{Compression, ContentType, HandshakeType, ProtocolVersion};
 use crate::msgs::handshake::{CertificateRequestPayload, NewSessionTicketPayload, Random};
 use crate::msgs::handshake::{CertificateStatus, DigitallySignedStruct, ECDHEServerKeyExchange};
+use crate::msgs::handshake::{ClientExtension, SessionID};
 use crate::msgs::handshake::{ClientHelloPayload, HandshakeMessagePayload, ServerHelloPayload};
+use crate::msgs::handshake::{ECPointFormatList, SupportedPointFormats};
 use crate::msgs::handshake::{HandshakePayload, ServerECDHParams};
 use crate::msgs::handshake::{ServerExtension, ServerKeyExchangePayload};
 use crate::msgs::message::{Message, MessagePayload};
@@ -26,6 +29,264 @@ use crate::server::common::HandshakeDetails;
 use crate::server::hs;
 
 use ring::constant_time;
+
+pub(super) struct CompleteClientHelloHandling {
+    pub handshake: HandshakeDetails,
+    pub suite: &'static SupportedCipherSuite,
+    pub using_ems: bool,
+    pub randoms: ConnectionRandoms,
+    pub send_ticket: bool,
+    pub extra_exts: Vec<ServerExtension>,
+}
+
+impl CompleteClientHelloHandling {
+    pub fn handle_client_hello(
+        mut self,
+        sess: &mut ServerConnection,
+        server_key: &sign::CertifiedKey,
+        chm: &Message,
+        client_hello: &ClientHelloPayload,
+        sigschemes_ext: Vec<SignatureScheme>,
+        sni: Option<webpki::DNSName>,
+        tls13_enabled: bool,
+    ) -> hs::NextStateOrError {
+        // -- TLS1.2 only from hereon in --
+        self.handshake
+            .transcript
+            .add_message(&chm);
+
+        if client_hello.ems_support_offered() {
+            self.using_ems = true;
+        }
+
+        let groups_ext = client_hello
+            .get_namedgroups_extension()
+            .ok_or_else(|| hs::incompatible(sess, "client didn't describe groups"))?;
+        let ecpoints_ext = client_hello
+            .get_ecpoints_extension()
+            .ok_or_else(|| hs::incompatible(sess, "client didn't describe ec points"))?;
+
+        trace!("namedgroups {:?}", groups_ext);
+        trace!("ecpoints {:?}", ecpoints_ext);
+
+        if !ecpoints_ext.contains(&ECPointFormat::Uncompressed) {
+            sess.common
+                .send_fatal_alert(AlertDescription::IllegalParameter);
+            return Err(Error::PeerIncompatibleError(
+                "client didn't support uncompressed ec points".to_string(),
+            ));
+        }
+
+        // -- If TLS1.3 is enabled, signal the downgrade in the server random
+        if tls13_enabled {
+            self.randoms
+                .set_tls12_downgrade_marker();
+        }
+
+        // -- Check for resumption --
+        // We can do this either by (in order of preference):
+        // 1. receiving a ticket that decrypts
+        // 2. receiving a sessionid that is in our cache
+        //
+        // If we receive a ticket, the sessionid won't be in our
+        // cache, so don't check.
+        //
+        // If either works, we end up with a ServerSessionValue
+        // which is passed to start_resumption and concludes
+        // our handling of the ClientHello.
+        //
+        let mut ticket_received = false;
+
+        if let Some(ClientExtension::SessionTicketOffer(ticket)) =
+            client_hello.get_ticket_extension()
+        {
+            ticket_received = true;
+            debug!("Ticket received");
+
+            if let Some(resume) = sess
+                .config
+                .ticketer
+                .decrypt(&ticket.0)
+                .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+                .and_then(|resumedata| {
+                    hs::can_resume(self.suite, &sess.sni, self.using_ems, resumedata)
+                })
+            {
+                return self.start_resumption(
+                    sess,
+                    client_hello,
+                    sni.as_ref(),
+                    &client_hello.session_id,
+                    resume,
+                );
+            } else {
+                debug!("Ticket didn't decrypt");
+            }
+        }
+
+        // If we're not offered a ticket or a potential session ID,
+        // allocate a session ID.
+        if self.handshake.session_id.is_empty() && !ticket_received {
+            self.handshake.session_id = SessionID::random()?;
+        }
+
+        // Perhaps resume?  If we received a ticket, the sessionid
+        // does not correspond to a real session.
+        if !client_hello.session_id.is_empty() && !ticket_received {
+            if let Some(resume) = sess
+                .config
+                .session_storage
+                .get(&client_hello.session_id.get_encoding())
+                .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
+                .and_then(|resumedata| {
+                    hs::can_resume(self.suite, &sess.sni, self.using_ems, resumedata)
+                })
+            {
+                return self.start_resumption(
+                    sess,
+                    client_hello,
+                    sni.as_ref(),
+                    &client_hello.session_id,
+                    resume,
+                );
+            }
+        }
+
+        // Now we have chosen a ciphersuite, we can make kx decisions.
+        let sigschemes = self
+            .suite
+            .resolve_sig_schemes(&sigschemes_ext);
+
+        if sigschemes.is_empty() {
+            return Err(hs::incompatible(sess, "no supported sig scheme"));
+        }
+
+        let group = sess
+            .config
+            .kx_groups
+            .iter()
+            .find(|skxg| groups_ext.contains(&skxg.name))
+            .cloned()
+            .ok_or_else(|| hs::incompatible(sess, "no supported group"))?;
+
+        let ecpoint = ECPointFormatList::supported()
+            .iter()
+            .find(|format| ecpoints_ext.contains(format))
+            .cloned()
+            .ok_or_else(|| hs::incompatible(sess, "no supported point format"))?;
+
+        debug_assert_eq!(ecpoint, ECPointFormat::Uncompressed);
+
+        let (mut ocsp_response, mut sct_list) =
+            (server_key.ocsp.as_deref(), server_key.sct_list.as_deref());
+        self.send_ticket = emit_server_hello(
+            &mut self.handshake,
+            sess,
+            self.suite,
+            self.using_ems,
+            &mut ocsp_response,
+            &mut sct_list,
+            client_hello,
+            None,
+            &self.randoms,
+            self.extra_exts,
+        )?;
+        emit_certificate(&mut self.handshake, sess, &server_key.cert);
+        if let Some(ocsp_response) = ocsp_response {
+            emit_cert_status(&mut self.handshake, sess, ocsp_response);
+        }
+        let server_kx = emit_server_kx(
+            &mut self.handshake,
+            sess,
+            sigschemes,
+            group,
+            &*server_key.key,
+            &self.randoms,
+        )?;
+        let doing_client_auth = emit_certificate_req(&mut self.handshake, sess)?;
+        emit_server_hello_done(&mut self.handshake, sess);
+
+        if doing_client_auth {
+            Ok(Box::new(ExpectCertificate {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                suite: self.suite,
+                using_ems: self.using_ems,
+                server_kx,
+                send_ticket: self.send_ticket,
+            }))
+        } else {
+            Ok(Box::new(ExpectClientKx {
+                handshake: self.handshake,
+                randoms: self.randoms,
+                suite: self.suite,
+                using_ems: self.using_ems,
+                server_kx,
+                client_cert: None,
+                send_ticket: self.send_ticket,
+            }))
+        }
+    }
+
+    fn start_resumption(
+        mut self,
+        sess: &mut ServerConnection,
+        client_hello: &ClientHelloPayload,
+        sni: Option<&webpki::DNSName>,
+        id: &SessionID,
+        resumedata: persist::ServerSessionValue,
+    ) -> hs::NextStateOrError {
+        debug!("Resuming session");
+
+        if resumedata.extended_ms && !self.using_ems {
+            return Err(hs::illegal_param(sess, "refusing to resume without ems"));
+        }
+
+        self.handshake.session_id = *id;
+        self.send_ticket = emit_server_hello(
+            &mut self.handshake,
+            sess,
+            self.suite,
+            self.using_ems,
+            &mut None,
+            &mut None,
+            client_hello,
+            Some(&resumedata),
+            &self.randoms,
+            self.extra_exts,
+        )?;
+
+        let secrets =
+            ConnectionSecrets::new_resume(&self.randoms, self.suite, &resumedata.master_secret.0);
+        sess.config.key_log.log(
+            "CLIENT_RANDOM",
+            &secrets.randoms.client,
+            &secrets.master_secret,
+        );
+        sess.common
+            .start_encryption_tls12(&secrets);
+        sess.client_cert_chain = resumedata.client_cert_chain;
+
+        if self.send_ticket {
+            emit_ticket(&secrets, &mut self.handshake, self.using_ems, sess);
+        }
+        emit_ccs(sess);
+        sess.common
+            .record_layer
+            .start_encrypting();
+        emit_finished(&secrets, &mut self.handshake, sess);
+
+        assert!(hs::same_dns_name_or_both_none(sni, sess.get_sni()));
+
+        Ok(Box::new(ExpectCcs {
+            secrets,
+            handshake: self.handshake,
+            using_ems: self.using_ems,
+            resuming: true,
+            send_ticket: self.send_ticket,
+        }))
+    }
+}
 
 pub(super) fn emit_server_hello(
     handshake: &mut HandshakeDetails,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -2,47 +2,23 @@ use crate::check::check_message;
 use crate::conn::ConnectionRandoms;
 use crate::error::Error;
 use crate::key::Certificate;
-use crate::key_schedule::{
-    KeyScheduleEarly, KeyScheduleHandshake, KeyScheduleNonSecret, KeyScheduleTraffic,
-    KeyScheduleTrafficWithClientFinishedPending,
-};
-use crate::kx;
+use crate::key_schedule::{KeyScheduleTraffic, KeyScheduleTrafficWithClientFinishedPending};
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
-use crate::msgs::base::{Payload, PayloadU8};
-use crate::msgs::ccs::ChangeCipherSpecPayload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::KeyUpdateRequest;
-use crate::msgs::enums::{AlertDescription, NamedGroup, SignatureScheme};
-use crate::msgs::enums::{Compression, PSKKeyExchangeMode};
+use crate::msgs::enums::{AlertDescription, KeyUpdateRequest};
 use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
-use crate::msgs::handshake::CertReqExtension;
-use crate::msgs::handshake::CertificateEntry;
-use crate::msgs::handshake::CertificateExtension;
-use crate::msgs::handshake::CertificatePayloadTLS13;
-use crate::msgs::handshake::CertificateRequestPayloadTLS13;
-use crate::msgs::handshake::CertificateStatus;
-use crate::msgs::handshake::ClientHelloPayload;
-use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::handshake::HandshakePayload;
-use crate::msgs::handshake::HelloRetryExtension;
-use crate::msgs::handshake::HelloRetryRequest;
-use crate::msgs::handshake::KeyShareEntry;
 use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
-use crate::msgs::handshake::Random;
-use crate::msgs::handshake::ServerExtension;
-use crate::msgs::handshake::ServerHelloPayload;
-use crate::msgs::handshake::SessionID;
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::rand;
 use crate::server::ServerConnection;
-use crate::sign;
 use crate::verify;
 use crate::{cipher, SupportedCipherSuite};
 #[cfg(feature = "quic")]
-use crate::{conn::Protocol, msgs::handshake::NewSessionTicketExtension, quic};
+use crate::{conn::Protocol, msgs::handshake::NewSessionTicketExtension};
 
 use crate::server::common::HandshakeDetails;
 use crate::server::hs;
@@ -50,664 +26,701 @@ use crate::server::hs;
 use ring::constant_time;
 use ring::digest::Digest;
 
-pub struct CompleteClientHelloHandling {
-    pub handshake: HandshakeDetails,
-    pub suite: &'static SupportedCipherSuite,
-    pub randoms: ConnectionRandoms,
-    pub done_retry: bool,
-    pub send_ticket: bool,
-    pub extra_exts: Vec<ServerExtension>,
-}
+pub(super) use client_hello::CompleteClientHelloHandling;
 
-impl CompleteClientHelloHandling {
-    fn check_binder(
-        &self,
-        suite: &'static SupportedCipherSuite,
-        client_hello: &Message,
-        psk: &[u8],
-        binder: &[u8],
-    ) -> bool {
-        let binder_plaintext = match client_hello.payload {
-            MessagePayload::Handshake(ref hmp) => hmp.get_encoding_for_binder_signing(),
-            _ => unreachable!(),
-        };
+mod client_hello {
+    use crate::key_schedule::{KeyScheduleEarly, KeyScheduleHandshake, KeyScheduleNonSecret};
+    use crate::kx;
+    use crate::msgs::base::{Payload, PayloadU8};
+    use crate::msgs::ccs::ChangeCipherSpecPayload;
+    use crate::msgs::enums::{Compression, PSKKeyExchangeMode};
+    use crate::msgs::enums::{NamedGroup, SignatureScheme};
+    use crate::msgs::handshake::CertReqExtension;
+    use crate::msgs::handshake::CertificateEntry;
+    use crate::msgs::handshake::CertificateExtension;
+    use crate::msgs::handshake::CertificatePayloadTLS13;
+    use crate::msgs::handshake::CertificateRequestPayloadTLS13;
+    use crate::msgs::handshake::CertificateStatus;
+    use crate::msgs::handshake::ClientHelloPayload;
+    use crate::msgs::handshake::DigitallySignedStruct;
+    use crate::msgs::handshake::HelloRetryExtension;
+    use crate::msgs::handshake::HelloRetryRequest;
+    use crate::msgs::handshake::KeyShareEntry;
+    use crate::msgs::handshake::Random;
+    use crate::msgs::handshake::ServerExtension;
+    use crate::msgs::handshake::ServerHelloPayload;
+    use crate::msgs::handshake::SessionID;
+    #[cfg(feature = "quic")]
+    use crate::quic;
+    use crate::sign;
 
-        let suite_hash = suite.get_hash();
-        let handshake_hash = self
-            .handshake
-            .transcript
-            .get_hash_given(suite_hash, &binder_plaintext);
+    use super::*;
 
-        let key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, &psk);
-        let real_binder =
-            key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
-
-        constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
+    pub(in crate::server) struct CompleteClientHelloHandling {
+        pub(in crate::server) handshake: HandshakeDetails,
+        pub(in crate::server) suite: &'static SupportedCipherSuite,
+        pub(in crate::server) randoms: ConnectionRandoms,
+        pub(in crate::server) done_retry: bool,
+        pub(in crate::server) send_ticket: bool,
+        pub(in crate::server) extra_exts: Vec<ServerExtension>,
     }
 
-    fn attempt_tls13_ticket_decryption(
-        &mut self,
-        conn: &mut ServerConnection,
-        ticket: &[u8],
-    ) -> Option<persist::ServerSessionValue> {
-        if conn.config.ticketer.enabled() {
-            conn.config
-                .ticketer
-                .decrypt(ticket)
-                .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-        } else {
-            conn.config
-                .session_storage
-                .take(ticket)
-                .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-        }
-    }
+    impl CompleteClientHelloHandling {
+        fn check_binder(
+            &self,
+            suite: &'static SupportedCipherSuite,
+            client_hello: &Message,
+            psk: &[u8],
+            binder: &[u8],
+        ) -> bool {
+            let binder_plaintext = match client_hello.payload {
+                MessagePayload::Handshake(ref hmp) => hmp.get_encoding_for_binder_signing(),
+                _ => unreachable!(),
+            };
 
-    pub fn handle_client_hello(
-        mut self,
-        suite: &'static SupportedCipherSuite,
-        conn: &mut ServerConnection,
-        server_key: &sign::CertifiedKey,
-        chm: &Message,
-    ) -> hs::NextStateOrError {
-        let client_hello = require_handshake_msg!(
-            chm,
-            HandshakeType::ClientHello,
-            HandshakePayload::ClientHello
-        )?;
+            let suite_hash = suite.get_hash();
+            let handshake_hash = self
+                .handshake
+                .transcript
+                .get_hash_given(suite_hash, &binder_plaintext);
 
-        if client_hello.compression_methods.len() != 1 {
-            return Err(hs::illegal_param(conn, "client offered wrong compressions"));
+            let key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, &psk);
+            let real_binder =
+                key_schedule.resumption_psk_binder_key_and_sign_verify_data(&handshake_hash);
+
+            constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
         }
 
-        let groups_ext = client_hello
-            .get_namedgroups_extension()
-            .ok_or_else(|| hs::incompatible(conn, "client didn't describe groups"))?;
-
-        let mut sigschemes_ext = client_hello
-            .get_sigalgs_extension()
-            .ok_or_else(|| hs::incompatible(conn, "client didn't describe sigschemes"))?
-            .clone();
-
-        let tls13_schemes = sign::supported_sign_tls13();
-        sigschemes_ext.retain(|scheme| tls13_schemes.contains(scheme));
-
-        let shares_ext = client_hello
-            .get_keyshare_extension()
-            .ok_or_else(|| hs::incompatible(conn, "client didn't send keyshares"))?;
-
-        if client_hello.has_keyshare_extension_with_duplicates() {
-            return Err(hs::illegal_param(conn, "client sent duplicate keyshares"));
+        fn attempt_tls13_ticket_decryption(
+            &mut self,
+            conn: &mut ServerConnection,
+            ticket: &[u8],
+        ) -> Option<persist::ServerSessionValue> {
+            if conn.config.ticketer.enabled() {
+                conn.config
+                    .ticketer
+                    .decrypt(ticket)
+                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+            } else {
+                conn.config
+                    .session_storage
+                    .take(ticket)
+                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
+            }
         }
 
-        // choose a share that we support
-        let chosen_share = conn
-            .config
-            .kx_groups
-            .iter()
-            .find_map(|group| {
-                shares_ext
-                    .iter()
-                    .find(|share| share.group == group.name)
-            });
+        pub(in crate::server) fn handle_client_hello(
+            mut self,
+            suite: &'static SupportedCipherSuite,
+            conn: &mut ServerConnection,
+            server_key: &sign::CertifiedKey,
+            chm: &Message,
+        ) -> hs::NextStateOrError {
+            let client_hello = require_handshake_msg!(
+                chm,
+                HandshakeType::ClientHello,
+                HandshakePayload::ClientHello
+            )?;
 
-        let chosen_share = match chosen_share {
-            Some(s) => s,
-            None => {
-                // We don't have a suitable key share.  Choose a suitable group and
-                // send a HelloRetryRequest.
-                let retry_group_maybe = conn
-                    .config
-                    .kx_groups
-                    .iter()
-                    .find(|group| groups_ext.contains(&group.name))
-                    .cloned();
+            if client_hello.compression_methods.len() != 1 {
+                return Err(hs::illegal_param(conn, "client offered wrong compressions"));
+            }
 
-                self.handshake
-                    .transcript
-                    .add_message(chm);
+            let groups_ext = client_hello
+                .get_namedgroups_extension()
+                .ok_or_else(|| hs::incompatible(conn, "client didn't describe groups"))?;
 
-                if let Some(group) = retry_group_maybe {
-                    if self.done_retry {
-                        return Err(hs::illegal_param(conn, "did not follow retry request"));
+            let mut sigschemes_ext = client_hello
+                .get_sigalgs_extension()
+                .ok_or_else(|| hs::incompatible(conn, "client didn't describe sigschemes"))?
+                .clone();
+
+            let tls13_schemes = sign::supported_sign_tls13();
+            sigschemes_ext.retain(|scheme| tls13_schemes.contains(scheme));
+
+            let shares_ext = client_hello
+                .get_keyshare_extension()
+                .ok_or_else(|| hs::incompatible(conn, "client didn't send keyshares"))?;
+
+            if client_hello.has_keyshare_extension_with_duplicates() {
+                return Err(hs::illegal_param(conn, "client sent duplicate keyshares"));
+            }
+
+            // choose a share that we support
+            let chosen_share = conn
+                .config
+                .kx_groups
+                .iter()
+                .find_map(|group| {
+                    shares_ext
+                        .iter()
+                        .find(|share| share.group == group.name)
+                });
+
+            let chosen_share = match chosen_share {
+                Some(s) => s,
+                None => {
+                    // We don't have a suitable key share.  Choose a suitable group and
+                    // send a HelloRetryRequest.
+                    let retry_group_maybe = conn
+                        .config
+                        .kx_groups
+                        .iter()
+                        .find(|group| groups_ext.contains(&group.name))
+                        .cloned();
+
+                    self.handshake
+                        .transcript
+                        .add_message(chm);
+
+                    if let Some(group) = retry_group_maybe {
+                        if self.done_retry {
+                            return Err(hs::illegal_param(conn, "did not follow retry request"));
+                        }
+
+                        emit_hello_retry_request(&mut self.handshake, suite, conn, group.name);
+                        emit_fake_ccs(conn);
+                        return Ok(Box::new(hs::ExpectClientHello {
+                            handshake: self.handshake,
+                            using_ems: false,
+                            done_retry: true,
+                            send_ticket: self.send_ticket,
+                            extra_exts: self.extra_exts,
+                        }));
                     }
 
-                    emit_hello_retry_request(&mut self.handshake, suite, conn, group.name);
-                    emit_fake_ccs(conn);
-                    return Ok(Box::new(hs::ExpectClientHello {
-                        handshake: self.handshake,
-                        using_ems: false,
-                        done_retry: true,
-                        send_ticket: self.send_ticket,
-                        extra_exts: self.extra_exts,
-                    }));
+                    return Err(hs::incompatible(conn, "no kx group overlap with client"));
+                }
+            };
+
+            let mut chosen_psk_index = None;
+            let mut resumedata = None;
+            if let Some(psk_offer) = client_hello.get_psk() {
+                if !client_hello.check_psk_ext_is_last() {
+                    return Err(hs::illegal_param(conn, "psk extension in wrong position"));
                 }
 
-                return Err(hs::incompatible(conn, "no kx group overlap with client"));
-            }
-        };
+                if psk_offer.binders.is_empty() {
+                    return Err(hs::decode_error(conn, "psk extension missing binder"));
+                }
 
-        let mut chosen_psk_index = None;
-        let mut resumedata = None;
-        if let Some(psk_offer) = client_hello.get_psk() {
-            if !client_hello.check_psk_ext_is_last() {
-                return Err(hs::illegal_param(conn, "psk extension in wrong position"));
-            }
-
-            if psk_offer.binders.is_empty() {
-                return Err(hs::decode_error(conn, "psk extension missing binder"));
-            }
-
-            if psk_offer.binders.len() != psk_offer.identities.len() {
-                return Err(hs::illegal_param(
-                    conn,
-                    "psk extension mismatched ids/binders",
-                ));
-            }
-
-            for (i, psk_id) in psk_offer.identities.iter().enumerate() {
-                let resume = match self
-                    .attempt_tls13_ticket_decryption(conn, &psk_id.identity.0)
-                    .and_then(|resumedata| hs::can_resume(self.suite, &conn.sni, false, resumedata))
-                {
-                    Some(resume) => resume,
-                    None => continue,
-                };
-
-                if !self.check_binder(suite, chm, &resume.master_secret.0, &psk_offer.binders[i].0)
-                {
-                    conn.common
-                        .send_fatal_alert(AlertDescription::DecryptError);
-                    return Err(Error::PeerMisbehavedError(
-                        "client sent wrong binder".to_string(),
+                if psk_offer.binders.len() != psk_offer.identities.len() {
+                    return Err(hs::illegal_param(
+                        conn,
+                        "psk extension mismatched ids/binders",
                     ));
                 }
 
-                chosen_psk_index = Some(i);
-                resumedata = Some(resume);
-                break;
+                for (i, psk_id) in psk_offer.identities.iter().enumerate() {
+                    let resume = match self
+                        .attempt_tls13_ticket_decryption(conn, &psk_id.identity.0)
+                        .and_then(|resumedata| {
+                            hs::can_resume(self.suite, &conn.sni, false, resumedata)
+                        }) {
+                        Some(resume) => resume,
+                        None => continue,
+                    };
+
+                    if !self.check_binder(
+                        suite,
+                        chm,
+                        &resume.master_secret.0,
+                        &psk_offer.binders[i].0,
+                    ) {
+                        conn.common
+                            .send_fatal_alert(AlertDescription::DecryptError);
+                        return Err(Error::PeerMisbehavedError(
+                            "client sent wrong binder".to_string(),
+                        ));
+                    }
+
+                    chosen_psk_index = Some(i);
+                    resumedata = Some(resume);
+                    break;
+                }
+            }
+
+            if !client_hello.psk_mode_offered(PSKKeyExchangeMode::PSK_DHE_KE) {
+                debug!("Client unwilling to resume, DHE_KE not offered");
+                self.send_ticket = false;
+                chosen_psk_index = None;
+                resumedata = None;
+            } else {
+                self.send_ticket = true;
+            }
+
+            if let Some(ref resume) = resumedata {
+                conn.received_resumption_data = Some(resume.application_data.0.clone());
+                conn.client_cert_chain = resume.client_cert_chain.clone();
+            }
+
+            let full_handshake = resumedata.is_none();
+            self.handshake
+                .transcript
+                .add_message(chm);
+            let key_schedule = emit_server_hello(
+                &mut self.handshake,
+                &self.randoms,
+                suite,
+                conn,
+                &client_hello.session_id,
+                chosen_share,
+                chosen_psk_index,
+                resumedata
+                    .as_ref()
+                    .map(|x| &x.master_secret.0[..]),
+            )?;
+            if !self.done_retry {
+                emit_fake_ccs(conn);
+            }
+
+            let (mut ocsp_response, mut sct_list) =
+                (server_key.ocsp.as_deref(), server_key.sct_list.as_deref());
+            emit_encrypted_extensions(
+                &mut self.handshake,
+                suite,
+                conn,
+                &mut ocsp_response,
+                &mut sct_list,
+                client_hello,
+                resumedata.as_ref(),
+                self.extra_exts,
+            )?;
+
+            let doing_client_auth = if full_handshake {
+                let client_auth = emit_certificate_req_tls13(&mut self.handshake, conn)?;
+                emit_certificate_tls13(
+                    &mut self.handshake,
+                    conn,
+                    &server_key.cert,
+                    ocsp_response,
+                    sct_list,
+                );
+                emit_certificate_verify_tls13(
+                    &mut self.handshake,
+                    conn,
+                    &*server_key.key,
+                    &sigschemes_ext,
+                )?;
+                client_auth
+            } else {
+                false
+            };
+
+            hs::check_aligned_handshake(conn)?;
+            let (key_schedule_traffic, hash_at_server_fin) = emit_finished_tls13(
+                &mut self.handshake,
+                self.suite,
+                &self.randoms,
+                conn,
+                key_schedule,
+            );
+
+            if doing_client_auth {
+                Ok(Box::new(ExpectCertificate {
+                    handshake: self.handshake,
+                    suite: self.suite,
+                    randoms: self.randoms,
+                    key_schedule: key_schedule_traffic,
+                    send_ticket: self.send_ticket,
+                    hash_at_server_fin,
+                }))
+            } else {
+                Ok(Box::new(ExpectFinished {
+                    handshake: self.handshake,
+                    suite: self.suite,
+                    randoms: self.randoms,
+                    key_schedule: key_schedule_traffic,
+                    send_ticket: self.send_ticket,
+                    hash_at_server_fin,
+                }))
             }
         }
+    }
 
-        if !client_hello.psk_mode_offered(PSKKeyExchangeMode::PSK_DHE_KE) {
-            debug!("Client unwilling to resume, DHE_KE not offered");
-            self.send_ticket = false;
-            chosen_psk_index = None;
-            resumedata = None;
-        } else {
-            self.send_ticket = true;
+    fn emit_server_hello(
+        handshake: &mut HandshakeDetails,
+        randoms: &ConnectionRandoms,
+        suite: &'static SupportedCipherSuite,
+        conn: &mut ServerConnection,
+        session_id: &SessionID,
+        share: &KeyShareEntry,
+        chosen_psk_idx: Option<usize>,
+        resuming_psk: Option<&[u8]>,
+    ) -> Result<KeyScheduleHandshake, Error> {
+        let mut extensions = Vec::new();
+
+        // Do key exchange
+        let kxr = kx::KeyExchange::choose(share.group, &conn.config.kx_groups)
+            .and_then(kx::KeyExchange::start)
+            .and_then(|kx| kx.complete(&share.payload.0))
+            .ok_or_else(|| Error::PeerMisbehavedError("key exchange failed".to_string()))?;
+
+        let kse = KeyShareEntry::new(share.group, kxr.pubkey.as_ref());
+        extensions.push(ServerExtension::KeyShare(kse));
+        extensions.push(ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_3));
+
+        if let Some(psk_idx) = chosen_psk_idx {
+            extensions.push(ServerExtension::PresharedKey(psk_idx as u16));
         }
 
-        if let Some(ref resume) = resumedata {
-            conn.received_resumption_data = Some(resume.application_data.0.clone());
-            conn.client_cert_chain = resume.client_cert_chain.clone();
-        }
-
-        let full_handshake = resumedata.is_none();
-        self.handshake
-            .transcript
-            .add_message(chm);
-        let key_schedule = emit_server_hello(
-            &mut self.handshake,
-            &self.randoms,
-            suite,
-            conn,
-            &client_hello.session_id,
-            chosen_share,
-            chosen_psk_index,
-            resumedata
-                .as_ref()
-                .map(|x| &x.master_secret.0[..]),
-        )?;
-        if !self.done_retry {
-            emit_fake_ccs(conn);
-        }
-
-        let (mut ocsp_response, mut sct_list) =
-            (server_key.ocsp.as_deref(), server_key.sct_list.as_deref());
-        emit_encrypted_extensions(
-            &mut self.handshake,
-            suite,
-            conn,
-            &mut ocsp_response,
-            &mut sct_list,
-            client_hello,
-            resumedata.as_ref(),
-            self.extra_exts,
-        )?;
-
-        let doing_client_auth = if full_handshake {
-            let client_auth = emit_certificate_req_tls13(&mut self.handshake, conn)?;
-            emit_certificate_tls13(
-                &mut self.handshake,
-                conn,
-                &server_key.cert,
-                ocsp_response,
-                sct_list,
-            );
-            emit_certificate_verify_tls13(
-                &mut self.handshake,
-                conn,
-                &*server_key.key,
-                &sigschemes_ext,
-            )?;
-            client_auth
-        } else {
-            false
+        let sh = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::ServerHello,
+                payload: HandshakePayload::ServerHello(ServerHelloPayload {
+                    legacy_version: ProtocolVersion::TLSv1_2,
+                    random: Random::from_slice(&randoms.server),
+                    session_id: *session_id,
+                    cipher_suite: suite.suite,
+                    compression_method: Compression::Null,
+                    extensions,
+                }),
+            }),
         };
 
         hs::check_aligned_handshake(conn)?;
-        let (key_schedule_traffic, hash_at_server_fin) = emit_finished_tls13(
-            &mut self.handshake,
-            self.suite,
-            &self.randoms,
-            conn,
-            key_schedule,
-        );
 
-        if doing_client_auth {
-            Ok(Box::new(ExpectCertificate {
-                handshake: self.handshake,
-                suite: self.suite,
-                randoms: self.randoms,
-                key_schedule: key_schedule_traffic,
-                send_ticket: self.send_ticket,
-                hash_at_server_fin,
-            }))
+        #[cfg(feature = "quic")]
+        let client_hello_hash = handshake
+            .transcript
+            .get_hash_given(suite.get_hash(), &[]);
+
+        trace!("sending server hello {:?}", sh);
+        handshake.transcript.add_message(&sh);
+        conn.common.send_msg(sh, false);
+
+        // Start key schedule
+        let mut key_schedule = if let Some(psk) = resuming_psk {
+            let early_key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, psk);
+
+            #[cfg(feature = "quic")]
+            {
+                if conn.common.protocol == Protocol::Quic {
+                    let client_early_traffic_secret = early_key_schedule
+                        .client_early_traffic_secret(
+                            &client_hello_hash,
+                            &*conn.config.key_log,
+                            &randoms.client,
+                        );
+                    // If 0-RTT should be rejected, this will be clobbered by ExtensionProcessing
+                    // before the application can see.
+                    conn.common.quic.early_secret = Some(client_early_traffic_secret);
+                }
+            }
+
+            early_key_schedule.into_handshake(&kxr.shared_secret)
         } else {
-            Ok(Box::new(ExpectFinished {
-                handshake: self.handshake,
-                suite: self.suite,
-                randoms: self.randoms,
-                key_schedule: key_schedule_traffic,
-                send_ticket: self.send_ticket,
-                hash_at_server_fin,
-            }))
-        }
-    }
-}
+            KeyScheduleNonSecret::new(suite.hkdf_algorithm).into_handshake(&kxr.shared_secret)
+        };
 
-fn emit_server_hello(
-    handshake: &mut HandshakeDetails,
-    randoms: &ConnectionRandoms,
-    suite: &'static SupportedCipherSuite,
-    sess: &mut ServerConnection,
-    session_id: &SessionID,
-    share: &KeyShareEntry,
-    chosen_psk_idx: Option<usize>,
-    resuming_psk: Option<&[u8]>,
-) -> Result<KeyScheduleHandshake, Error> {
-    let mut extensions = Vec::new();
+        let handshake_hash = handshake.transcript.get_current_hash();
+        let write_key = key_schedule.server_handshake_traffic_secret(
+            &handshake_hash,
+            &*conn.config.key_log,
+            &randoms.client,
+        );
+        conn.common
+            .record_layer
+            .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
 
-    // Do key exchange
-    let kxr = kx::KeyExchange::choose(share.group, &sess.config.kx_groups)
-        .and_then(kx::KeyExchange::start)
-        .and_then(|kx| kx.complete(&share.payload.0))
-        .ok_or_else(|| Error::PeerMisbehavedError("key exchange failed".to_string()))?;
-
-    let kse = KeyShareEntry::new(share.group, kxr.pubkey.as_ref());
-    extensions.push(ServerExtension::KeyShare(kse));
-    extensions.push(ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_3));
-
-    if let Some(psk_idx) = chosen_psk_idx {
-        extensions.push(ServerExtension::PresharedKey(psk_idx as u16));
-    }
-
-    let sh = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::ServerHello,
-            payload: HandshakePayload::ServerHello(ServerHelloPayload {
-                legacy_version: ProtocolVersion::TLSv1_2,
-                random: Random::from_slice(&randoms.server),
-                session_id: *session_id,
-                cipher_suite: suite.suite,
-                compression_method: Compression::Null,
-                extensions,
-            }),
-        }),
-    };
-
-    hs::check_aligned_handshake(sess)?;
-
-    #[cfg(feature = "quic")]
-    let client_hello_hash = handshake
-        .transcript
-        .get_hash_given(suite.get_hash(), &[]);
-
-    trace!("sending server hello {:?}", sh);
-    handshake.transcript.add_message(&sh);
-    sess.common.send_msg(sh, false);
-
-    // Start key schedule
-    let mut key_schedule = if let Some(psk) = resuming_psk {
-        let early_key_schedule = KeyScheduleEarly::new(suite.hkdf_algorithm, psk);
+        let read_key = key_schedule.client_handshake_traffic_secret(
+            &handshake_hash,
+            &*conn.config.key_log,
+            &randoms.client,
+        );
+        conn.common
+            .record_layer
+            .set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
 
         #[cfg(feature = "quic")]
         {
-            if sess.common.protocol == Protocol::Quic {
-                let client_early_traffic_secret = early_key_schedule.client_early_traffic_secret(
-                    &client_hello_hash,
-                    &*sess.config.key_log,
-                    &randoms.client,
-                );
-                // If 0-RTT should be rejected, this will be clobbered by ExtensionProcessing
-                // before the application can see.
-                sess.common.quic.early_secret = Some(client_early_traffic_secret);
+            conn.common.quic.hs_secrets = Some(quic::Secrets {
+                client: read_key,
+                server: write_key,
+            });
+        }
+
+        Ok(key_schedule)
+    }
+
+    fn emit_fake_ccs(conn: &mut ServerConnection) {
+        if conn.common.is_quic() {
+            return;
+        }
+        let m = Message {
+            typ: ContentType::ChangeCipherSpec,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
+        };
+        conn.common.send_msg(m, false);
+    }
+
+    fn emit_hello_retry_request(
+        handshake: &mut HandshakeDetails,
+        suite: &'static SupportedCipherSuite,
+        conn: &mut ServerConnection,
+        group: NamedGroup,
+    ) {
+        let mut req = HelloRetryRequest {
+            legacy_version: ProtocolVersion::TLSv1_2,
+            session_id: SessionID::empty(),
+            cipher_suite: suite.suite,
+            extensions: Vec::new(),
+        };
+
+        req.extensions
+            .push(HelloRetryExtension::KeyShare(group));
+        req.extensions
+            .push(HelloRetryExtension::SupportedVersions(
+                ProtocolVersion::TLSv1_3,
+            ));
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_2,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::HelloRetryRequest,
+                payload: HandshakePayload::HelloRetryRequest(req),
+            }),
+        };
+
+        trace!("Requesting retry {:?}", m);
+        handshake.transcript.rollup_for_hrr();
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, false);
+    }
+
+    fn emit_encrypted_extensions(
+        handshake: &mut HandshakeDetails,
+        suite: &'static SupportedCipherSuite,
+        conn: &mut ServerConnection,
+        ocsp_response: &mut Option<&[u8]>,
+        sct_list: &mut Option<&[u8]>,
+        hello: &ClientHelloPayload,
+        resumedata: Option<&persist::ServerSessionValue>,
+        extra_exts: Vec<ServerExtension>,
+    ) -> Result<(), Error> {
+        let mut ep = hs::ExtensionProcessing::new();
+        ep.process_common(
+            conn,
+            suite,
+            ocsp_response,
+            sct_list,
+            hello,
+            resumedata,
+            extra_exts,
+        )?;
+
+        let ee = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::EncryptedExtensions,
+                payload: HandshakePayload::EncryptedExtensions(ep.exts),
+            }),
+        };
+
+        trace!("sending encrypted extensions {:?}", ee);
+        handshake.transcript.add_message(&ee);
+        conn.common.send_msg(ee, true);
+        Ok(())
+    }
+
+    fn emit_certificate_req_tls13(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+    ) -> Result<bool, Error> {
+        if !conn.config.verifier.offer_client_auth() {
+            return Ok(false);
+        }
+
+        let mut cr = CertificateRequestPayloadTLS13 {
+            context: PayloadU8::empty(),
+            extensions: Vec::new(),
+        };
+
+        let schemes = conn
+            .config
+            .get_verifier()
+            .supported_verify_schemes();
+        cr.extensions
+            .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
+
+        let names = conn
+            .config
+            .verifier
+            .client_auth_root_subjects(conn.get_sni())
+            .ok_or_else(|| {
+                debug!("could not determine root subjects based on SNI");
+                conn.common
+                    .send_fatal_alert(AlertDescription::AccessDenied);
+                Error::General("client rejected by client_auth_root_subjects".into())
+            })?;
+
+        if !names.is_empty() {
+            cr.extensions
+                .push(CertReqExtension::AuthorityNames(names));
+        }
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::CertificateRequest,
+                payload: HandshakePayload::CertificateRequestTLS13(cr),
+            }),
+        };
+
+        trace!("Sending CertificateRequest {:?}", m);
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, true);
+        Ok(true)
+    }
+
+    fn emit_certificate_tls13(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        cert_chain: &[Certificate],
+        ocsp_response: Option<&[u8]>,
+        sct_list: Option<&[u8]>,
+    ) {
+        let mut cert_entries = vec![];
+        for cert in cert_chain {
+            let entry = CertificateEntry {
+                cert: cert.to_owned(),
+                exts: Vec::new(),
+            };
+
+            cert_entries.push(entry);
+        }
+
+        if let Some(end_entity_cert) = cert_entries.first_mut() {
+            // Apply OCSP response to first certificate (we don't support OCSP
+            // except for leaf certs).
+            if let Some(ocsp) = ocsp_response {
+                let cst = CertificateStatus::new(ocsp.to_owned());
+                end_entity_cert
+                    .exts
+                    .push(CertificateExtension::CertificateStatus(cst));
+            }
+
+            // Likewise, SCT
+            if let Some(sct_list) = sct_list {
+                end_entity_cert
+                    .exts
+                    .push(CertificateExtension::make_sct(sct_list.to_owned()));
             }
         }
 
-        early_key_schedule.into_handshake(&kxr.shared_secret)
-    } else {
-        KeyScheduleNonSecret::new(suite.hkdf_algorithm).into_handshake(&kxr.shared_secret)
-    };
-
-    let handshake_hash = handshake.transcript.get_current_hash();
-    let write_key = key_schedule.server_handshake_traffic_secret(
-        &handshake_hash,
-        &*sess.config.key_log,
-        &randoms.client,
-    );
-    sess.common
-        .record_layer
-        .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
-
-    let read_key = key_schedule.client_handshake_traffic_secret(
-        &handshake_hash,
-        &*sess.config.key_log,
-        &randoms.client,
-    );
-    sess.common
-        .record_layer
-        .set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
-
-    #[cfg(feature = "quic")]
-    {
-        sess.common.quic.hs_secrets = Some(quic::Secrets {
-            client: read_key,
-            server: write_key,
-        });
-    }
-
-    Ok(key_schedule)
-}
-
-fn emit_fake_ccs(conn: &mut ServerConnection) {
-    if conn.common.is_quic() {
-        return;
-    }
-    let m = Message {
-        typ: ContentType::ChangeCipherSpec,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
-    };
-    conn.common.send_msg(m, false);
-}
-
-fn emit_hello_retry_request(
-    handshake: &mut HandshakeDetails,
-    suite: &'static SupportedCipherSuite,
-    conn: &mut ServerConnection,
-    group: NamedGroup,
-) {
-    let mut req = HelloRetryRequest {
-        legacy_version: ProtocolVersion::TLSv1_2,
-        session_id: SessionID::empty(),
-        cipher_suite: suite.suite,
-        extensions: Vec::new(),
-    };
-
-    req.extensions
-        .push(HelloRetryExtension::KeyShare(group));
-    req.extensions
-        .push(HelloRetryExtension::SupportedVersions(
-            ProtocolVersion::TLSv1_3,
-        ));
-
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_2,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::HelloRetryRequest,
-            payload: HandshakePayload::HelloRetryRequest(req),
-        }),
-    };
-
-    trace!("Requesting retry {:?}", m);
-    handshake.transcript.rollup_for_hrr();
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, false);
-}
-
-fn emit_encrypted_extensions(
-    handshake: &mut HandshakeDetails,
-    suite: &'static SupportedCipherSuite,
-    sess: &mut ServerConnection,
-    ocsp_response: &mut Option<&[u8]>,
-    sct_list: &mut Option<&[u8]>,
-    hello: &ClientHelloPayload,
-    resumedata: Option<&persist::ServerSessionValue>,
-    extra_exts: Vec<ServerExtension>,
-) -> Result<(), Error> {
-    let mut ep = hs::ExtensionProcessing::new();
-    ep.process_common(
-        sess,
-        suite,
-        ocsp_response,
-        sct_list,
-        hello,
-        resumedata,
-        extra_exts,
-    )?;
-
-    let ee = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::EncryptedExtensions,
-            payload: HandshakePayload::EncryptedExtensions(ep.exts),
-        }),
-    };
-
-    trace!("sending encrypted extensions {:?}", ee);
-    handshake.transcript.add_message(&ee);
-    sess.common.send_msg(ee, true);
-    Ok(())
-}
-
-fn emit_certificate_req_tls13(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-) -> Result<bool, Error> {
-    if !conn.config.verifier.offer_client_auth() {
-        return Ok(false);
-    }
-
-    let mut cr = CertificateRequestPayloadTLS13 {
-        context: PayloadU8::empty(),
-        extensions: Vec::new(),
-    };
-
-    let schemes = conn
-        .config
-        .get_verifier()
-        .supported_verify_schemes();
-    cr.extensions
-        .push(CertReqExtension::SignatureAlgorithms(schemes.to_vec()));
-
-    let names = conn
-        .config
-        .verifier
-        .client_auth_root_subjects(conn.get_sni())
-        .ok_or_else(|| {
-            debug!("could not determine root subjects based on SNI");
-            conn.common
-                .send_fatal_alert(AlertDescription::AccessDenied);
-            Error::General("client rejected by client_auth_root_subjects".into())
-        })?;
-
-    if !names.is_empty() {
-        cr.extensions
-            .push(CertReqExtension::AuthorityNames(names));
-    }
-
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateRequest,
-            payload: HandshakePayload::CertificateRequestTLS13(cr),
-        }),
-    };
-
-    trace!("Sending CertificateRequest {:?}", m);
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, true);
-    Ok(true)
-}
-
-fn emit_certificate_tls13(
-    handshake: &mut HandshakeDetails,
-    sess: &mut ServerConnection,
-    cert_chain: &[Certificate],
-    ocsp_response: Option<&[u8]>,
-    sct_list: Option<&[u8]>,
-) {
-    let mut cert_entries = vec![];
-    for cert in cert_chain {
-        let entry = CertificateEntry {
-            cert: cert.to_owned(),
-            exts: Vec::new(),
+        let cert_body = CertificatePayloadTLS13::new(cert_entries);
+        let c = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::Certificate,
+                payload: HandshakePayload::CertificateTLS13(cert_body),
+            }),
         };
 
-        cert_entries.push(entry);
+        trace!("sending certificate {:?}", c);
+        handshake.transcript.add_message(&c);
+        conn.common.send_msg(c, true);
     }
 
-    if let Some(end_entity_cert) = cert_entries.first_mut() {
-        // Apply OCSP response to first certificate (we don't support OCSP
-        // except for leaf certs).
-        if let Some(ocsp) = ocsp_response {
-            let cst = CertificateStatus::new(ocsp.to_owned());
-            end_entity_cert
-                .exts
-                .push(CertificateExtension::CertificateStatus(cst));
+    fn emit_certificate_verify_tls13(
+        handshake: &mut HandshakeDetails,
+        conn: &mut ServerConnection,
+        signing_key: &dyn sign::SigningKey,
+        schemes: &[SignatureScheme],
+    ) -> Result<(), Error> {
+        let message =
+            verify::construct_tls13_server_verify_message(&handshake.transcript.get_current_hash());
+
+        let signer = signing_key
+            .choose_scheme(schemes)
+            .ok_or_else(|| hs::incompatible(conn, "no overlapping sigschemes"))?;
+
+        let scheme = signer.get_scheme();
+        let sig = signer.sign(&message)?;
+
+        let cv = DigitallySignedStruct::new(scheme, sig);
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::CertificateVerify,
+                payload: HandshakePayload::CertificateVerify(cv),
+            }),
+        };
+
+        trace!("sending certificate-verify {:?}", m);
+        handshake.transcript.add_message(&m);
+        conn.common.send_msg(m, true);
+        Ok(())
+    }
+
+    fn emit_finished_tls13(
+        handshake: &mut HandshakeDetails,
+        suite: &'static SupportedCipherSuite,
+        randoms: &ConnectionRandoms,
+        conn: &mut ServerConnection,
+        key_schedule: KeyScheduleHandshake,
+    ) -> (KeyScheduleTrafficWithClientFinishedPending, Digest) {
+        let handshake_hash = handshake.transcript.get_current_hash();
+        let verify_data = key_schedule.sign_server_finish(&handshake_hash);
+        let verify_data_payload = Payload::new(verify_data.as_ref());
+
+        let m = Message {
+            typ: ContentType::Handshake,
+            version: ProtocolVersion::TLSv1_3,
+            payload: MessagePayload::Handshake(HandshakeMessagePayload {
+                typ: HandshakeType::Finished,
+                payload: HandshakePayload::Finished(verify_data_payload),
+            }),
+        };
+
+        trace!("sending finished {:?}", m);
+        handshake.transcript.add_message(&m);
+        let hash_at_server_fin = handshake.transcript.get_current_hash();
+        conn.common.send_msg(m, true);
+
+        // Now move to application data keys.  Read key change is deferred until
+        // the Finish message is received & validated.
+        let mut key_schedule_traffic = key_schedule.into_traffic_with_client_finished_pending();
+        let write_key = key_schedule_traffic.server_application_traffic_secret(
+            &hash_at_server_fin,
+            &*conn.config.key_log,
+            &randoms.client,
+        );
+        conn.common
+            .record_layer
+            .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
+
+        key_schedule_traffic.exporter_master_secret(
+            &hash_at_server_fin,
+            &*conn.config.key_log,
+            &randoms.client,
+        );
+
+        let _read_key = key_schedule_traffic.client_application_traffic_secret(
+            &hash_at_server_fin,
+            &*conn.config.key_log,
+            &randoms.client,
+        );
+
+        #[cfg(feature = "quic")]
+        {
+            conn.common.quic.traffic_secrets = Some(quic::Secrets {
+                client: _read_key,
+                server: write_key,
+            });
         }
 
-        // Likewise, SCT
-        if let Some(sct_list) = sct_list {
-            end_entity_cert
-                .exts
-                .push(CertificateExtension::make_sct(sct_list.to_owned()));
-        }
+        (key_schedule_traffic, hash_at_server_fin)
     }
-
-    let cert_body = CertificatePayloadTLS13::new(cert_entries);
-    let c = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Certificate,
-            payload: HandshakePayload::CertificateTLS13(cert_body),
-        }),
-    };
-
-    trace!("sending certificate {:?}", c);
-    handshake.transcript.add_message(&c);
-    sess.common.send_msg(c, true);
-}
-
-fn emit_certificate_verify_tls13(
-    handshake: &mut HandshakeDetails,
-    conn: &mut ServerConnection,
-    signing_key: &dyn sign::SigningKey,
-    schemes: &[SignatureScheme],
-) -> Result<(), Error> {
-    let message =
-        verify::construct_tls13_server_verify_message(&handshake.transcript.get_current_hash());
-
-    let signer = signing_key
-        .choose_scheme(schemes)
-        .ok_or_else(|| hs::incompatible(conn, "no overlapping sigschemes"))?;
-
-    let scheme = signer.get_scheme();
-    let sig = signer.sign(&message)?;
-
-    let cv = DigitallySignedStruct::new(scheme, sig);
-
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::CertificateVerify,
-            payload: HandshakePayload::CertificateVerify(cv),
-        }),
-    };
-
-    trace!("sending certificate-verify {:?}", m);
-    handshake.transcript.add_message(&m);
-    conn.common.send_msg(m, true);
-    Ok(())
-}
-
-fn emit_finished_tls13(
-    handshake: &mut HandshakeDetails,
-    suite: &'static SupportedCipherSuite,
-    randoms: &ConnectionRandoms,
-    sess: &mut ServerConnection,
-    key_schedule: KeyScheduleHandshake,
-) -> (KeyScheduleTrafficWithClientFinishedPending, Digest) {
-    let handshake_hash = handshake.transcript.get_current_hash();
-    let verify_data = key_schedule.sign_server_finish(&handshake_hash);
-    let verify_data_payload = Payload::new(verify_data.as_ref());
-
-    let m = Message {
-        typ: ContentType::Handshake,
-        version: ProtocolVersion::TLSv1_3,
-        payload: MessagePayload::Handshake(HandshakeMessagePayload {
-            typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(verify_data_payload),
-        }),
-    };
-
-    trace!("sending finished {:?}", m);
-    handshake.transcript.add_message(&m);
-    let hash_at_server_fin = handshake.transcript.get_current_hash();
-    sess.common.send_msg(m, true);
-
-    // Now move to application data keys.  Read key change is deferred until
-    // the Finish message is received & validated.
-    let mut key_schedule_traffic = key_schedule.into_traffic_with_client_finished_pending();
-    let write_key = key_schedule_traffic.server_application_traffic_secret(
-        &hash_at_server_fin,
-        &*sess.config.key_log,
-        &randoms.client,
-    );
-    sess.common
-        .record_layer
-        .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
-
-    key_schedule_traffic.exporter_master_secret(
-        &hash_at_server_fin,
-        &*sess.config.key_log,
-        &randoms.client,
-    );
-
-    let _read_key = key_schedule_traffic.client_application_traffic_secret(
-        &hash_at_server_fin,
-        &*sess.config.key_log,
-        &randoms.client,
-    );
-
-    #[cfg(feature = "quic")]
-    {
-        sess.common.quic.traffic_secrets = Some(quic::Secrets {
-            client: _read_key,
-            server: write_key,
-        });
-    }
-
-    (key_schedule_traffic, hash_at_server_fin)
 }
 
 pub struct ExpectCertificate {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -845,7 +845,7 @@ impl hs::State for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        conn.client_cert_chain = Some(self.client_cert.take_chain());
+        conn.client_cert_chain = Some(self.client_cert.cert_chain);
 
         self.handshake
             .transcript

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -83,58 +83,6 @@ impl CompleteClientHelloHandling {
         constant_time::verify_slices_are_equal(real_binder.as_ref(), binder).is_ok()
     }
 
-    fn emit_certificate_tls13(
-        &mut self,
-        conn: &mut ServerConnection,
-        cert_chain: &[Certificate],
-        ocsp_response: Option<&[u8]>,
-        sct_list: Option<&[u8]>,
-    ) {
-        let mut cert_entries = vec![];
-        for cert in cert_chain {
-            let entry = CertificateEntry {
-                cert: cert.to_owned(),
-                exts: Vec::new(),
-            };
-
-            cert_entries.push(entry);
-        }
-
-        if let Some(end_entity_cert) = cert_entries.first_mut() {
-            // Apply OCSP response to first certificate (we don't support OCSP
-            // except for leaf certs).
-            if let Some(ocsp) = ocsp_response {
-                let cst = CertificateStatus::new(ocsp.to_owned());
-                end_entity_cert
-                    .exts
-                    .push(CertificateExtension::CertificateStatus(cst));
-            }
-
-            // Likewise, SCT
-            if let Some(sct_list) = sct_list {
-                end_entity_cert
-                    .exts
-                    .push(CertificateExtension::make_sct(sct_list.to_owned()));
-            }
-        }
-
-        let cert_body = CertificatePayloadTLS13::new(cert_entries);
-        let c = Message {
-            typ: ContentType::Handshake,
-            version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::Handshake(HandshakeMessagePayload {
-                typ: HandshakeType::Certificate,
-                payload: HandshakePayload::CertificateTLS13(cert_body),
-            }),
-        };
-
-        trace!("sending certificate {:?}", c);
-        self.handshake
-            .transcript
-            .add_message(&c);
-        conn.common.send_msg(c, true);
-    }
-
     fn emit_certificate_verify_tls13(
         &mut self,
         conn: &mut ServerConnection,
@@ -432,7 +380,13 @@ impl CompleteClientHelloHandling {
 
         let doing_client_auth = if full_handshake {
             let client_auth = emit_certificate_req_tls13(&mut self.handshake, conn)?;
-            self.emit_certificate_tls13(conn, &server_key.cert, ocsp_response, sct_list);
+            emit_certificate_tls13(
+                &mut self.handshake,
+                conn,
+                &server_key.cert,
+                ocsp_response,
+                sct_list,
+            );
             self.emit_certificate_verify_tls13(conn, &*server_key.key, &sigschemes_ext)?;
             client_auth
         } else {
@@ -700,6 +654,57 @@ fn emit_certificate_req_tls13(
     conn.common.send_msg(m, true);
     Ok(true)
 }
+
+fn emit_certificate_tls13(
+    handshake: &mut HandshakeDetails,
+    sess: &mut ServerConnection,
+    cert_chain: &[Certificate],
+    ocsp_response: Option<&[u8]>,
+    sct_list: Option<&[u8]>,
+) {
+    let mut cert_entries = vec![];
+    for cert in cert_chain {
+        let entry = CertificateEntry {
+            cert: cert.to_owned(),
+            exts: Vec::new(),
+        };
+
+        cert_entries.push(entry);
+    }
+
+    if let Some(end_entity_cert) = cert_entries.first_mut() {
+        // Apply OCSP response to first certificate (we don't support OCSP
+        // except for leaf certs).
+        if let Some(ocsp) = ocsp_response {
+            let cst = CertificateStatus::new(ocsp.to_owned());
+            end_entity_cert
+                .exts
+                .push(CertificateExtension::CertificateStatus(cst));
+        }
+
+        // Likewise, SCT
+        if let Some(sct_list) = sct_list {
+            end_entity_cert
+                .exts
+                .push(CertificateExtension::make_sct(sct_list.to_owned()));
+        }
+    }
+
+    let cert_body = CertificatePayloadTLS13::new(cert_entries);
+    let c = Message {
+        typ: ContentType::Handshake,
+        version: ProtocolVersion::TLSv1_3,
+        payload: MessagePayload::Handshake(HandshakeMessagePayload {
+            typ: HandshakeType::Certificate,
+            payload: HandshakePayload::CertificateTLS13(cert_body),
+        }),
+    };
+
+    trace!("sending certificate {:?}", c);
+    handshake.transcript.add_message(&c);
+    sess.common.send_msg(c, true);
+}
+
 pub struct ExpectCertificate {
     pub handshake: HandshakeDetails,
     pub suite: &'static SupportedCipherSuite,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -55,6 +55,7 @@ pub struct CompleteClientHelloHandling {
     pub randoms: ConnectionRandoms,
     pub done_retry: bool,
     pub send_ticket: bool,
+    pub extra_exts: Vec<ServerExtension>,
 }
 
 impl CompleteClientHelloHandling {
@@ -177,6 +178,7 @@ impl CompleteClientHelloHandling {
                         using_ems: false,
                         done_retry: true,
                         send_ticket: self.send_ticket,
+                        extra_exts: self.extra_exts,
                     }));
                 }
 
@@ -270,6 +272,7 @@ impl CompleteClientHelloHandling {
             &mut sct_list,
             client_hello,
             resumedata.as_ref(),
+            self.extra_exts,
         )?;
 
         let doing_client_auth = if full_handshake {
@@ -482,6 +485,7 @@ fn emit_encrypted_extensions(
     sct_list: &mut Option<&[u8]>,
     hello: &ClientHelloPayload,
     resumedata: Option<&persist::ServerSessionValue>,
+    extra_exts: Vec<ServerExtension>,
 ) -> Result<(), Error> {
     let mut ep = hs::ExtensionProcessing::new();
     ep.process_common(
@@ -491,7 +495,7 @@ fn emit_encrypted_extensions(
         sct_list,
         hello,
         resumedata,
-        &handshake,
+        extra_exts,
     )?;
 
     let ee = Message {


### PR DESCRIPTION
Detach all methods that take a state (to prevent issues with partial moves) and move most data from `HandshakeDetails`, `ServerKXDetails` and `ClientCertDetails` into the relevant handshake states. TLS 1.2-specific methods are moved from `server::hs` to `server::tls12`. Remove one unnecessary case of unwrapping and prevent cloning of extra (QUIC) extensions.