### PR TITLE
Replace SessionID::new() with SessionID::random() constructor

### DIFF
--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -9,6 +9,7 @@ use crate::msgs::enums::{CipherSuite, Compression, ECPointFormat, ExtensionType}
 use crate::msgs::enums::{HandshakeType, ProtocolVersion};
 use crate::msgs::enums::{HashAlgorithm, ServerNameType, SignatureAlgorithm};
 use crate::msgs::enums::{KeyUpdateRequest, NamedGroup, SignatureScheme};
+use crate::rand;
 
 #[cfg(feature = "logging")]
 use crate::log::warn;
@@ -142,15 +143,10 @@ impl Codec for SessionID {
 }
 
 impl SessionID {
-    pub fn new(bytes: &[u8]) -> SessionID {
-        debug_assert!(bytes.len() <= 32);
-        let mut d = [0u8; 32];
-        d[..bytes.len()].clone_from_slice(&bytes[..]);
-
-        SessionID {
-            data: d,
-            len: bytes.len(),
-        }
+    pub fn random() -> Result<Self, rand::GetRandomFailed> {
+        let mut data = [0u8; 32];
+        rand::fill_random(&mut data)?;
+        Ok(Self { data, len: 32 })
     }
 
     pub fn empty() -> SessionID {

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -40,8 +40,8 @@ fn rejects_sessionid_with_bad_length() {
 
 #[test]
 fn sessionid_with_different_lengths_are_unequal() {
-    let a = SessionID::new(&[1u8]);
-    let b = SessionID::new(&[1u8, 2u8]);
+    let a = SessionID::read(&mut Reader::init(&[1u8, 1])).unwrap();
+    let b = SessionID::read(&mut Reader::init(&[2u8, 1, 2])).unwrap();
     assert_eq!(a, a);
     assert_eq!(b, b);
     assert_ne!(a, b);
@@ -56,7 +56,6 @@ fn accepts_short_sessionid() {
 
     assert_eq!(sess.is_empty(), false);
     assert_eq!(sess.len(), 1);
-    assert_eq!(sess, SessionID::new(&[1u8]));
     assert_eq!(rd.any_left(), false);
 }
 
@@ -69,7 +68,6 @@ fn accepts_empty_sessionid() {
 
     assert_eq!(sess.is_empty(), true);
     assert_eq!(sess.len(), 0);
-    assert_eq!(sess, SessionID::new(&[]));
     assert_eq!(rd.any_left(), false);
 }
 

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -25,7 +25,7 @@ fn clientsessionvalue_is_debug() {
     let csv = ClientSessionValueWithResolvedCipherSuite::new(
         ProtocolVersion::TLSv1_2,
         &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-        &SessionID::new(&[1u8]),
+        &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],
         &vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -20,7 +20,6 @@ use crate::msgs::handshake::{HandshakeMessagePayload, Random, ServerHelloPayload
 use crate::msgs::handshake::{HandshakePayload, SupportedSignatureSchemes};
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
-use crate::rand;
 use crate::server::{ClientHello, ServerConfig, ServerSession};
 #[cfg(feature = "quic")]
 use crate::session::Protocol;
@@ -843,9 +842,7 @@ impl State for ExpectClientHello {
         // If we're not offered a ticket or a potential session ID,
         // allocate a session ID.
         if self.handshake.session_id.is_empty() && !ticket_received {
-            let mut bytes = [0u8; 32];
-            rand::fill_random(&mut bytes)?;
-            self.handshake.session_id = SessionID::new(&bytes);
+            self.handshake.session_id = SessionID::random()?;
         }
 
         // Perhaps resume?  If we received a ticket, the sessionid


### PR DESCRIPTION
The library code only ever uses `new()` to create a randomized SessionID,
but the indirection made it harder to work with this abstraction. See
discussion in #596 for more details.