### PR TITLE
Client: Fix client key share selection during HelloRetryRequest.

### DIFF
--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -1,8 +1,6 @@
-use crate::kx;
 #[cfg(feature = "logging")]
 use crate::log::trace;
 use crate::msgs::enums::ExtensionType;
-use crate::msgs::enums::NamedGroup;
 use crate::msgs::handshake::CertificatePayload;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::SCTList;
@@ -55,46 +53,18 @@ impl ServerKxDetails {
 
 pub struct ClientHelloDetails {
     pub sent_extensions: Vec<ExtensionType>,
-    pub offered_key_shares: Vec<kx::KeyExchange>,
 }
 
 impl ClientHelloDetails {
     pub fn new() -> ClientHelloDetails {
         ClientHelloDetails {
             sent_extensions: Vec::new(),
-            offered_key_shares: Vec::new(),
         }
     }
 
     pub fn server_may_send_sct_list(&self) -> bool {
         self.sent_extensions
             .contains(&ExtensionType::SCT)
-    }
-
-    pub fn has_key_share(&self, group: NamedGroup) -> bool {
-        self.offered_key_shares
-            .iter()
-            .any(|share| share.group() == group)
-    }
-
-    pub fn find_key_share(&mut self, group: NamedGroup) -> Option<kx::KeyExchange> {
-        self.offered_key_shares
-            .iter()
-            .position(|s| s.group() == group)
-            .map(|idx| self.offered_key_shares.remove(idx))
-    }
-
-    pub fn find_key_share_and_discard_others(
-        &mut self,
-        group: NamedGroup,
-    ) -> Option<kx::KeyExchange> {
-        match self.find_key_share(group) {
-            Some(group) => {
-                self.offered_key_shares.clear();
-                Some(group)
-            }
-            None => None,
-        }
     }
 
     pub fn server_sent_unsolicited_extensions(

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -789,18 +789,6 @@ impl ExpectServerHelloOrHelloRetryRequest {
                 .illegal_param("server requested hrr with our group"));
         }
 
-        // Or asks for us to retry on an unsupported group.
-        let req_group = if let Some(group) = req_group {
-            Some(
-                kx::KeyExchange::choose(group, &conn.config.kx_groups).ok_or_else(|| {
-                    conn.common
-                        .illegal_param("server requested hrr with bad group")
-                })?,
-            )
-        } else {
-            None
-        };
-
         // Or has an empty cookie.
         if let Some(cookie) = cookie {
             if cookie.0.is_empty() {
@@ -879,7 +867,12 @@ impl ExpectServerHelloOrHelloRetryRequest {
             .server_may_send_sct_list();
 
         let key_share = match req_group {
-            Some(group) if group.name != offered_key_share.group() => {
+            Some(group) if group != offered_key_share.group() => {
+                let group =
+                    kx::KeyExchange::choose(group, &conn.config.kx_groups).ok_or_else(|| {
+                        conn.common
+                            .illegal_param("server requested hrr with bad group")
+                    })?;
                 kx::KeyExchange::start(group).ok_or(Error::FailedToGetRandomBytes)?
             }
             _ => offered_key_share,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -16,11 +16,11 @@ use crate::msgs::codec::Codec;
 use crate::msgs::enums::KeyUpdateRequest;
 use crate::msgs::enums::{AlertDescription, NamedGroup, ProtocolVersion};
 use crate::msgs::enums::{ContentType, ExtensionType, HandshakeType, SignatureScheme};
+use crate::msgs::handshake::ClientExtension;
 use crate::msgs::handshake::DigitallySignedStruct;
 use crate::msgs::handshake::EncryptedExtensions;
 use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
 use crate::msgs::handshake::{CertificateEntry, CertificatePayloadTLS13};
-use crate::msgs::handshake::{ClientExtension, HelloRetryRequest, KeyShareEntry};
 use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
 use crate::msgs::handshake::{HasServerExtensions, ServerHelloPayload, SessionID};
 use crate::msgs::handshake::{PresharedKeyIdentity, PresharedKeyOffer};
@@ -73,7 +73,10 @@ pub fn validate_server_hello(
     Ok(())
 }
 
-fn find_kx_hint(conn: &ClientConnection, dns_name: webpki::DnsNameRef) -> Option<NamedGroup> {
+pub(super) fn initial_key_share(
+    conn: &ClientConnection,
+    dns_name: webpki::DnsNameRef,
+) -> Result<kx::KeyExchange, Error> {
     let key = persist::ClientSessionKey::hint_for_dns_name(dns_name);
     let key_buf = key.get_encoding();
 
@@ -81,7 +84,19 @@ fn find_kx_hint(conn: &ClientConnection, dns_name: webpki::DnsNameRef) -> Option
         .config
         .session_persistence
         .get(&key_buf);
-    maybe_value.and_then(|enc| NamedGroup::read_bytes(&enc))
+
+    let group = maybe_value
+        .and_then(|enc| NamedGroup::read_bytes(&enc))
+        .and_then(|group| kx::KeyExchange::choose(group, &conn.config.kx_groups))
+        .unwrap_or_else(|| {
+            *conn
+                .config
+                .kx_groups
+                .first()
+                .expect("No kx groups configured")
+        });
+
+    kx::KeyExchange::start(group).ok_or(Error::FailedToGetRandomBytes)
 }
 
 fn save_kx_hint(conn: &mut ClientConnection, dns_name: webpki::DnsNameRef, group: NamedGroup) {
@@ -90,52 +105,6 @@ fn save_kx_hint(conn: &mut ClientConnection, dns_name: webpki::DnsNameRef, group
     conn.config
         .session_persistence
         .put(key.get_encoding(), group.get_encoding());
-}
-
-pub fn choose_kx_groups(
-    conn: &ClientConnection,
-    exts: &mut Vec<ClientExtension>,
-    hello: &mut ClientHelloDetails,
-    dns_name: webpki::DnsNameRef,
-    retryreq: Option<&HelloRetryRequest>,
-) {
-    // Choose our groups:
-    // - if we've been asked via HelloRetryRequest for a specific
-    //   one, do that.
-    // - if not, we might have a hint of what the server supports.
-    // - if not, send just the first configured group.
-    //
-    let group = retryreq
-        .and_then(|req| HelloRetryRequest::get_requested_key_share_group(req))
-        .or_else(|| find_kx_hint(conn, dns_name))
-        .unwrap_or_else(|| {
-            conn.config
-                .kx_groups
-                .get(0)
-                .expect("No kx groups configured")
-                .name
-        });
-
-    let mut key_shares = vec![];
-
-    // in reply to HelloRetryRequest, we must not alter any existing key
-    // shares
-    if let Some(already_offered_share) = hello.find_key_share(group) {
-        key_shares.push(KeyShareEntry::new(
-            group,
-            already_offered_share.pubkey.as_ref(),
-        ));
-        hello
-            .offered_key_shares
-            .push(already_offered_share);
-    } else if let Some(key_share) =
-        kx::KeyExchange::choose(group, &conn.config.kx_groups).and_then(kx::KeyExchange::start)
-    {
-        key_shares.push(KeyShareEntry::new(group, key_share.pubkey.as_ref()));
-        hello.offered_key_shares.push(key_share);
-    }
-
-    exts.push(ClientExtension::KeyShare(key_shares));
 }
 
 /// This implements the horrifying TLS1.3 hack where PSK binders have a
@@ -175,7 +144,7 @@ pub fn start_handshake_traffic(
     resuming_session: &mut Option<persist::ClientSessionValueWithResolvedCipherSuite>,
     dns_name: webpki::DnsNameRef,
     transcript: &mut HandshakeHash,
-    hello: &mut ClientHelloDetails,
+    our_key_share: kx::KeyExchange,
     randoms: &ConnectionRandoms,
 ) -> Result<(KeyScheduleHandshake, Digest), Error> {
     let their_key_share = server_hello
@@ -186,12 +155,11 @@ pub fn start_handshake_traffic(
             Error::PeerMisbehavedError("missing key share".to_string())
         })?;
 
-    let our_key_share = hello
-        .find_key_share_and_discard_others(their_key_share.group)
-        .ok_or_else(|| {
-            conn.common
-                .illegal_param("wrong group for key share")
-        })?;
+    if our_key_share.group() != their_key_share.group {
+        return Err(conn
+            .common
+            .illegal_param("wrong group for key share"));
+    }
     let shared = our_key_share
         .complete(&their_key_share.payload.0)
         .ok_or_else(|| Error::PeerMisbehavedError("key exchange failed".to_string()))?;


### PR DESCRIPTION
During a HelloRetryRequest (HRR), if the HRR didn't request a different algorithm, then
we must send the same key share we sent before. During a retry we must never look up the
key share algorithm to use from the cache (`.or_else(|| find_kx_hint(conn, dns_name)`) in
the old code), because the cache contents may have changed since the initial HRR. Only
`emit_initial_client_hello` is allowed to read from the cache. (In a future refactoring, we
should enforce this with the type system.)

It turns out that the selection criteria for shares is completely disjoint between
initial and retry hellos. Instead of grouping the two code paths into one function, split
them into separate code paths.

When we are selecting the initial key share, and we find a the server's selected key share
grou pin the cache, and that group is not enabled for the current group, then fall back to
the default algorithm. Previously, we just kept going without any key share! Similarly, if
agreement key generation fails, stop with an error instead of siliently continuing without
sending a key share(!):

```diff
- else if let Some(key_share) =
-        kx::KeyExchange::choose(group, &conn.config.kx_groups).and_then(kx::KeyExchange::start)
```

We either send one key share (if TLS 1.3 is enabled) or zero (if it isn't). Encode this in
the types used, instead of using `Vec`s.

Move the offered key share out of `ClientHelloDetails` so that we can move it during HRR
processing. (In the future we should remove `ClientHelloDetails`.)
