### PR TITLE
Thread cipher suite through handshake states

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -554,8 +554,13 @@ impl State for ExpectServerHello {
             })?;
 
         debug!("Using ciphersuite {:?}", server_hello.cipher_suite);
-        if !sess.common.set_suite(suite) {
-            return Err(illegal_param(sess, "server varied selected ciphersuite"));
+        match sess.common.suite {
+            Some(prev_suite) if prev_suite != suite => {
+                return Err(illegal_param(sess, "server varied selected ciphersuite"));
+            }
+            _ => {
+                sess.common.suite = Some(suite);
+            }
         }
 
         if !suite.usable_for_version(version) {
@@ -831,7 +836,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         };
 
         // HRR selects the ciphersuite.
-        sess.common.set_suite(cs);
+        sess.common.suite = Some(cs);
 
         // This is the draft19 change where the transcript became a tree
         self.next

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -771,7 +771,7 @@ impl quic::QuicExt for ClientSession {
         self.common.quic.alert
     }
 
-    fn next_1rtt_keys(&mut self) -> quic::PacketKeySet {
+    fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
         quic::next_1rtt_keys(&mut self.common)
     }
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -418,6 +418,7 @@ pub struct ExpectEncryptedExtensions {
     pub handshake: HandshakeDetails,
     pub dns_name: webpki::DNSName,
     pub randoms: SessionRandoms,
+    pub suite: &'static SupportedCipherSuite,
     pub transcript: HandshakeHash,
     pub key_schedule: KeyScheduleHandshake,
     pub hello: ClientHelloDetails,
@@ -458,7 +459,6 @@ impl hs::State for ExpectEncryptedExtensions {
 
             if was_early_traffic && !sess.common.early_traffic {
                 // If no early traffic, set the encryption key for handshakes
-                let suite = sess.common.get_suite_assert();
                 let write_key = self
                     .key_schedule
                     .client_handshake_traffic_secret(
@@ -468,7 +468,7 @@ impl hs::State for ExpectEncryptedExtensions {
                     );
                 sess.common
                     .record_layer
-                    .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
+                    .set_message_encrypter(cipher::new_tls13_write(self.suite, &write_key));
             }
 
             sess.server_cert_chain = resuming_session
@@ -482,6 +482,7 @@ impl hs::State for ExpectEncryptedExtensions {
             Ok(Box::new(ExpectFinished {
                 dns_name: self.dns_name,
                 randoms: self.randoms,
+                suite: self.suite,
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 client_auth: None,
@@ -497,6 +498,7 @@ impl hs::State for ExpectEncryptedExtensions {
             Ok(Box::new(ExpectCertificateOrCertReq {
                 dns_name: self.dns_name,
                 randoms: self.randoms,
+                suite: self.suite,
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 may_send_sct_list: self.hello.server_may_send_sct_list(),
@@ -509,6 +511,7 @@ impl hs::State for ExpectEncryptedExtensions {
 struct ExpectCertificate {
     dns_name: webpki::DNSName,
     randoms: SessionRandoms,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     may_send_sct_list: bool,
@@ -565,6 +568,7 @@ impl hs::State for ExpectCertificate {
         Ok(Box::new(ExpectCertificateVerify {
             dns_name: self.dns_name,
             randoms: self.randoms,
+            suite: self.suite,
             transcript: self.transcript,
             key_schedule: self.key_schedule,
             server_cert,
@@ -577,6 +581,7 @@ impl hs::State for ExpectCertificate {
 struct ExpectCertificateOrCertReq {
     dns_name: webpki::DNSName,
     randoms: SessionRandoms,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     may_send_sct_list: bool,
@@ -597,6 +602,7 @@ impl hs::State for ExpectCertificateOrCertReq {
             Box::new(ExpectCertificate {
                 dns_name: self.dns_name,
                 randoms: self.randoms,
+                suite: self.suite,
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 may_send_sct_list: self.may_send_sct_list,
@@ -608,6 +614,7 @@ impl hs::State for ExpectCertificateOrCertReq {
             Box::new(ExpectCertificateRequest {
                 dns_name: self.dns_name,
                 randoms: self.randoms,
+                suite: self.suite,
                 transcript: self.transcript,
                 key_schedule: self.key_schedule,
                 may_send_sct_list: self.may_send_sct_list,
@@ -622,6 +629,7 @@ impl hs::State for ExpectCertificateOrCertReq {
 struct ExpectCertificateVerify {
     dns_name: webpki::DNSName,
     randoms: SessionRandoms,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     server_cert: ServerCertDetails,
@@ -696,6 +704,7 @@ impl hs::State for ExpectCertificateVerify {
         Ok(Box::new(ExpectFinished {
             dns_name: self.dns_name,
             randoms: self.randoms,
+            suite: self.suite,
             transcript: self.transcript,
             key_schedule: self.key_schedule,
             client_auth: self.client_auth,
@@ -712,6 +721,7 @@ impl hs::State for ExpectCertificateVerify {
 struct ExpectCertificateRequest {
     dns_name: webpki::DNSName,
     randoms: SessionRandoms,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     may_send_sct_list: bool,
@@ -785,6 +795,7 @@ impl hs::State for ExpectCertificateRequest {
         Ok(Box::new(ExpectCertificate {
             dns_name: self.dns_name,
             randoms: self.randoms,
+            suite: self.suite,
             transcript: self.transcript,
             key_schedule: self.key_schedule,
             may_send_sct_list: self.may_send_sct_list,
@@ -905,6 +916,7 @@ fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, sess: &mut Clien
 struct ExpectFinished {
     dns_name: webpki::DNSName,
     randoms: SessionRandoms,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleHandshake,
     client_auth: Option<ClientAuthDetails>,
@@ -932,7 +944,6 @@ impl hs::State for ExpectFinished {
             })
             .map(|_| verify::FinishedMessageVerified::assertion())?;
 
-        let suite = sess.common.get_suite_assert();
         let maybe_write_key = if sess.common.early_traffic {
             /* Derive the client-to-server encryption key before key schedule update */
             let key = st
@@ -958,7 +969,7 @@ impl hs::State for ExpectFinished {
             sess.early_data.finished();
             sess.common
                 .record_layer
-                .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
+                .set_message_encrypter(cipher::new_tls13_write(st.suite, &write_key));
         }
 
         /* Send our authentication/finished messages.  These are still encrypted
@@ -984,7 +995,7 @@ impl hs::State for ExpectFinished {
         );
         sess.common
             .record_layer
-            .set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
+            .set_message_decrypter(cipher::new_tls13_read(st.suite, &read_key));
 
         key_schedule_finished.exporter_master_secret(
             &hash_after_handshake,
@@ -999,13 +1010,14 @@ impl hs::State for ExpectFinished {
         );
         sess.common
             .record_layer
-            .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
+            .set_message_encrypter(cipher::new_tls13_write(st.suite, &write_key));
 
         let key_schedule_traffic = key_schedule_finished.into_traffic();
         sess.common.start_traffic();
 
         let st = ExpectTraffic {
             dns_name: st.dns_name,
+            suite: st.suite,
             transcript: st.transcript,
             key_schedule: key_schedule_traffic,
             want_write_key_update: false,
@@ -1034,6 +1046,7 @@ impl hs::State for ExpectFinished {
 // and application data.
 struct ExpectTraffic {
     dns_name: webpki::DNSName,
+    suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleTraffic,
     want_write_key_update: bool,
@@ -1055,7 +1068,7 @@ impl ExpectTraffic {
 
         let mut value = persist::ClientSessionValueWithResolvedCipherSuite::new(
             ProtocolVersion::TLSv1_3,
-            sess.common.get_suite_assert(),
+            self.suite,
             &SessionID::empty(),
             nst.ticket.0.clone(),
             secret,
@@ -1143,10 +1156,9 @@ impl ExpectTraffic {
         let new_read_key = self
             .key_schedule
             .next_server_application_traffic_secret();
-        let suite = sess.common.get_suite_assert();
         sess.common
             .record_layer
-            .set_message_decrypter(cipher::new_tls13_read(suite, &new_read_key));
+            .set_message_decrypter(cipher::new_tls13_read(self.suite, &new_read_key));
 
         Ok(())
     }
@@ -1201,10 +1213,9 @@ impl hs::State for ExpectTraffic {
             let write_key = self
                 .key_schedule
                 .next_client_application_traffic_secret();
-            let scs = sess.common.get_suite_assert();
             sess.common
                 .record_layer
-                .set_message_encrypter(cipher::new_tls13_write(scs, &write_key));
+                .set_message_encrypter(cipher::new_tls13_write(self.suite, &write_key));
         }
     }
 }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -732,7 +732,7 @@ impl State for ExpectClientHello {
         .ok_or_else(|| incompatible(sess, "no ciphersuites in common"))?;
 
         debug!("decided upon suite {:?}", ciphersuite);
-        sess.common.set_suite(ciphersuite);
+        sess.common.suite = Some(ciphersuite);
 
         // Start handshake hash.
         let starting_hash = sess

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -26,6 +26,8 @@ use crate::session::Protocol;
 use crate::session::{SessionRandoms, SessionSecrets};
 use crate::sign;
 use crate::suites;
+use crate::SupportedCipherSuite;
+
 use webpki;
 
 use crate::server::common::{HandshakeDetails, ServerKXDetails};
@@ -76,7 +78,8 @@ pub fn decode_error(sess: &mut ServerSession, why: &str) -> Error {
 }
 
 pub fn can_resume(
-    sess: &ServerSession,
+    suite: &'static SupportedCipherSuite,
+    sni: &Option<webpki::DNSName>,
     using_ems: bool,
     resumedata: persist::ServerSessionValue,
 ) -> Option<persist::ServerSessionValue> {
@@ -88,9 +91,9 @@ pub fn can_resume(
     // a different name. Instead, it proceeds with a full handshake to
     // establish a new session."
 
-    if resumedata.cipher_suite == sess.common.get_suite_assert().suite
+    if resumedata.cipher_suite == suite.suite
         && (resumedata.extended_ms == using_ems || (resumedata.extended_ms && !using_ems))
-        && same_dns_name_or_both_none(resumedata.sni.as_ref(), sess.sni.as_ref())
+        && same_dns_name_or_both_none(resumedata.sni.as_ref(), sni.as_ref())
     {
         return Some(resumedata);
     }
@@ -151,6 +154,8 @@ impl ExtensionProcessing {
     pub fn process_common(
         &mut self,
         sess: &mut ServerSession,
+        #[allow(unused_variables)] // #[cfg(feature = "quic")] only
+        suite: &'static SupportedCipherSuite,
         ocsp_response: &mut Option<&[u8]>,
         sct_list: &mut Option<&[u8]>,
         hello: &ClientHelloPayload,
@@ -204,7 +209,7 @@ impl ExtensionProcessing {
                     if sess.config.max_early_data_size > 0
                         && hello.early_data_extension_offered()
                         && resume.version == sess.common.negotiated_version.unwrap()
-                        && resume.cipher_suite == sess.common.get_suite_assert().suite
+                        && resume.cipher_suite == suite.suite
                         && resume.alpn.as_ref().map(|x| &x.0) == sess.common.alpn_protocol.as_ref()
                         && !sess.reject_early_data
                     {
@@ -337,6 +342,7 @@ impl ExpectClientHello {
     fn emit_server_hello(
         &mut self,
         sess: &mut ServerSession,
+        suite: &'static SupportedCipherSuite,
         ocsp_response: &mut Option<&[u8]>,
         sct_list: &mut Option<&[u8]>,
         hello: &ClientHelloPayload,
@@ -346,6 +352,7 @@ impl ExpectClientHello {
         let mut ep = ExtensionProcessing::new();
         ep.process_common(
             sess,
+            suite,
             ocsp_response,
             sct_list,
             hello,
@@ -365,7 +372,7 @@ impl ExpectClientHello {
                     legacy_version: ProtocolVersion::TLSv1_2,
                     random: Random::from_slice(&randoms.server),
                     session_id: self.handshake.session_id,
-                    cipher_suite: sess.common.get_suite_assert().suite,
+                    cipher_suite: suite.suite,
                     compression_method: Compression::Null,
                     extensions: ep.exts,
                 }),
@@ -522,6 +529,7 @@ impl ExpectClientHello {
         mut self,
         sess: &mut ServerSession,
         client_hello: &ClientHelloPayload,
+        suite: &'static SupportedCipherSuite,
         sni: Option<&webpki::DNSName>,
         id: &SessionID,
         resumedata: persist::ServerSessionValue,
@@ -536,6 +544,7 @@ impl ExpectClientHello {
         self.handshake.session_id = *id;
         self.emit_server_hello(
             sess,
+            suite,
             &mut None,
             &mut None,
             client_hello,
@@ -543,7 +552,6 @@ impl ExpectClientHello {
             randoms,
         )?;
 
-        let suite = sess.common.get_suite_assert();
         let secrets = SessionSecrets::new_resume(&randoms, suite, &resumedata.master_secret.0);
         sess.config.key_log.log(
             "CLIENT_RANDOM",
@@ -718,7 +726,7 @@ impl State for ExpectClientHello {
         // And version
         let suitable_suites = suites::reduce_given_version(&suitable_suites, version);
 
-        let ciphersuite = if sess.config.ignore_client_order {
+        let suite = if sess.config.ignore_client_order {
             suites::choose_ciphersuite_preferring_server(
                 &client_hello.cipher_suites,
                 &suitable_suites,
@@ -731,14 +739,11 @@ impl State for ExpectClientHello {
         }
         .ok_or_else(|| incompatible(sess, "no ciphersuites in common"))?;
 
-        debug!("decided upon suite {:?}", ciphersuite);
-        sess.common.suite = Some(ciphersuite);
+        debug!("decided upon suite {:?}", suite);
+        sess.common.suite = Some(suite);
 
         // Start handshake hash.
-        let starting_hash = sess
-            .common
-            .get_suite_assert()
-            .get_hash();
+        let starting_hash = suite.get_hash();
         if !self
             .handshake
             .transcript
@@ -760,11 +765,12 @@ impl State for ExpectClientHello {
         if sess.common.is_tls13() {
             return tls13::CompleteClientHelloHandling {
                 handshake: self.handshake,
+                suite,
                 randoms,
                 done_retry: self.done_retry,
                 send_ticket: self.send_ticket,
             }
-            .handle_client_hello(ciphersuite, sess, &certkey, &m);
+            .handle_client_hello(suite, sess, &certkey, &m);
         }
 
         // -- TLS1.2 only from hereon in --
@@ -823,11 +829,12 @@ impl State for ExpectClientHello {
                     .ticketer
                     .decrypt(&ticket.0)
                     .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-                    .and_then(|resumedata| can_resume(sess, self.using_ems, resumedata))
+                    .and_then(|resumedata| can_resume(suite, &sess.sni, self.using_ems, resumedata))
                 {
                     return self.start_resumption(
                         sess,
                         client_hello,
+                        suite,
                         sni.as_ref(),
                         &client_hello.session_id,
                         resume,
@@ -853,11 +860,12 @@ impl State for ExpectClientHello {
                 .session_storage
                 .get(&client_hello.session_id.get_encoding())
                 .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
-                .and_then(|resumedata| can_resume(sess, self.using_ems, resumedata))
+                .and_then(|resumedata| can_resume(suite, &sess.sni, self.using_ems, resumedata))
             {
                 return self.start_resumption(
                     sess,
                     client_hello,
+                    suite,
                     sni.as_ref(),
                     &client_hello.session_id,
                     resume,
@@ -867,10 +875,7 @@ impl State for ExpectClientHello {
         }
 
         // Now we have chosen a ciphersuite, we can make kx decisions.
-        let sigschemes = sess
-            .common
-            .get_suite_assert()
-            .resolve_sig_schemes(&sigschemes_ext);
+        let sigschemes = suite.resolve_sig_schemes(&sigschemes_ext);
 
         if sigschemes.is_empty() {
             return Err(incompatible(sess, "no supported sig scheme"));
@@ -896,6 +901,7 @@ impl State for ExpectClientHello {
             (certkey.ocsp.as_deref(), certkey.sct_list.as_deref());
         self.emit_server_hello(
             sess,
+            suite,
             &mut ocsp_response,
             &mut sct_list,
             client_hello,
@@ -915,6 +921,7 @@ impl State for ExpectClientHello {
             Ok(Box::new(tls12::ExpectCertificate {
                 handshake: self.handshake,
                 randoms,
+                suite,
                 using_ems: self.using_ems,
                 server_kx,
                 send_ticket: self.send_ticket,
@@ -923,6 +930,7 @@ impl State for ExpectClientHello {
             Ok(Box::new(tls12::ExpectClientKX {
                 handshake: self.handshake,
                 randoms,
+                suite,
                 using_ems: self.using_ems,
                 server_kx,
                 client_cert: None,

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -436,7 +436,7 @@ pub struct SessionCommon {
     pub negotiated_version: Option<ProtocolVersion>,
     pub is_client: bool,
     pub record_layer: record_layer::RecordLayer,
-    suite: Option<&'static SupportedCipherSuite>,
+    pub suite: Option<&'static SupportedCipherSuite>,
     pub alpn_protocol: Option<Vec<u8>>,
     peer_eof: bool,
     pub traffic: bool,
@@ -538,20 +538,6 @@ impl SessionCommon {
 
     pub fn get_suite_assert(&self) -> &'static SupportedCipherSuite {
         self.suite.as_ref().unwrap()
-    }
-
-    pub fn set_suite(&mut self, suite: &'static SupportedCipherSuite) -> bool {
-        match self.suite {
-            None => {
-                self.suite = Some(suite);
-                true
-            }
-            Some(s) if s == suite => {
-                self.suite = Some(suite);
-                true
-            }
-            _ => false,
-        }
     }
 
     pub fn get_alpn_protocol(&self) -> Option<&[u8]> {

--- a/rustls/src/session.rs
+++ b/rustls/src/session.rs
@@ -536,10 +536,6 @@ impl SessionCommon {
         self.suite
     }
 
-    pub fn get_suite_assert(&self) -> &'static SupportedCipherSuite {
-        self.suite.as_ref().unwrap()
-    }
-
     pub fn get_alpn_protocol(&self) -> Option<&[u8]> {
         self.alpn_protocol
             .as_ref()


### PR DESCRIPTION
Avoids a lot of unwrapping via `SessionCommon::get_suite_assert()`.