### PR TITLE
Avoid panicking in the unlikely case that the time is set very wrong.

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -3,6 +3,7 @@ use crate::rand;
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::time::SystemTimeError;
 
 /// The reason WebPKI operation was performed, used in [`Error`].
 #[derive(Debug, PartialEq, Clone)]
@@ -155,6 +156,13 @@ impl fmt::Display for Error {
             Error::FailedToGetRandomBytes => write!(f, "failed to get random bytes"),
             Error::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
         }
+    }
+}
+
+impl From<SystemTimeError> for Error {
+    #[inline]
+    fn from(_: SystemTimeError) -> Self {
+        Self::FailedToGetCurrentTime
     }
 }
 

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -4,6 +4,7 @@ use super::handshake::*;
 use super::persist::*;
 use crate::key::Certificate;
 use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
+use crate::ticketer::TimeBase;
 use webpki::DnsNameRef;
 
 #[test]
@@ -29,6 +30,7 @@ fn clientsessionvalue_is_debug() {
         vec![],
         vec![1, 2, 3],
         &vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
+        TimeBase::now().unwrap(),
     );
     println!("{:?}", csv);
 }


### PR DESCRIPTION
If the system time is set to before the Unix epoch (probably not possible on
most operating systems) then computing the duration since the Unix epoch will
fail. Avoid that very unlikely case.

Add the time of retrieval (storage) to `ClientSessionValueWithResolvedCipherSuite`
since the lifetime of the needed time is exactly the lifetime of the value of that
type. (Perhaps `ClientSessionValueWithResolvedCipherSuite` could be given a better
name.)

In the future, if we were to refactor the `Ticekter` API to accept the current time
then we could probably reduce the number of times the current time is retrieved by
adding a `TimeBase` parameter to each of `encrypt()` and `decrypt()`.

Also stengthen the type used to represent the current time from `u64` to a new
`TimeBase` type.