### PR TITLE
server: simplify SNI handling and make it more robust

### DIFF
--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -77,29 +77,12 @@ pub fn can_resume(
 
     if resumedata.cipher_suite == suite.suite
         && (resumedata.extended_ms == using_ems || (resumedata.extended_ms && !using_ems))
-        && same_dns_name_or_both_none(resumedata.sni.as_ref(), sni.as_ref())
+        && &resumedata.sni == sni
     {
         return Some(resumedata);
     }
 
     None
-}
-
-// Require an exact match for the purpose of comparing SNI DNS Names from two
-// client hellos, even though a case-insensitive comparison might also be OK.
-pub(super) fn same_dns_name_or_both_none(
-    a: Option<&webpki::DnsName>,
-    b: Option<&webpki::DnsName>,
-) -> bool {
-    match (a, b) {
-        (Some(a), Some(b)) => {
-            let a: &str = a.as_ref().into();
-            let b: &str = b.as_ref().into();
-            a == b
-        }
-        (None, None) => true,
-        _ => false,
-    }
 }
 
 // Changing the keys must not span any fragmented handshake

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -118,15 +118,6 @@ pub fn check_aligned_handshake(conn: &mut ServerConnection) -> Result<(), Error>
     }
 }
 
-pub fn save_sni(conn: &mut ServerConnection, sni: Option<webpki::DnsName>) {
-    if let Some(sni) = sni {
-        // Save the SNI into the session.
-        // The SNI hostname is immutable once set.
-        assert!(conn.sni.is_none());
-        conn.sni = Some(sni);
-    }
-}
-
 #[derive(Default)]
 pub struct ExtensionProcessing {
     // extensions to reply with
@@ -416,9 +407,12 @@ impl State for ExpectClientHello {
             None => None,
         };
 
-        if !self.done_retry {
-            // save only the first SNI
-            save_sni(conn, sni.clone());
+        // save only the first SNI
+        if let (Some(sni), false) = (&sni, self.done_retry) {
+            // Save the SNI into the session.
+            // The SNI hostname is immutable once set.
+            assert!(conn.sni.is_none());
+            conn.sni = Some(sni.clone());
         }
 
         // We communicate to the upper layer what kind of key they should choose

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -121,7 +121,9 @@ pub fn check_aligned_handshake(conn: &mut ServerConnection) -> Result<(), Error>
 pub fn save_sni(conn: &mut ServerConnection, sni: Option<webpki::DnsName>) {
     if let Some(sni) = sni {
         // Save the SNI into the session.
-        conn.set_sni(sni);
+        // The SNI hostname is immutable once set.
+        assert!(conn.sni.is_none());
+        conn.sni = Some(sni);
     }
 }
 

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -390,6 +390,10 @@ impl State for ExpectClientHello {
             // The SNI hostname is immutable once set.
             assert!(conn.sni.is_none());
             conn.sni = Some(sni.clone());
+        } else if conn.sni != sni {
+            return Err(Error::PeerIncompatibleError(
+                "SNI differed on retry".to_string(),
+            ));
         }
 
         // We communicate to the upper layer what kind of key they should choose
@@ -508,7 +512,6 @@ impl State for ExpectClientHello {
                 &m,
                 client_hello,
                 sigschemes_ext,
-                sni,
                 tls13_enabled,
             )
         }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -65,8 +65,8 @@ pub fn can_resume(
     suite: &'static SupportedCipherSuite,
     sni: &Option<webpki::DnsName>,
     using_ems: bool,
-    resumedata: persist::ServerSessionValue,
-) -> Option<persist::ServerSessionValue> {
+    resumedata: &persist::ServerSessionValue,
+) -> bool {
     // The RFCs underspecify what happens if we try to resume to
     // an unoffered/varying suite.  We merely don't resume in weird cases.
     //
@@ -74,15 +74,9 @@ pub fn can_resume(
     // the request to resume the session if the server_name extension contains
     // a different name. Instead, it proceeds with a full handshake to
     // establish a new session."
-
-    if resumedata.cipher_suite == suite.suite
+    resumedata.cipher_suite == suite.suite
         && (resumedata.extended_ms == using_ems || (resumedata.extended_ms && !using_ems))
         && &resumedata.sni == sni
-    {
-        return Some(resumedata);
-    }
-
-    None
 }
 
 // Changing the keys must not span any fragmented handshake

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -448,12 +448,6 @@ impl ServerConnection {
         self.sni.as_ref()
     }
 
-    fn set_sni(&mut self, value: webpki::DnsName) {
-        // The SNI hostname is immutable once set.
-        assert!(self.sni.is_none());
-        self.sni = Some(value)
-    }
-
     /// Application-controlled portion of the resumption ticket supplied by the client, if any.
     ///
     /// Recovered from the prior session's `set_resumption_data`. Integrity is guaranteed by rustls.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -132,12 +132,6 @@ mod client_hello {
                 }
             }
 
-            // If we're not offered a ticket or a potential connion ID,
-            // allocate a connion ID.
-            if self.handshake.session_id.is_empty() && !ticket_received {
-                self.handshake.session_id = SessionID::random()?;
-            }
-
             // Perhaps resume?  If we received a ticket, the connionid
             // does not correspond to a real connion.
             if !client_hello.session_id.is_empty() && !ticket_received {
@@ -187,6 +181,12 @@ mod client_hello {
 
             let (mut ocsp_response, mut sct_list) =
                 (server_key.get_ocsp(), server_key.get_sct_list());
+
+            // If we're not offered a ticket or a potential connection ID,
+            // allocate a connection ID.
+            if self.handshake.session_id.is_empty() && !ticket_received {
+                self.handshake.session_id = SessionID::random()?;
+            }
 
             self.send_ticket = emit_server_hello(
                 &mut self.handshake,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -279,7 +279,7 @@ mod client_hello {
                 .start_encrypting();
             emit_finished(&secrets, &mut self.handshake, conn);
 
-            assert!(hs::same_dns_name_or_both_none(sni, conn.get_sni()));
+            assert_eq!(sni, conn.get_sni());
 
             Ok(Box::new(ExpectCcs {
                 secrets,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -104,54 +104,45 @@ mod client_hello {
             // our handling of the ClientHello.
             //
             let mut ticket_received = false;
+            let resume_data = client_hello
+                .get_ticket_extension()
+                .and_then(|ticket_ext| match ticket_ext {
+                    ClientExtension::SessionTicketOffer(ticket) => Some(ticket),
+                    _ => None,
+                })
+                .and_then(|ticket| {
+                    ticket_received = true;
+                    debug!("Ticket received");
+                    let data = conn.config.ticketer.decrypt(&ticket.0);
+                    if data.is_none() {
+                        debug!("Ticket didn't decrypt");
+                    }
+                    data
+                })
+                .or_else(|| {
+                    // Perhaps resume?  If we received a ticket, the sessionid
+                    // does not correspond to a real session.
+                    if client_hello.session_id.is_empty() || ticket_received {
+                        return None;
+                    }
 
-            if let Some(ClientExtension::SessionTicketOffer(ref ticket)) =
-                client_hello.get_ticket_extension()
-            {
-                ticket_received = true;
-                debug!("Ticket received");
+                    conn.config
+                        .session_storage
+                        .get(&client_hello.session_id.get_encoding())
+                })
+                .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
+                .and_then(|resumedata| {
+                    hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
+                });
 
-                if let Some(resume) = conn
-                    .config
-                    .ticketer
-                    .decrypt(&ticket.0)
-                    .and_then(|plain| persist::ServerSessionValue::read_bytes(&plain))
-                    .and_then(|resumedata| {
-                        hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
-                    })
-                {
-                    return self.start_resumption(
-                        conn,
-                        client_hello,
-                        sni.as_ref(),
-                        &client_hello.session_id,
-                        resume,
-                    );
-                } else {
-                    debug!("Ticket didn't decrypt");
-                }
-            }
-
-            // Perhaps resume?  If we received a ticket, the connionid
-            // does not correspond to a real connion.
-            if !client_hello.session_id.is_empty() && !ticket_received {
-                if let Some(resume) = conn
-                    .config
-                    .session_storage
-                    .get(&client_hello.session_id.get_encoding())
-                    .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
-                    .and_then(|resumedata| {
-                        hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
-                    })
-                {
-                    return self.start_resumption(
-                        conn,
-                        client_hello,
-                        sni.as_ref(),
-                        &client_hello.session_id,
-                        resume,
-                    );
-                }
+            if let Some(data) = resume_data {
+                return self.start_resumption(
+                    conn,
+                    client_hello,
+                    sni.as_ref(),
+                    &client_hello.session_id,
+                    data,
+                );
             }
 
             // Now we have chosen a ciphersuite, we can make kx decisions.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -131,7 +131,7 @@ mod client_hello {
                         .get(&client_hello.session_id.get_encoding())
                 })
                 .and_then(|x| persist::ServerSessionValue::read_bytes(&x))
-                .and_then(|resumedata| {
+                .filter(|resumedata| {
                     hs::can_resume(self.suite, &conn.sni, self.using_ems, resumedata)
                 });
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -215,7 +215,7 @@ mod client_hello {
                 for (i, psk_id) in psk_offer.identities.iter().enumerate() {
                     let resume = match self
                         .attempt_tls13_ticket_decryption(conn, &psk_id.identity.0)
-                        .and_then(|resumedata| {
+                        .filter(|resumedata| {
                             hs::can_resume(self.suite, &conn.sni, false, resumedata)
                         }) {
                         Some(resume) => resume,


### PR DESCRIPTION
Replaces an assertion with an `Error` and removes about 50 lines of code (net).