### PR TITLE
Ignore DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ target/
 *.info
 sslkeylogfile.txt
 admin/rustfmt
+.DS_Store
+._.DS_Store
 **/.DS_Store
 **/._.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 *.info
 sslkeylogfile.txt
 admin/rustfmt
+**/.DS_Store
+**/._.DS_Store


### PR DESCRIPTION
macOS leaves these annoying files around if you browse a directory in the Finder.