### PR TITLE
Add is_close_notify helper.

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -288,7 +288,7 @@ pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache}
 pub use crate::server::StoresServerSessions;
 pub use crate::server::{ClientHello, ProducesTickets, ResolvesServerCert};
 pub use crate::server::{ServerConfig, ServerSession};
-pub use crate::session::Session;
+pub use crate::session::{is_close_notify, Session};
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES, DEFAULT_CIPHERSUITES,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -319,9 +319,10 @@ fn check_read_and_close(reader: &mut dyn io::Read, expect: &[u8]) {
     assert_eq!(expect.len(), reader.read(&mut buf).unwrap());
     assert_eq!(expect.to_vec(), buf);
 
-    let err = reader.read(&mut buf);
-    assert!(err.is_err());
-    assert_eq!(err.err().unwrap().kind(), io::ErrorKind::ConnectionAborted);
+    let err = reader.read(&mut buf).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+    assert!(rustls::is_close_notify(&err));
+    assert_eq!(err.to_string(), "received fatal alert: CloseNotify");
 }
 
 #[test]


### PR DESCRIPTION
This helps users distinguish a CloseNotify from other types of I/O
errors.