### PR TITLE
Refactor construction of AEAD keys for TLS 1.2 to clarify lack of panicking 

### DIFF
--- a/rustls-mio/tests/common/mod.rs
+++ b/rustls-mio/tests/common/mod.rs
@@ -809,7 +809,7 @@ pub struct OpenSSLClient {
 impl OpenSSLClient {
     pub fn new(port: u16) -> OpenSSLClient {
         OpenSSLClient {
-            port: port,
+            port,
             cafile: PathBuf::new(),
             extra_args: Vec::new(),
             expect_fails: false,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -343,7 +343,9 @@ impl ConnectionSecrets {
         ret
     }
 
-    pub fn make_key_block(&self, len: usize) -> Vec<u8> {
+    pub fn make_key_block(&self, scs: &SupportedCipherSuite) -> Vec<u8> {
+        let len = (scs.aead_algorithm.key_len() + scs.fixed_iv_len) * 2 + scs.explicit_nonce_len;
+
         let mut out = Vec::new();
         out.resize(len, 0u8);
 

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -43,9 +43,6 @@ pub struct SupportedCipherSuite {
     /// to the ciphersuite concept there.
     pub sign: Option<&'static [SignatureScheme]>,
 
-    /// Encryption key length, for the bulk algorithm.
-    pub enc_key_len: usize,
-
     /// How long the fixed part of the 'IV' is.
     ///
     /// This isn't usually an IV, but we continue the
@@ -77,7 +74,6 @@ impl fmt::Debug for SupportedCipherSuite {
             .field("bulk", &self.bulk)
             .field("hash", &self.hash)
             .field("sign", &self.sign)
-            .field("enc_key_len", &self.enc_key_len)
             .field("fixed_iv_len", &self.fixed_iv_len)
             .field("explicit_nonce_len", &self.explicit_nonce_len)
             .finish()
@@ -108,12 +104,6 @@ impl SupportedCipherSuite {
         } else {
             vec![]
         }
-    }
-
-    /// Length of key block that needs to be output by the key
-    /// derivation phase for this suite.
-    pub fn key_block_len(&self) -> usize {
-        (self.enc_key_len + self.fixed_iv_len) * 2 + self.explicit_nonce_len
     }
 
     /// Return true if this suite is usable for TLS `version`.
@@ -181,7 +171,6 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         sign: Some(TLS12_ECDSA_SCHEMES),
         bulk: BulkAlgorithm::Chacha20Poly1305,
         hash: HashAlgorithm::SHA256,
-        enc_key_len: 32,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
         hkdf_algorithm: ring::hkdf::HKDF_SHA256,
@@ -198,7 +187,6 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
         sign: Some(TLS12_RSA_SCHEMES),
         bulk: BulkAlgorithm::Chacha20Poly1305,
         hash: HashAlgorithm::SHA256,
-        enc_key_len: 32,
         fixed_iv_len: 12,
         explicit_nonce_len: 0,
         hkdf_algorithm: ring::hkdf::HKDF_SHA256,
@@ -214,7 +202,6 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Support
     sign: Some(TLS12_RSA_SCHEMES),
     bulk: BulkAlgorithm::Aes128Gcm,
     hash: HashAlgorithm::SHA256,
-    enc_key_len: 16,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
@@ -230,7 +217,6 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Support
     sign: Some(TLS12_RSA_SCHEMES),
     bulk: BulkAlgorithm::Aes256Gcm,
     hash: HashAlgorithm::SHA384,
-    enc_key_len: 32,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA384,
@@ -246,7 +232,6 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Suppo
     sign: Some(TLS12_ECDSA_SCHEMES),
     bulk: BulkAlgorithm::Aes128Gcm,
     hash: HashAlgorithm::SHA256,
-    enc_key_len: 16,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
@@ -262,7 +247,6 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Suppo
     sign: Some(TLS12_ECDSA_SCHEMES),
     bulk: BulkAlgorithm::Aes256Gcm,
     hash: HashAlgorithm::SHA384,
-    enc_key_len: 32,
     fixed_iv_len: 4,
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA384,
@@ -278,7 +262,6 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite = SupportedCiphe
     sign: None,
     bulk: BulkAlgorithm::Chacha20Poly1305,
     hash: HashAlgorithm::SHA256,
-    enc_key_len: 32,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
@@ -294,7 +277,6 @@ pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite
     sign: None,
     bulk: BulkAlgorithm::Aes256Gcm,
     hash: HashAlgorithm::SHA384,
-    enc_key_len: 32,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
     hkdf_algorithm: ring::hkdf::HKDF_SHA384,
@@ -310,7 +292,6 @@ pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite
     sign: None,
     bulk: BulkAlgorithm::Aes128Gcm,
     hash: HashAlgorithm::SHA256,
-    enc_key_len: 16,
     fixed_iv_len: 12,
     explicit_nonce_len: 0,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -219,8 +219,8 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Support
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     aead_algorithm: &ring::aead::AES_128_GCM,
-    build_tls12_encrypter: Some(cipher::build_tls12_gcm_128_encrypter),
-    build_tls12_decrypter: Some(cipher::build_tls12_gcm_128_decrypter),
+    build_tls12_encrypter: Some(cipher::build_tls12_gcm_encrypter),
+    build_tls12_decrypter: Some(cipher::build_tls12_gcm_decrypter),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -235,8 +235,8 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Support
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA384,
     aead_algorithm: &ring::aead::AES_256_GCM,
-    build_tls12_encrypter: Some(cipher::build_tls12_gcm_256_encrypter),
-    build_tls12_decrypter: Some(cipher::build_tls12_gcm_256_decrypter),
+    build_tls12_encrypter: Some(cipher::build_tls12_gcm_encrypter),
+    build_tls12_decrypter: Some(cipher::build_tls12_gcm_decrypter),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
@@ -251,8 +251,8 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = Suppo
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA256,
     aead_algorithm: &ring::aead::AES_128_GCM,
-    build_tls12_encrypter: Some(cipher::build_tls12_gcm_128_encrypter),
-    build_tls12_decrypter: Some(cipher::build_tls12_gcm_128_decrypter),
+    build_tls12_encrypter: Some(cipher::build_tls12_gcm_encrypter),
+    build_tls12_decrypter: Some(cipher::build_tls12_gcm_decrypter),
 };
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -267,8 +267,8 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Suppo
     explicit_nonce_len: 8,
     hkdf_algorithm: ring::hkdf::HKDF_SHA384,
     aead_algorithm: &ring::aead::AES_256_GCM,
-    build_tls12_encrypter: Some(cipher::build_tls12_gcm_256_encrypter),
-    build_tls12_decrypter: Some(cipher::build_tls12_gcm_256_decrypter),
+    build_tls12_encrypter: Some(cipher::build_tls12_gcm_encrypter),
+    build_tls12_decrypter: Some(cipher::build_tls12_gcm_decrypter),
 };
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -611,7 +611,7 @@ impl ClientCheckCertResolve {
     fn new(expect_queries: usize) -> ClientCheckCertResolve {
         ClientCheckCertResolve {
             query_count: AtomicUsize::new(0),
-            expect_queries: expect_queries,
+            expect_queries,
         }
     }
 }


### PR DESCRIPTION
See the individual commit messages for details.

Fixes #626.