### PR TITLE
Remove unintended webpki-roots patch from Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ members = [
   "rustls-mio",
 ]
 exclude = ["admin/rustfmt"]
-
-[patches.crates-io]
-webpki-roots = { path = "../webpki-roots" }


### PR DESCRIPTION
This patch was part of the WIP PR but wasn't intended to be part of the
merged commit.