### PR TITLE
Stricter fuzz corpus test

### DIFF
--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -27,7 +27,7 @@ fn test_read_fuzz_corpus() {
 
         let mut rd = Reader::init(&bytes);
         let mut msg = Message::read(&mut rd).unwrap();
-        //println!("{:?}", msg);
+        println!("{:?}", msg);
         msg.decode_payload();
         let enc = msg.get_encoding();
         assert_eq!(bytes.to_vec(), enc);

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -31,7 +31,7 @@ fn test_read_fuzz_corpus() {
         msg.decode_payload();
         let enc = msg.get_encoding();
         assert_eq!(bytes.to_vec(), enc);
-        assert_eq!(bytes[..rd.used()], enc);
+        assert_eq!(bytes[..rd.used()].to_vec(), enc);
     }
 }
 

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -26,9 +26,12 @@ fn test_read_fuzz_corpus() {
         f.read_to_end(&mut bytes).unwrap();
 
         let mut rd = Reader::init(&bytes);
-        let msg = Message::read(&mut rd).unwrap();
-        println!("{:?}", msg);
-        assert_eq!(bytes.to_vec(), msg.get_encoding());
+        let mut msg = Message::read(&mut rd).unwrap();
+        //println!("{:?}", msg);
+        msg.decode_payload();
+        let enc = msg.get_encoding();
+        assert_eq!(bytes.to_vec(), enc);
+        assert_eq!(bytes[..rd.used()], enc);
     }
 }
 


### PR DESCRIPTION
I noticed a test I added to the corpus was failing if I pointed `cargo fuzz` at it, but passing here. This patch makes `message_test` just as tough as `cargo fuzz`, but leaves in what was there before, on the assumption that it's there to ease debugging.

Happy to squash these commits as suggested in other PRs, but I think GitHub's squash-on-merge feature would be fine here (I'll just do whatever is easiest to work with). I don't think the formatting test failure has anything to do with this patch.