### PR TITLE
Abort connection if no QUIC transport parameters are found

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -440,8 +440,15 @@ impl hs::State for ExpectEncryptedExtensions {
         #[cfg(feature = "quic")]
         {
             // QUIC transport parameters
-            if let Some(params) = exts.get_quic_params_extension() {
-                conn.common.quic.params = Some(params);
+            if conn.common.is_quic() {
+                match exts.get_quic_params_extension() {
+                    Some(params) => conn.common.quic.params = Some(params),
+                    None => {
+                        return Err(conn
+                            .common
+                            .missing_extension("QUIC transport parameters not found"));
+                    }
+                }
             }
         }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -958,6 +958,12 @@ impl ConnectionCommon {
             .prepare_message_decrypter(dec);
     }
 
+    #[cfg(feature = "quic")]
+    pub fn missing_extension(&mut self, why: &str) -> Error {
+        self.send_fatal_alert(AlertDescription::MissingExtension);
+        Error::PeerMisbehavedError(why.to_string())
+    }
+
     pub fn send_warning_alert(&mut self, desc: AlertDescription) {
         warn!("Sending warning alert {:?}", desc);
         self.send_warning_alert_no_log(desc);

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -32,6 +32,12 @@ impl Secrets {
 /// Generic methods for QUIC sessions
 pub trait QuicExt {
     /// Return the TLS-encoded transport parameters for the session's peer.
+    ///
+    /// While the transport parameters are technically available prior to the
+    /// completion of the handshake, they cannot be fully trusted until the
+    /// handshake completes, and reliance on them should be minimized.
+    /// However, any tampering with the parameters will cause the handshake
+    /// to fail.
     fn get_quic_transport_parameters(&self) -> Option<&[u8]>;
 
     /// Compute the keys for encrypting/decrypting 0-RTT packets, if available

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -157,9 +157,14 @@ impl ExtensionProcessing {
 
         #[cfg(feature = "quic")]
         {
-            if conn.common.protocol == Protocol::Quic {
-                if let Some(params) = hello.get_quic_params_extension() {
-                    conn.common.quic.params = Some(params);
+            if conn.common.is_quic() {
+                match hello.get_quic_params_extension() {
+                    Some(params) => conn.common.quic.params = Some(params),
+                    None => {
+                        return Err(conn
+                            .common
+                            .missing_extension("QUIC transport parameters not found"));
+                    }
                 }
 
                 if let Some(resume) = resumedata {


### PR DESCRIPTION
cc @Ralith 