### PR TITLE
bogo: rebuild shim before running the tests

### DIFF
--- a/bogo/runme
+++ b/bogo/runme
@@ -17,6 +17,9 @@ fi
 # Best effort on OS-X
 case $OSTYPE in darwin*) set +e ;; esac
 
+# Make sure the shim binary is up to date
+cargo build --features="dangerous_configuration quic" --example bogo_shim
+
 ( cd bogo/ssl/test/runner && ./runner.test -shim-path ../../../../../target/debug/examples/bogo_shim \
      -shim-config ../../../../config.json \
      -pipe \


### PR DESCRIPTION
Rebuild the shim before running to prevent confusion from running an old build, and pass any additional arguments from the `runme` script through to `runner.test` (in particular, `-test` enables selecting a comma separated list of tests to run).