### PR TITLE
Upgrade to webpki 0.22.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
   "rustls-mio",
 ]
 exclude = ["admin/rustfmt"]
+
+[patches.crates-io]
+webpki-roots = { path = "../webpki-roots" }

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
     let config = Arc::new(ClientConfig::new(root_store, &[], DEFAULT_CIPHERSUITES));
-    let example_com = webpki::DNSNameRef::try_from_ascii_str("example.com").unwrap();
+    let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
     let mut client = ClientConnection::new(&config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -38,7 +38,7 @@ struct TlsClient {
 impl TlsClient {
     fn new(
         sock: TcpStream,
-        hostname: webpki::DNSNameRef<'_>,
+        hostname: webpki::DnsNameRef<'_>,
         cfg: Arc<rustls::ClientConfig>,
     ) -> TlsClient {
         TlsClient {
@@ -450,7 +450,7 @@ mod danger {
             &self,
             _end_entity: &rustls::Certificate,
             _intermediates: &[rustls::Certificate],
-            _dns_name: webpki::DNSNameRef<'_>,
+            _dns_name: webpki::DnsNameRef<'_>,
             _scts: &mut dyn Iterator<Item = &[u8]>,
             _ocsp: &[u8],
             _now: std::time::SystemTime,
@@ -560,7 +560,7 @@ fn main() {
     let config = make_config(&args);
 
     let sock = TcpStream::connect(addr).unwrap();
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str(&args.arg_hostname).unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str(&args.arg_hostname).unwrap();
     let mut tlsclient = TlsClient::new(sock, dns_name, config);
 
     if args.flag_http {

--- a/rustls-mio/tests/common/mod.rs
+++ b/rustls-mio/tests/common/mod.rs
@@ -809,7 +809,7 @@ pub struct OpenSSLClient {
 impl OpenSSLClient {
     pub fn new(port: u16) -> OpenSSLClient {
         OpenSSLClient {
-            port: port,
+            port,
             cafile: PathBuf::new(),
             extra_args: Vec::new(),
             expect_fails: false,

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -15,7 +15,7 @@ autobenches = false
 log = { version = "0.4.4", optional = true }
 ring = "0.16.19"
 sct = "0.6.0"
-webpki = "0.21.4"
+webpki = { version = "0.22.0", features = ["alloc", "std"] }
 
 [features]
 default = ["logging"]
@@ -26,7 +26,7 @@ quic = []
 [dev-dependencies]
 env_logger = "0.8.2"
 log = "0.4.4"
-webpki-roots = "0.21"
+webpki-roots = "0.22.0"
 criterion = "0.3.0"
 rustls-pemfile = "0.2.0"
 base64 = "0.13.0"

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -365,7 +365,7 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
     let mut server_time = 0f64;
 
     for _ in 0..rounds {
-        let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+        let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
         let mut server = ServerConnection::new(&server_config);
 
@@ -440,7 +440,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, mtu: Option<usize>) 
         mtu,
     ));
 
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
     let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
     let mut server = ServerConnection::new(&server_config);
 
@@ -509,7 +509,7 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
 
     for _i in 0..conn_count {
         servers.push(ServerConnection::new(&server_config));
-        let dns_name = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
+        let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         clients.push(ClientConnection::new(&client_config, dns_name).unwrap());
     }
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -180,13 +180,13 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
         true
     }
 
-    fn client_auth_mandatory(&self, _sni: Option<&webpki::DNSName>) -> Option<bool> {
+    fn client_auth_mandatory(&self, _sni: Option<&webpki::DnsName>) -> Option<bool> {
         Some(self.mandatory)
     }
 
     fn client_auth_root_subjects(
         &self,
-        _sni: Option<&webpki::DNSName>,
+        _sni: Option<&webpki::DnsName>,
     ) -> Option<rustls::DistinguishedNames> {
         Some(rustls::DistinguishedNames::new())
     }
@@ -195,7 +195,7 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
         &self,
         _end_entity: &rustls::Certificate,
         _intermediates: &[rustls::Certificate],
-        _sni: Option<&webpki::DNSName>,
+        _sni: Option<&webpki::DnsName>,
         _now: SystemTime,
     ) -> Result<rustls::ClientCertVerified, rustls::Error> {
         Ok(rustls::ClientCertVerified::assertion())
@@ -211,7 +211,7 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
         &self,
         _end_entity: &rustls::Certificate,
         _certs: &[rustls::Certificate],
-        _hostname: webpki::DNSNameRef<'_>,
+        _hostname: webpki::DnsNameRef<'_>,
         _scts: &mut dyn Iterator<Item = &[u8]>,
         _ocsp: &[u8],
         _now: SystemTime,
@@ -1046,7 +1046,7 @@ fn main() {
             };
             ClientOrServer::Server(s)
         } else {
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str(&opts.host_name).unwrap();
+            let dns_name = webpki::DnsNameRef::try_from_ascii_str(&opts.host_name).unwrap();
             let c = if opts.quic_transport_params.is_empty() {
                 rustls::ClientConnection::new(ccfg.as_ref().unwrap(), dns_name)
             } else {

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -49,7 +49,7 @@ fn communicate(
     port: u16,
     config: ClientConfig,
 ) -> Result<Verdict, Box<dyn StdError>> {
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str(&host).unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str(&host).unwrap();
     let rc_config = Arc::new(config);
     let mut client = ClientConnection::new(&rc_config, dns_name).unwrap();
     let mut stream = TcpStream::connect((&*host, port))?;

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -21,7 +21,7 @@ fn main() {
         &[&rustls::cipher_suites::TLS13_CHACHA20_POLY1305_SHA256],
     );
 
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str("google.com").unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
     let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -10,7 +10,7 @@ use webpki;
 use webpki_roots;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str(domain_name).unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str(domain_name).unwrap();
     let mut conn = rustls::ClientConnection::new(config, dns_name).unwrap();
     let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
     sock.set_nodelay(true).unwrap();

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -23,7 +23,7 @@ fn main() {
     root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     let config = rustls::ClientConfig::new(root_store, &[], rustls::DEFAULT_CIPHERSUITES);
 
-    let dns_name = webpki::DNSNameRef::try_from_ascii_str("google.com").unwrap();
+    let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
     let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -87,7 +87,7 @@ impl RootCertStore {
 
     /// Add a single DER-encoded certificate to the store.
     pub fn add(&mut self, der: &key::Certificate) -> Result<(), webpki::Error> {
-        let ta = webpki::trust_anchor_util::cert_der_as_trust_anchor(&der.0)?;
+        let ta = webpki::TrustAnchor::try_from_cert_der(&der.0)?;
 
         let ota = OwnedTrustAnchor::from_trust_anchor(&ta);
         self.roots.push(ota);
@@ -98,7 +98,7 @@ impl RootCertStore {
     /// fail.
     pub fn add_server_trust_anchors(
         &mut self,
-        &webpki::TLSServerTrustAnchors(anchors): &webpki::TLSServerTrustAnchors,
+        &webpki::TlsServerTrustAnchors(anchors): &webpki::TlsServerTrustAnchors,
     ) {
         for ta in anchors {
             self.roots

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -71,7 +71,7 @@ pub fn check_aligned_handshake(conn: &mut ClientConnection) -> Result<(), Error>
 
 fn find_session(
     conn: &mut ClientConnection,
-    dns_name: webpki::DNSNameRef,
+    dns_name: webpki::DnsNameRef,
 ) -> Option<persist::ClientSessionValueWithResolvedCipherSuite> {
     let key = persist::ClientSessionKey::session_for_dns_name(dns_name);
     let key_buf = key.get_encoding();
@@ -108,13 +108,13 @@ fn find_session(
 
 struct InitialState {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     transcript: HandshakeHash,
     extra_exts: Vec<ClientExtension>,
 }
 
 impl InitialState {
-    fn new(dns_name: webpki::DNSName, extra_exts: Vec<ClientExtension>) -> InitialState {
+    fn new(dns_name: webpki::DnsName, extra_exts: Vec<ClientExtension>) -> InitialState {
         InitialState {
             resuming_session: None,
             dns_name,
@@ -186,7 +186,7 @@ impl InitialState {
 
 pub fn start_handshake(
     conn: &mut ClientConnection,
-    host_name: webpki::DNSName,
+    host_name: webpki::DnsName,
     extra_exts: Vec<ClientExtension>,
 ) -> NextStateOrError {
     InitialState::new(host_name, extra_exts).emit_initial_client_hello(conn)
@@ -194,7 +194,7 @@ pub fn start_handshake(
 
 struct ExpectServerHello {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -220,7 +220,7 @@ fn emit_client_hello_for_retry(
     mut hello: ClientHelloDetails,
     session_id: Option<SessionID>,
     retryreq: Option<&HelloRetryRequest>,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     extra_exts: Vec<ClientExtension>,
     may_send_sct_list: bool,
     suite: Option<&'static SupportedCipherSuite>,
@@ -891,7 +891,7 @@ impl State for ExpectServerHelloOrHelloRetryRequest {
 
 pub fn send_cert_error_alert(conn: &mut ClientConnection, err: Error) -> Error {
     match err {
-        Error::WebPkiError(webpki::Error::BadDER, _) => {
+        Error::WebPkiError(webpki::Error::BadDer, _) => {
             conn.common
                 .send_fatal_alert(AlertDescription::DecodeError);
         }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -422,7 +422,7 @@ impl ClientConnection {
     /// hostname of who we want to talk to.
     pub fn new(
         config: &Arc<ClientConfig>,
-        hostname: webpki::DNSNameRef,
+        hostname: webpki::DnsNameRef,
     ) -> Result<ClientConnection, Error> {
         let mut new = Self::from_config(config);
         new.start_handshake(hostname.into(), vec![])?;
@@ -477,7 +477,7 @@ impl ClientConnection {
 
     fn start_handshake(
         &mut self,
-        dns_name: webpki::DNSName,
+        dns_name: webpki::DnsName,
         extra_exts: Vec<ClientExtension>,
     ) -> Result<(), Error> {
         self.state = Some(hs::start_handshake(self, dns_name, extra_exts)?);
@@ -777,7 +777,7 @@ pub trait ClientQuicExt {
     fn new_quic(
         config: &Arc<ClientConfig>,
         quic_version: quic::Version,
-        hostname: webpki::DNSNameRef,
+        hostname: webpki::DnsNameRef,
         params: Vec<u8>,
     ) -> Result<ClientConnection, Error> {
         assert!(

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -31,7 +31,7 @@ use std::mem;
 pub struct ExpectCertificate {
     pub resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     pub session_id: SessionID,
-    pub dns_name: webpki::DNSName,
+    pub dns_name: webpki::DnsName,
     pub randoms: ConnectionRandoms,
     pub using_ems: bool,
     pub transcript: HandshakeHash,
@@ -89,7 +89,7 @@ impl hs::State for ExpectCertificate {
 struct ExpectCertificateStatus {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -141,7 +141,7 @@ impl hs::State for ExpectCertificateStatus {
 struct ExpectCertificateStatusOrServerKx {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -200,7 +200,7 @@ impl hs::State for ExpectCertificateStatusOrServerKx {
 struct ExpectServerKx {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -371,7 +371,7 @@ fn emit_finished(
 struct ExpectCertificateRequest {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -446,7 +446,7 @@ impl hs::State for ExpectCertificateRequest {
 struct ExpectServerDoneOrCertReq {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -506,7 +506,7 @@ impl hs::State for ExpectServerDoneOrCertReq {
 struct ExpectServerDone {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     using_ems: bool,
     transcript: HandshakeHash,
@@ -669,7 +669,7 @@ pub struct ExpectCcs {
     pub secrets: ConnectionSecrets,
     pub resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     pub session_id: SessionID,
-    pub dns_name: webpki::DNSName,
+    pub dns_name: webpki::DnsName,
     pub using_ems: bool,
     pub transcript: HandshakeHash,
     pub ticket: ReceivedTicketDetails,
@@ -709,7 +709,7 @@ pub struct ExpectNewTicket {
     pub secrets: ConnectionSecrets,
     pub resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     pub session_id: SessionID,
-    pub dns_name: webpki::DNSName,
+    pub dns_name: webpki::DnsName,
     pub using_ems: bool,
     pub transcript: HandshakeHash,
     pub resuming: bool,
@@ -751,7 +751,7 @@ fn save_session(
     secrets: &ConnectionSecrets,
     mut resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSNameRef,
+    dns_name: webpki::DnsNameRef,
     using_ems: bool,
     recvd_ticket: &mut ReceivedTicketDetails,
     conn: &mut ClientConnection,
@@ -802,7 +802,7 @@ fn save_session(
 struct ExpectFinished {
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     session_id: SessionID,
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     using_ems: bool,
     transcript: HandshakeHash,
     ticket: ReceivedTicketDetails,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -73,7 +73,7 @@ pub fn validate_server_hello(
     Ok(())
 }
 
-fn find_kx_hint(conn: &ClientConnection, dns_name: webpki::DNSNameRef) -> Option<NamedGroup> {
+fn find_kx_hint(conn: &ClientConnection, dns_name: webpki::DnsNameRef) -> Option<NamedGroup> {
     let key = persist::ClientSessionKey::hint_for_dns_name(dns_name);
     let key_buf = key.get_encoding();
 
@@ -84,7 +84,7 @@ fn find_kx_hint(conn: &ClientConnection, dns_name: webpki::DNSNameRef) -> Option
     maybe_value.and_then(|enc| NamedGroup::read_bytes(&enc))
 }
 
-fn save_kx_hint(conn: &mut ClientConnection, dns_name: webpki::DNSNameRef, group: NamedGroup) {
+fn save_kx_hint(conn: &mut ClientConnection, dns_name: webpki::DnsNameRef, group: NamedGroup) {
     let key = persist::ClientSessionKey::hint_for_dns_name(dns_name);
 
     conn.config
@@ -96,7 +96,7 @@ pub fn choose_kx_groups(
     conn: &ClientConnection,
     exts: &mut Vec<ClientExtension>,
     hello: &mut ClientHelloDetails,
-    dns_name: webpki::DNSNameRef,
+    dns_name: webpki::DnsNameRef,
     retryreq: Option<&HelloRetryRequest>,
 ) {
     // Choose our groups:
@@ -173,7 +173,7 @@ pub fn start_handshake_traffic(
     early_key_schedule: Option<KeyScheduleEarly>,
     server_hello: &ServerHelloPayload,
     resuming_session: &mut Option<persist::ClientSessionValueWithResolvedCipherSuite>,
-    dns_name: webpki::DNSNameRef,
+    dns_name: webpki::DnsNameRef,
     transcript: &mut HandshakeHash,
     hello: &mut ClientHelloDetails,
     randoms: &ConnectionRandoms,
@@ -411,7 +411,7 @@ fn validate_encrypted_extensions(
 
 pub struct ExpectEncryptedExtensions {
     pub resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
-    pub dns_name: webpki::DNSName,
+    pub dns_name: webpki::DnsName,
     pub randoms: ConnectionRandoms,
     pub suite: &'static SupportedCipherSuite,
     pub transcript: HandshakeHash,
@@ -508,7 +508,7 @@ impl hs::State for ExpectEncryptedExtensions {
 }
 
 struct ExpectCertificate {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
@@ -582,7 +582,7 @@ impl hs::State for ExpectCertificate {
 }
 
 struct ExpectCertificateOrCertReq {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
@@ -630,7 +630,7 @@ impl hs::State for ExpectCertificateOrCertReq {
 
 // --- TLS1.3 CertificateVerify ---
 struct ExpectCertificateVerify {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
@@ -642,7 +642,7 @@ struct ExpectCertificateVerify {
 
 fn send_cert_error_alert(conn: &mut ClientConnection, err: Error) -> Error {
     match err {
-        Error::WebPkiError(webpki::Error::BadDER, _) => {
+        Error::WebPkiError(webpki::Error::BadDer, _) => {
             conn.common
                 .send_fatal_alert(AlertDescription::DecodeError);
         }
@@ -726,7 +726,7 @@ impl hs::State for ExpectCertificateVerify {
 // Certificate. Unfortunately the CertificateRequest type changed in an annoying way
 // in TLS1.3.
 struct ExpectCertificateRequest {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
@@ -925,7 +925,7 @@ fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, conn: &mut Clien
 }
 
 struct ExpectFinished {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     randoms: ConnectionRandoms,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
@@ -1056,7 +1056,7 @@ impl hs::State for ExpectFinished {
 // In this state we can be sent tickets, keyupdates,
 // and application data.
 struct ExpectTraffic {
-    dns_name: webpki::DNSName,
+    dns_name: webpki::DnsName,
     suite: &'static SupportedCipherSuite,
     transcript: HandshakeHash,
     key_schedule: KeyScheduleTraffic,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -127,7 +127,7 @@
 //! #     trusted_ct_logs,
 //! #     rustls::DEFAULT_CIPHERSUITES);
 //! let rc_config = Arc::new(config);
-//! let example_com = webpki::DNSNameRef::try_from_ascii_str("example.com").unwrap();
+//! let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
 //! let mut client = rustls::ClientConnection::new(&rc_config, example_com);
 //! ```
 //!

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -3,7 +3,7 @@ use super::codec::{put_u16, Codec, Reader};
 use super::enums::*;
 use super::handshake::*;
 use crate::key::Certificate;
-use webpki::DNSNameRef;
+use webpki::DnsNameRef;
 
 use std::mem;
 
@@ -368,7 +368,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::ECPointFormats(ECPointFormatList::supported()),
             ClientExtension::NamedGroups(vec![NamedGroup::X25519]),
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
-            ClientExtension::make_sni(DNSNameRef::try_from_ascii_str("hello").unwrap()),
+            ClientExtension::make_sni(DnsNameRef::try_from_ascii_str("hello").unwrap()),
             ClientExtension::SessionTicketRequest,
             ClientExtension::SessionTicketOffer(Payload(vec![])),
             ClientExtension::Protocols(vec![PayloadU8(vec![0])]),

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -32,7 +32,7 @@ impl Codec for ClientSessionKey {
 }
 
 impl ClientSessionKey {
-    pub fn session_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
+    pub fn session_for_dns_name(dns_name: webpki::DnsNameRef) -> ClientSessionKey {
         let dns_name_str: &str = dns_name.into();
         ClientSessionKey {
             kind: b"session",
@@ -40,7 +40,7 @@ impl ClientSessionKey {
         }
     }
 
-    pub fn hint_for_dns_name(dns_name: webpki::DNSNameRef) -> ClientSessionKey {
+    pub fn hint_for_dns_name(dns_name: webpki::DnsNameRef) -> ClientSessionKey {
         let dns_name_str: &str = dns_name.into();
         ClientSessionKey {
             kind: b"kx-hint",
@@ -209,7 +209,7 @@ pub type ServerSessionKey = SessionID;
 
 #[derive(Debug)]
 pub struct ServerSessionValue {
-    pub sni: Option<webpki::DNSName>,
+    pub sni: Option<webpki::DnsName>,
     pub version: ProtocolVersion,
     pub cipher_suite: CipherSuite,
     pub master_secret: PayloadU8,
@@ -251,7 +251,7 @@ impl Codec for ServerSessionValue {
         let has_sni = u8::read(r)?;
         let sni = if has_sni == 1 {
             let dns_name = PayloadU8::read(r)?;
-            let dns_name = webpki::DNSNameRef::try_from_ascii(&dns_name.0).ok()?;
+            let dns_name = webpki::DnsNameRef::try_from_ascii(&dns_name.0).ok()?;
             Some(dns_name.into())
         } else {
             None
@@ -289,7 +289,7 @@ impl Codec for ServerSessionValue {
 
 impl ServerSessionValue {
     pub fn new(
-        sni: Option<&webpki::DNSName>,
+        sni: Option<&webpki::DnsName>,
         v: ProtocolVersion,
         cs: CipherSuite,
         ms: Vec<u8>,

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -4,11 +4,11 @@ use super::handshake::*;
 use super::persist::*;
 use crate::key::Certificate;
 use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
-use webpki::DNSNameRef;
+use webpki::DnsNameRef;
 
 #[test]
 fn clientsessionkey_is_debug() {
-    let name = DNSNameRef::try_from_ascii_str("hello").unwrap();
+    let name = DnsNameRef::try_from_ascii_str("hello").unwrap();
     let csk = ClientSessionKey::session_for_dns_name(name);
     println!("{:?}", csk);
 }

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -152,7 +152,7 @@ impl ResolvesServerCertUsingSni {
     /// it's not valid for the supplied certificate, or if the certificate
     /// chain is syntactically faulty.
     pub fn add(&mut self, name: &str, ck: sign::CertifiedKey) -> Result<(), Error> {
-        let checked_name = webpki::DNSNameRef::try_from_ascii_str(name)
+        let checked_name = webpki::DnsNameRef::try_from_ascii_str(name)
             .map_err(|_| Error::General("Bad DNS name".into()))?;
 
         ck.cross_check_end_entity_cert(Some(checked_name))?;
@@ -273,7 +273,7 @@ mod test {
     #[test]
     fn test_resolvesservercertusingsni_handles_unknown_name() {
         let rscsni = ResolvesServerCertUsingSni::new();
-        let name = webpki::DNSNameRef::try_from_ascii_str("hello.com").unwrap();
+        let name = webpki::DnsNameRef::try_from_ascii_str("hello.com").unwrap();
         assert!(
             rscsni
                 .resolve(ClientHello::new(Some(name), &[], None))

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -75,7 +75,7 @@ pub fn decode_error(conn: &mut ServerConnection, why: &str) -> Error {
 
 pub fn can_resume(
     suite: &'static SupportedCipherSuite,
-    sni: &Option<webpki::DNSName>,
+    sni: &Option<webpki::DnsName>,
     using_ems: bool,
     resumedata: persist::ServerSessionValue,
 ) -> Option<persist::ServerSessionValue> {
@@ -99,7 +99,7 @@ pub fn can_resume(
 
 // Require an exact match for the purpose of comparing SNI DNS Names from two
 // client hellos, even though a case-insensitive comparison might also be OK.
-fn same_dns_name_or_both_none(a: Option<&webpki::DNSName>, b: Option<&webpki::DNSName>) -> bool {
+fn same_dns_name_or_both_none(a: Option<&webpki::DnsName>, b: Option<&webpki::DnsName>) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => {
             let a: &str = a.as_ref().into();
@@ -127,7 +127,7 @@ pub fn check_aligned_handshake(conn: &mut ServerConnection) -> Result<(), Error>
     }
 }
 
-pub fn save_sni(conn: &mut ServerConnection, sni: Option<webpki::DNSName>) {
+pub fn save_sni(conn: &mut ServerConnection, sni: Option<webpki::DnsName>) {
     if let Some(sni) = sni {
         // Save the SNI into the session.
         conn.set_sni(sni);
@@ -531,7 +531,7 @@ impl ExpectClientHello {
         conn: &mut ServerConnection,
         client_hello: &ClientHelloPayload,
         suite: &'static SupportedCipherSuite,
-        sni: Option<&webpki::DNSName>,
+        sni: Option<&webpki::DnsName>,
         id: &SessionID,
         resumedata: persist::ServerSessionValue,
         randoms: &ConnectionRandoms,
@@ -644,7 +644,7 @@ impl State for ExpectClientHello {
         // send an Illegal Parameter alert instead of the Internal Error alert
         // (or whatever) that we'd send if this were checked later or in a
         // different way.
-        let sni: Option<webpki::DNSName> = match client_hello.get_sni_extension() {
+        let sni: Option<webpki::DnsName> = match client_hello.get_sni_extension() {
             Some(sni) => {
                 if sni.has_duplicate_names_for_type() {
                     return Err(decode_error(
@@ -697,7 +697,7 @@ impl State for ExpectClientHello {
         let certkey = {
             let sni_ref = sni
                 .as_ref()
-                .map(webpki::DNSName::as_ref);
+                .map(webpki::DnsName::as_ref);
             trace!("sni {:?}", sni_ref);
             trace!("sig schemes {:?}", sigschemes_ext);
             trace!("alpn protocols {:?}", alpn_protocols);

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -102,7 +102,7 @@ pub trait ResolvesServerCert: Send + Sync {
 
 /// A struct representing the received Client Hello
 pub struct ClientHello<'a> {
-    server_name: Option<webpki::DNSNameRef<'a>>,
+    server_name: Option<webpki::DnsNameRef<'a>>,
     signature_schemes: &'a [SignatureScheme],
     alpn: Option<&'a [&'a [u8]]>,
 }
@@ -110,7 +110,7 @@ pub struct ClientHello<'a> {
 impl<'a> ClientHello<'a> {
     /// Creates a new ClientHello
     fn new(
-        server_name: Option<webpki::DNSNameRef<'a>>,
+        server_name: Option<webpki::DnsNameRef<'a>>,
         signature_schemes: &'a [SignatureScheme],
         alpn: Option<&'a [&'a [u8]]>,
     ) -> Self {
@@ -124,7 +124,7 @@ impl<'a> ClientHello<'a> {
     /// Get the server name indicator.
     ///
     /// Returns `None` if the client did not supply a SNI.
-    pub fn server_name(&self) -> Option<webpki::DNSNameRef> {
+    pub fn server_name(&self) -> Option<webpki::DnsNameRef> {
         self.server_name
     }
 
@@ -344,7 +344,7 @@ impl ServerConfig {
 pub struct ServerConnection {
     config: Arc<ServerConfig>,
     common: ConnectionCommon,
-    sni: Option<webpki::DNSName>,
+    sni: Option<webpki::DnsName>,
     received_resumption_data: Option<Vec<u8>>,
     resumption_data: Vec<u8>,
     state: Option<Box<dyn hs::State + Send + Sync>>,
@@ -442,11 +442,11 @@ impl ServerConnection {
             .map(|s| s.as_ref().into())
     }
 
-    fn get_sni(&self) -> Option<&webpki::DNSName> {
+    fn get_sni(&self) -> Option<&webpki::DnsName> {
         self.sni.as_ref()
     }
 
-    fn set_sni(&mut self, value: webpki::DNSName) {
+    fn set_sni(&mut self, value: webpki::DnsName) {
         // The SNI hostname is immutable once set.
         assert!(self.sni.is_none());
         self.sni = Some(value)

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -4,6 +4,7 @@ use crate::msgs::enums::{SignatureAlgorithm, SignatureScheme};
 
 use ring::signature::{self, EcdsaKeyPair, Ed25519KeyPair, RsaKeyPair};
 
+use std::convert::TryFrom;
 use std::mem;
 use std::sync::Arc;
 
@@ -82,7 +83,7 @@ impl CertifiedKey {
     /// *server* attempting to detect accidental misconfiguration.
     pub fn cross_check_end_entity_cert(
         &self,
-        name: Option<webpki::DNSNameRef>,
+        name: Option<webpki::DnsNameRef>,
     ) -> Result<(), Error> {
         // Always reject an empty certificate chain.
         let end_entity_cert = self
@@ -93,7 +94,7 @@ impl CertifiedKey {
 
         // Reject syntactically-invalid end-entity certificates.
         let end_entity_cert =
-            webpki::EndEntityCert::from(end_entity_cert.as_ref()).map_err(|_| {
+            webpki::EndEntityCert::try_from(end_entity_cert.as_ref()).map_err(|_| {
                 Error::General(
                     "End-entity certificate in certificate \
                                   chain is syntactically invalid"

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -212,7 +212,7 @@ impl Context {
         let (end_entity, intermediates) = self.chain.split_first().unwrap();
         for _ in 0..count {
             let start = Instant::now();
-            let dns_name = webpki::DNSNameRef::try_from_ascii_str(self.domain).unwrap();
+            let dns_name = webpki::DnsNameRef::try_from_ascii_str(self.domain).unwrap();
             verifier
                 .verify_server_cert(
                     end_entity,

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -611,7 +611,7 @@ impl ClientCheckCertResolve {
     fn new(expect_queries: usize) -> ClientCheckCertResolve {
         ClientCheckCertResolve {
             query_count: AtomicUsize::new(0),
-            expect_queries: expect_queries,
+            expect_queries,
         }
     }
 }
@@ -1685,7 +1685,7 @@ fn server_exposes_offered_sni() {
 
 #[test]
 fn server_exposes_offered_sni_smashed_to_lowercase() {
-    // webpki actually does this for us in its DNSName type
+    // webpki actually does this for us in its DnsName type
     let kt = KeyType::RSA;
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut client =

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -340,7 +340,7 @@ pub struct MockClientVerifier {
 
 #[cfg(feature = "dangerous_configuration")]
 impl ClientCertVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self, sni: Option<&webpki::DNSName>) -> Option<bool> {
+    fn client_auth_mandatory(&self, sni: Option<&webpki::DnsName>) -> Option<bool> {
         // This is just an added 'test' to make sure we plumb through the SNI,
         // although its valid for it to be None, its just our tests should (as of now) always provide it
         assert!(sni.is_some());
@@ -349,7 +349,7 @@ impl ClientCertVerifier for MockClientVerifier {
 
     fn client_auth_root_subjects(
         &self,
-        sni: Option<&webpki::DNSName>,
+        sni: Option<&webpki::DnsName>,
     ) -> Option<DistinguishedNames> {
         assert!(sni.is_some());
         self.subjects.as_ref().cloned()
@@ -359,7 +359,7 @@ impl ClientCertVerifier for MockClientVerifier {
         &self,
         _end_entity: &Certificate,
         _intermediates: &[Certificate],
-        sni: Option<&webpki::DNSName>,
+        sni: Option<&webpki::DnsName>,
         _now: std::time::SystemTime,
     ) -> Result<ClientCertVerified, Error> {
         assert!(sni.is_some());
@@ -430,8 +430,8 @@ pub fn do_handshake_until_both_error(
     }
 }
 
-pub fn dns_name(name: &'static str) -> webpki::DNSNameRef<'_> {
-    webpki::DNSNameRef::try_from_ascii_str(name).unwrap()
+pub fn dns_name(name: &'static str) -> webpki::DnsNameRef<'_> {
+    webpki::DnsNameRef::try_from_ascii_str(name).unwrap()
 }
 
 pub struct FailsReads {


### PR DESCRIPTION
webpki 0.22.0 has breaking API changes. The most notable change is the
renaming of some types to conform to Rust naming conventions, in support
of Rustls's recent similar effort.

This depends on https://github.com/ctz/webpki-roots/pull/21.