### PR TITLE
Add explicit dyn keyword where needed

### DIFF
--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -29,8 +29,8 @@ pub struct RecordLayer {
 impl RecordLayer {
     pub fn new() -> RecordLayer {
         RecordLayer {
-            message_encrypter: MessageEncrypter::invalid(),
-            message_decrypter: MessageDecrypter::invalid(),
+            message_encrypter: <dyn MessageEncrypter>::invalid(),
+            message_decrypter: <dyn MessageDecrypter>::invalid(),
             write_seq: 0,
             read_seq: 0,
             encrypt_state: DirectionState::Invalid,


### PR DESCRIPTION
Implicit trait objects are now deprecated on nightly.