### PR TITLE
Ticketer: Avoid panicking.

### DIFF
--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -143,7 +143,7 @@ impl TicketSwitcher {
     ///
     /// Calling this regularly will ensure timely key erasure.  Otherwise,
     /// key erasure will be delayed until the next encrypt/decrypt call.
-    pub fn maybe_roll(&self) -> Result<(), rand::GetRandomFailed> {
+    fn maybe_roll(&self) -> Result<(), rand::GetRandomFailed> {
         let mut state = self.state.lock().unwrap();
         let now = timebase();
 

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -165,7 +165,7 @@ impl ProducesTickets for TicketSwitcher {
     }
 
     fn encrypt(&self, message: &[u8]) -> Option<Vec<u8>> {
-        self.maybe_roll().unwrap();
+        self.maybe_roll().ok()?;
 
         self.state
             .lock()
@@ -175,7 +175,7 @@ impl ProducesTickets for TicketSwitcher {
     }
 
     fn decrypt(&self, ciphertext: &[u8]) -> Option<Vec<u8>> {
-        self.maybe_roll().unwrap();
+        self.maybe_roll().ok()?;
 
         // Decrypt with the current key; if that fails, try with the previous.
         let state = self.state.lock().unwrap();


### PR DESCRIPTION
Or, more generally, avoid panicking if the generator failed.

Also refactor the locking logic to allow more of the unwraps to be avoided.

```
Before: Lock. Maybe roll. Unlock. Lock. Do the work. Unlock.
After:  Lock. Maybe roll.               Do the work. Unlock.
```

This is still not ideal because the lock is held too long, and held over
inappropriate operations (syscalls). I will file a separate issue about
that. It was the case before this change as well.

