### PR TITLE
Further deduplicate client/server session handling

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -910,7 +910,7 @@ impl State for ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-pub fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
+pub(super) fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
     match err {
         Error::WebPkiError(webpki::Error::BadDer, _) => {
             common.send_fatal_alert(AlertDescription::DecodeError);

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -53,6 +53,26 @@ pub(super) trait State {
     fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
 }
 
+impl crate::conn::HandleState for Box<dyn State + Send + Sync> {
+    type Data = ClientConnectionData;
+    type Config = ClientConfig;
+
+    fn handle(
+        self,
+        message: Message,
+        data: &mut Self::Data,
+        common: &mut ConnectionCommon,
+        config: &Self::Config,
+    ) -> Result<Self, Error> {
+        let mut cx = ClientContext {
+            common,
+            data,
+            config,
+        };
+        self.handle(&mut cx, message)
+    }
+}
+
 pub(super) struct ClientContext<'a> {
     pub(super) common: &'a mut ConnectionCommon,
     pub(super) data: &'a mut ClientConnectionData,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -33,10 +33,10 @@ use crate::ticketer::TimeBase;
 
 use std::convert::TryFrom;
 
-pub(super) type NextState = Box<dyn State + Send + Sync>;
+pub(super) type NextState = Box<dyn State>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
 
-pub(super) trait State {
+pub(super) trait State: Send + Sync {
     /// Each handle() implementation consumes a whole TLS message, and returns
     /// either an error or the next state.
     fn handle(self: Box<Self>, conn: &mut ClientContext<'_>, m: Message) -> NextStateOrError;
@@ -53,7 +53,7 @@ pub(super) trait State {
     fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
 }
 
-impl crate::conn::HandleState for Box<dyn State + Send + Sync> {
+impl crate::conn::HandleState for Box<dyn State> {
     type Data = ClientConnectionData;
     type Config = ClientConfig;
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -382,7 +382,7 @@ fn emit_client_hello_for_retry(
 
     // Calculate the hash of ClientHello and use it to derive EarlyTrafficSecret
     let early_key_schedule = early_key_schedule.map(|(resuming, schedule)| {
-        if !conn.early_data.is_enabled() {
+        if !conn.data.early_data.is_enabled() {
             return schedule;
         }
 
@@ -469,7 +469,7 @@ impl State for ExpectServerHello {
         let version = match server_version {
             TLSv1_3 if tls13_supported => TLSv1_3,
             TLSv1_2 if conn.config.supports_version(TLSv1_2) => {
-                if conn.early_data.is_enabled() && conn.common.early_traffic {
+                if conn.data.early_data.is_enabled() && conn.common.early_traffic {
                     // The client must fail with a dedicated error code if the server
                     // responds with TLS 1.2 when offering 0-RTT.
                     return Err(Error::PeerMisbehavedError(
@@ -693,7 +693,7 @@ impl State for ExpectServerHello {
 
                 // Since we're resuming, we verified the certificate and
                 // proof of possession in the prior session.
-                conn.server_cert_chain = resuming.server_cert_chain.clone();
+                conn.data.server_cert_chain = resuming.server_cert_chain.clone();
                 let cert_verified = verify::ServerCertVerified::assertion();
                 let sig_verified = verify::HandshakeSignatureValid::assertion();
 
@@ -857,8 +857,8 @@ impl ExpectServerHelloOrHelloRetryRequest {
         self.next.transcript.add_message(&m);
 
         // Early data is not allowed after HelloRetryrequest
-        if conn.early_data.is_enabled() {
-            conn.early_data.rejected();
+        if conn.data.early_data.is_enabled() {
+            conn.data.early_data.rejected();
         }
 
         let may_send_sct_list = self

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -541,7 +541,7 @@ impl ClientConnection {
     fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
         let mut st = self.state.take();
         if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(self);
+            st.perhaps_write_key_update(&mut self.common);
         }
         self.state = st;
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -486,7 +486,12 @@ impl ClientConnection {
         dns_name: webpki::DnsName,
         extra_exts: Vec<ClientExtension>,
     ) -> Result<(), Error> {
-        self.state = Some(hs::start_handshake(self, dns_name, extra_exts)?);
+        let mut cx = hs::ClientContext {
+            common: &mut self.common,
+            data: &mut self.data,
+            config: &self.config,
+        };
+        self.state = Some(hs::start_handshake(&mut cx, dns_name, extra_exts)?);
         Ok(())
     }
 
@@ -518,8 +523,14 @@ impl ClientConnection {
             return Ok(());
         }
 
+        let mut cx = hs::ClientContext {
+            common: &mut self.common,
+            data: &mut self.data,
+            config: &self.config,
+        };
+
         let state = self.state.take().unwrap();
-        let maybe_next_state = state.handle(self, msg);
+        let maybe_next_state = state.handle(&mut cx, msg);
         let next_state = self
             .common
             .maybe_send_unexpected_alert(maybe_next_state)?;

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -592,7 +592,7 @@ impl hs::State for ExpectServerDone {
                 .verify_tls12_signature(&message, &st.server_cert.cert_chain[0], sig)
                 .map_err(|err| hs::send_cert_error_alert(conn, err))?
         };
-        conn.server_cert_chain = st.server_cert.cert_chain;
+        conn.data.server_cert_chain = st.server_cert.cert_chain;
 
         // 4.
         if let Some(client_auth) = &mut st.client_auth {
@@ -802,7 +802,7 @@ fn save_session(
         &session_id,
         ticket,
         master_secret,
-        &conn.server_cert_chain,
+        &conn.data.server_cert_chain,
         time_now,
     );
     value.set_times(recvd_ticket.new_ticket_lifetime, 0);

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -165,7 +165,7 @@ pub fn fill_in_psk_binder(
 
 pub(super) fn start_handshake_traffic(
     suite: &'static SupportedCipherSuite,
-    conn: &mut ClientContext<'_>,
+    cx: &mut ClientContext<'_>,
     early_key_schedule: Option<KeyScheduleEarly>,
     server_hello: &ServerHelloPayload,
     resuming_session: &mut Option<persist::ClientSessionValueWithResolvedCipherSuite>,
@@ -177,7 +177,7 @@ pub(super) fn start_handshake_traffic(
     let their_key_share = server_hello
         .get_key_share()
         .ok_or_else(|| {
-            conn.common
+            cx.common
                 .send_fatal_alert(AlertDescription::MissingExtension);
             Error::PeerMisbehavedError("missing key share".to_string())
         })?;
@@ -185,7 +185,7 @@ pub(super) fn start_handshake_traffic(
     let our_key_share = hello
         .find_key_share_and_discard_others(their_key_share.group)
         .ok_or_else(|| {
-            conn.common
+            cx.common
                 .illegal_param("wrong group for key share")
         })?;
     let shared = our_key_share
@@ -198,21 +198,21 @@ pub(super) fn start_handshake_traffic(
                 .supported_cipher_suite()
                 .can_resume_to(suite)
             {
-                return Err(conn
+                return Err(cx
                     .common
                     .illegal_param("server resuming incompatible suite"));
             }
 
             // If the server varies the suite here, we will have encrypted early data with
             // the wrong suite.
-            if conn.data.early_data.is_enabled() && resuming.supported_cipher_suite() != suite {
-                return Err(conn
+            if cx.data.early_data.is_enabled() && resuming.supported_cipher_suite() != suite {
+                return Err(cx
                     .common
                     .illegal_param("server varied suite with early data"));
             }
 
             if selected_psk != 0 {
-                return Err(conn
+                return Err(cx
                     .common
                     .illegal_param("server selected invalid psk"));
             }
@@ -230,29 +230,29 @@ pub(super) fn start_handshake_traffic(
     } else {
         debug!("Not resuming");
         // Discard the early data key schedule.
-        conn.data.early_data.rejected();
-        conn.common.early_traffic = false;
+        cx.data.early_data.rejected();
+        cx.common.early_traffic = false;
         resuming_session.take();
         KeyScheduleNonSecret::new(suite.hkdf_algorithm).into_handshake(&shared.shared_secret)
     };
 
     // Remember what KX group the server liked for next time.
-    save_kx_hint(conn.config, dns_name, their_key_share.group);
+    save_kx_hint(cx.config, dns_name, their_key_share.group);
 
     // If we change keying when a subsequent handshake message is being joined,
     // the two halves will have different record layer protections.  Disallow this.
-    conn.common.check_aligned_handshake()?;
+    cx.common.check_aligned_handshake()?;
 
     let hash_at_client_recvd_server_hello = transcript.get_current_hash();
 
-    let _maybe_write_key = if !conn.data.early_data.is_enabled() {
+    let _maybe_write_key = if !cx.data.early_data.is_enabled() {
         // Set the client encryption key for handshakes if early data is not used
         let write_key = key_schedule.client_handshake_traffic_secret(
             &hash_at_client_recvd_server_hello,
-            &*conn.config.key_log,
+            &*cx.config.key_log,
             &randoms.client,
         );
-        conn.common
+        cx.common
             .record_layer
             .set_message_encrypter(cipher::new_tls13_write(suite, &write_key));
         Some(write_key)
@@ -262,21 +262,21 @@ pub(super) fn start_handshake_traffic(
 
     let read_key = key_schedule.server_handshake_traffic_secret(
         &hash_at_client_recvd_server_hello,
-        &*conn.config.key_log,
+        &*cx.config.key_log,
         &randoms.client,
     );
-    conn.common
+    cx.common
         .record_layer
         .set_message_decrypter(cipher::new_tls13_read(suite, &read_key));
 
     #[cfg(feature = "quic")]
     {
-        conn.common.quic.hs_secrets = Some(quic::Secrets {
+        cx.common.quic.hs_secrets = Some(quic::Secrets {
             server: read_key,
             client: _maybe_write_key.unwrap_or_else(|| {
                 key_schedule.client_handshake_traffic_secret(
                     &hash_at_client_recvd_server_hello,
-                    &*conn.config.key_log,
+                    &*cx.config.key_log,
                     &randoms.client,
                 )
             }),
@@ -287,7 +287,7 @@ pub(super) fn start_handshake_traffic(
 }
 
 pub(super) fn prepare_resumption(
-    conn: &mut ClientContext<'_>,
+    cx: &mut ClientContext<'_>,
     ticket: Vec<u8>,
     resuming_session: &persist::ClientSessionValueWithResolvedCipherSuite,
     exts: &mut Vec<ClientExtension>,
@@ -295,12 +295,12 @@ pub(super) fn prepare_resumption(
 ) {
     let resuming_suite = resuming_session.supported_cipher_suite();
 
-    conn.data.resumption_ciphersuite = Some(resuming_suite);
+    cx.data.resumption_ciphersuite = Some(resuming_suite);
     // The EarlyData extension MUST be supplied together with the
     // PreSharedKey extension.
     let max_early_data_size = resuming_session.max_early_data_size;
-    if conn.config.enable_early_data && max_early_data_size > 0 && !doing_retry {
-        conn.data
+    if cx.config.enable_early_data && max_early_data_size > 0 && !doing_retry {
+        cx.data
             .early_data
             .enable(max_early_data_size as usize);
         exts.push(ClientExtension::EarlyData);
@@ -323,7 +323,7 @@ pub(super) fn prepare_resumption(
 }
 
 pub(super) fn derive_early_traffic_secret(
-    conn: &mut ClientContext<'_>,
+    cx: &mut ClientContext<'_>,
     resuming_session: &persist::ClientSessionValueWithResolvedCipherSuite,
     early_key_schedule: &KeyScheduleEarly,
     sent_tls13_fake_ccs: &mut bool,
@@ -331,18 +331,18 @@ pub(super) fn derive_early_traffic_secret(
     client_random: &[u8; 32],
 ) {
     // For middlebox compatibility
-    emit_fake_ccs(sent_tls13_fake_ccs, conn.common);
+    emit_fake_ccs(sent_tls13_fake_ccs, cx.common);
 
     let resuming_suite = resuming_session.supported_cipher_suite();
 
     let client_hello_hash = transcript.get_hash_given(resuming_suite.get_hash(), &[]);
     let client_early_traffic_secret = early_key_schedule.client_early_traffic_secret(
         &client_hello_hash,
-        &*conn.config.key_log,
+        &*cx.config.key_log,
         client_random,
     );
     // Set early data encryption key
-    conn.common
+    cx.common
         .record_layer
         .set_message_encrypter(cipher::new_tls13_write(
             resuming_suite,
@@ -351,11 +351,11 @@ pub(super) fn derive_early_traffic_secret(
 
     #[cfg(feature = "quic")]
     {
-        conn.common.quic.early_secret = Some(client_early_traffic_secret);
+        cx.common.quic.early_secret = Some(client_early_traffic_secret);
     }
 
     // Now the client can send encrypted early data
-    conn.common.early_traffic = true;
+    cx.common.early_traffic = true;
     trace!("Starting early data traffic");
 }
 
@@ -419,11 +419,7 @@ pub struct ExpectEncryptedExtensions {
 }
 
 impl hs::State for ExpectEncryptedExtensions {
-    fn handle(
-        mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let exts = require_handshake_msg!(
             m,
             HandshakeType::EncryptedExtensions,
@@ -432,43 +428,43 @@ impl hs::State for ExpectEncryptedExtensions {
         debug!("TLS1.3 encrypted extensions: {:?}", exts);
         self.transcript.add_message(&m);
 
-        validate_encrypted_extensions(conn.common, &self.hello, &exts)?;
-        hs::process_alpn_protocol(conn, exts.get_alpn_protocol())?;
+        validate_encrypted_extensions(cx.common, &self.hello, &exts)?;
+        hs::process_alpn_protocol(cx, exts.get_alpn_protocol())?;
 
         #[cfg(feature = "quic")]
         {
             // QUIC transport parameters
             if let Some(params) = exts.get_quic_params_extension() {
-                conn.common.quic.params = Some(params);
+                cx.common.quic.params = Some(params);
             }
         }
 
         if let Some(resuming_session) = self.resuming_session {
-            let was_early_traffic = conn.common.early_traffic;
+            let was_early_traffic = cx.common.early_traffic;
             if was_early_traffic {
                 if exts.early_data_extension_offered() {
-                    conn.data.early_data.accepted();
+                    cx.data.early_data.accepted();
                 } else {
-                    conn.data.early_data.rejected();
-                    conn.common.early_traffic = false;
+                    cx.data.early_data.rejected();
+                    cx.common.early_traffic = false;
                 }
             }
 
-            if was_early_traffic && !conn.common.early_traffic {
+            if was_early_traffic && !cx.common.early_traffic {
                 // If no early traffic, set the encryption key for handshakes
                 let write_key = self
                     .key_schedule
                     .client_handshake_traffic_secret(
                         &self.hash_at_client_recvd_server_hello,
-                        &*conn.config.key_log,
+                        &*cx.config.key_log,
                         &self.randoms.client,
                     );
-                conn.common
+                cx.common
                     .record_layer
                     .set_message_encrypter(cipher::new_tls13_write(self.suite, &write_key));
             }
 
-            conn.data.server_cert_chain = resuming_session
+            cx.data.server_cert_chain = resuming_session
                 .server_cert_chain
                 .clone();
 
@@ -517,11 +513,7 @@ struct ExpectCertificate {
 }
 
 impl hs::State for ExpectCertificate {
-    fn handle(
-        mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_chain = require_handshake_msg!(
             m,
             HandshakeType::Certificate,
@@ -532,7 +524,7 @@ impl hs::State for ExpectCertificate {
         // This is only non-empty for client auth.
         if !cert_chain.context.0.is_empty() {
             warn!("certificate with non-empty context during handshake");
-            conn.common
+            cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
             return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
@@ -541,7 +533,7 @@ impl hs::State for ExpectCertificate {
             || cert_chain.any_entry_has_unknown_extension()
         {
             warn!("certificate chain contains unsolicited/unknown extension");
-            conn.common
+            cx.common
                 .send_fatal_alert(AlertDescription::UnsupportedExtension);
             return Err(Error::PeerMisbehavedError(
                 "bad cert chain extensions".to_string(),
@@ -590,7 +582,7 @@ struct ExpectCertificateOrCertReq {
 }
 
 impl hs::State for ExpectCertificateOrCertReq {
-    fn handle(self: Box<Self>, conn: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(
             &m,
             &[ContentType::Handshake],
@@ -610,7 +602,7 @@ impl hs::State for ExpectCertificateOrCertReq {
                 client_auth: None,
                 hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
             })
-            .handle(conn, m)
+            .handle(cx, m)
         } else {
             Box::new(ExpectCertificateRequest {
                 dns_name: self.dns_name,
@@ -621,7 +613,7 @@ impl hs::State for ExpectCertificateOrCertReq {
                 may_send_sct_list: self.may_send_sct_list,
                 hash_at_client_recvd_server_hello: self.hash_at_client_recvd_server_hello,
             })
-            .handle(conn, m)
+            .handle(cx, m)
         }
     }
 }
@@ -655,11 +647,7 @@ fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
 }
 
 impl hs::State for ExpectCertificateVerify {
-    fn handle(
-        mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_verify = require_handshake_msg!(
             m,
             HandshakeType::CertificateVerify,
@@ -675,7 +663,7 @@ impl hs::State for ExpectCertificateVerify {
             .split_first()
             .ok_or(Error::NoCertificatesPresented)?;
         let now = std::time::SystemTime::now();
-        let cert_verified = conn
+        let cert_verified = cx
             .config
             .get_verifier()
             .verify_server_cert(
@@ -686,11 +674,11 @@ impl hs::State for ExpectCertificateVerify {
                 &self.server_cert.ocsp_response,
                 now,
             )
-            .map_err(|err| send_cert_error_alert(conn.common, err))?;
+            .map_err(|err| send_cert_error_alert(cx.common, err))?;
 
         // 2. Verify their signature on the handshake.
         let handshake_hash = self.transcript.get_current_hash();
-        let sig_verified = conn
+        let sig_verified = cx
             .config
             .get_verifier()
             .verify_tls13_signature(
@@ -698,9 +686,9 @@ impl hs::State for ExpectCertificateVerify {
                 &self.server_cert.cert_chain[0],
                 &cert_verify,
             )
-            .map_err(|err| send_cert_error_alert(conn.common, err))?;
+            .map_err(|err| send_cert_error_alert(cx.common, err))?;
 
-        conn.data.server_cert_chain = self.server_cert.cert_chain;
+        cx.data.server_cert_chain = self.server_cert.cert_chain;
         self.transcript.add_message(&m);
 
         Ok(Box::new(ExpectFinished {
@@ -731,11 +719,7 @@ struct ExpectCertificateRequest {
 }
 
 impl hs::State for ExpectCertificateRequest {
-    fn handle(
-        mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let certreq = &require_handshake_msg!(
             m,
             HandshakeType::CertificateRequest,
@@ -750,7 +734,7 @@ impl hs::State for ExpectCertificateRequest {
         // Must be empty during handshake.
         if !certreq.context.0.is_empty() {
             warn!("Server sent non-empty certreq context");
-            conn.common
+            cx.common
                 .send_fatal_alert(AlertDescription::DecodeError);
             return Err(Error::CorruptMessagePayload(ContentType::Handshake));
         }
@@ -766,7 +750,7 @@ impl hs::State for ExpectCertificateRequest {
             .collect::<Vec<SignatureScheme>>();
 
         if compat_sigschemes.is_empty() {
-            conn.common
+            cx.common
                 .send_fatal_alert(AlertDescription::HandshakeFailure);
             return Err(Error::PeerIncompatibleError(
                 "server sent bad certreq schemes".to_string(),
@@ -780,7 +764,7 @@ impl hs::State for ExpectCertificateRequest {
             .iter()
             .map(|p| p.0.as_slice())
             .collect::<Vec<&[u8]>>();
-        let maybe_certkey = conn
+        let maybe_certkey = cx
             .config
             .client_auth_cert_resolver
             .resolve(&canames, &compat_sigschemes);
@@ -932,7 +916,7 @@ struct ExpectFinished {
 }
 
 impl hs::State for ExpectFinished {
-    fn handle(self: Box<Self>, conn: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -944,19 +928,19 @@ impl hs::State for ExpectFinished {
 
         let fin = constant_time::verify_slices_are_equal(expect_verify_data.as_ref(), &finished.0)
             .map_err(|_| {
-                conn.common
+                cx.common
                     .send_fatal_alert(AlertDescription::DecryptError);
                 Error::DecryptError
             })
             .map(|_| verify::FinishedMessageVerified::assertion())?;
 
-        let maybe_write_key = if conn.common.early_traffic {
+        let maybe_write_key = if cx.common.early_traffic {
             /* Derive the client-to-server encryption key before key schedule update */
             let key = st
                 .key_schedule
                 .client_handshake_traffic_secret(
                     &st.hash_at_client_recvd_server_hello,
-                    &*conn.config.key_log,
+                    &*cx.config.key_log,
                     &st.randoms.client,
                 );
             Some(key)
@@ -970,10 +954,10 @@ impl hs::State for ExpectFinished {
         /* The EndOfEarlyData message to server is still encrypted with early data keys,
          * but appears in the transcript after the server Finished. */
         if let Some(write_key) = maybe_write_key {
-            emit_end_of_early_data_tls13(&mut st.transcript, conn.common);
-            conn.common.early_traffic = false;
-            conn.data.early_data.finished();
-            conn.common
+            emit_end_of_early_data_tls13(&mut st.transcript, cx.common);
+            cx.common.early_traffic = false;
+            cx.data.early_data.finished();
+            cx.common
                 .record_layer
                 .set_message_encrypter(cipher::new_tls13_write(st.suite, &write_key));
         }
@@ -981,45 +965,45 @@ impl hs::State for ExpectFinished {
         /* Send our authentication/finished messages.  These are still encrypted
          * with our handshake keys. */
         if let Some(client_auth) = &mut st.client_auth {
-            emit_certificate_tls13(&mut st.transcript, client_auth, conn.common);
-            emit_certverify_tls13(&mut st.transcript, client_auth, conn.common)?;
+            emit_certificate_tls13(&mut st.transcript, client_auth, cx.common);
+            emit_certverify_tls13(&mut st.transcript, client_auth, cx.common)?;
         }
 
         let mut key_schedule_finished = st
             .key_schedule
             .into_traffic_with_client_finished_pending();
-        emit_finished_tls13(&mut st.transcript, &key_schedule_finished, conn.common);
+        emit_finished_tls13(&mut st.transcript, &key_schedule_finished, cx.common);
 
         /* Now move to our application traffic keys. */
-        conn.common.check_aligned_handshake()?;
+        cx.common.check_aligned_handshake()?;
 
         /* Traffic from server is now decrypted with application data keys. */
         let read_key = key_schedule_finished.server_application_traffic_secret(
             &hash_after_handshake,
-            &*conn.config.key_log,
+            &*cx.config.key_log,
             &st.randoms.client,
         );
-        conn.common
+        cx.common
             .record_layer
             .set_message_decrypter(cipher::new_tls13_read(st.suite, &read_key));
 
         key_schedule_finished.exporter_master_secret(
             &hash_after_handshake,
-            &*conn.config.key_log,
+            &*cx.config.key_log,
             &st.randoms.client,
         );
 
         let write_key = key_schedule_finished.client_application_traffic_secret(
             &hash_after_handshake,
-            &*conn.config.key_log,
+            &*cx.config.key_log,
             &st.randoms.client,
         );
-        conn.common
+        cx.common
             .record_layer
             .set_message_encrypter(cipher::new_tls13_write(st.suite, &write_key));
 
         let key_schedule_traffic = key_schedule_finished.into_traffic();
-        conn.common.start_traffic();
+        cx.common.start_traffic();
 
         let st = ExpectTraffic {
             dns_name: st.dns_name,
@@ -1034,8 +1018,8 @@ impl hs::State for ExpectFinished {
 
         #[cfg(feature = "quic")]
         {
-            if conn.common.protocol == Protocol::Quic {
-                conn.common.quic.traffic_secrets = Some(quic::Secrets {
+            if cx.common.protocol == Protocol::Quic {
+                cx.common.quic.traffic_secrets = Some(quic::Secrets {
                     client: write_key,
                     server: read_key,
                 });
@@ -1065,7 +1049,7 @@ impl ExpectTraffic {
     #[allow(clippy::unnecessary_wraps)] // returns Err for #[cfg(feature = "quic")]
     fn handle_new_ticket_tls13(
         &mut self,
-        conn: &mut ClientContext<'_>,
+        cx: &mut ClientContext<'_>,
         nst: &NewSessionTicketPayloadTLS13,
     ) -> Result<(), Error> {
         let handshake_hash = self.transcript.get_current_hash();
@@ -1080,7 +1064,7 @@ impl ExpectTraffic {
             &SessionID::empty(),
             nst.ticket.0.clone(),
             secret,
-            &conn.data.server_cert_chain,
+            &cx.data.server_cert_chain,
             time_now,
         );
         value.set_times(nst.lifetime, nst.age_add);
@@ -1089,7 +1073,7 @@ impl ExpectTraffic {
             value.set_max_early_data_size(sz);
             #[cfg(feature = "quic")]
             {
-                if conn.common.protocol == Protocol::Quic {
+                if cx.common.protocol == Protocol::Quic {
                     if sz != 0 && sz != 0xffff_ffff {
                         return Err(Error::PeerMisbehavedError(
                             "invalid max_early_data_size".into(),
@@ -1105,19 +1089,12 @@ impl ExpectTraffic {
 
         #[cfg(feature = "quic")]
         {
-            if conn.common.protocol == Protocol::Quic {
-                PayloadU16::encode_slice(
-                    conn.common
-                        .quic
-                        .params
-                        .as_ref()
-                        .unwrap(),
-                    &mut ticket,
-                );
+            if cx.common.protocol == Protocol::Quic {
+                PayloadU16::encode_slice(cx.common.quic.params.as_ref().unwrap(), &mut ticket);
             }
         }
 
-        let worked = conn
+        let worked = cx
             .config
             .session_persistence
             .put(key.get_encoding(), ticket);
@@ -1174,22 +1151,22 @@ impl ExpectTraffic {
 impl hs::State for ExpectTraffic {
     fn handle(
         mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
+        cx: &mut ClientContext<'_>,
         mut m: Message,
     ) -> hs::NextStateOrError {
         if m.is_content_type(ContentType::ApplicationData) {
-            conn.common
+            cx.common
                 .take_received_plaintext(m.take_opaque_payload().unwrap());
         } else if let Ok(ref new_ticket) = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,
             HandshakePayload::NewSessionTicketTLS13
         ) {
-            self.handle_new_ticket_tls13(conn, new_ticket)?;
+            self.handle_new_ticket_tls13(cx, new_ticket)?;
         } else if let Ok(ref key_update) =
             require_handshake_msg!(m, HandshakeType::KeyUpdate, HandshakePayload::KeyUpdate)
         {
-            self.handle_key_update(conn.common, key_update)?;
+            self.handle_key_update(cx.common, key_update)?;
         } else {
             check_message(
                 &m,
@@ -1231,18 +1208,14 @@ pub struct ExpectQUICTraffic(ExpectTraffic);
 
 #[cfg(feature = "quic")]
 impl hs::State for ExpectQUICTraffic {
-    fn handle(
-        mut self: Box<Self>,
-        conn: &mut ClientContext<'_>,
-        m: Message,
-    ) -> hs::NextStateOrError {
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let nst = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,
             HandshakePayload::NewSessionTicketTLS13
         )?;
         self.0
-            .handle_new_ticket_tls13(conn, nst)?;
+            .handle_new_ticket_tls13(cx, nst)?;
         Ok(self)
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -662,6 +662,19 @@ impl ConnectionCommon {
         Ok(Some(MessageType::Data(msg)))
     }
 
+    pub(crate) fn process_new_handshake_messages<S: HandleState>(
+        &mut self,
+        state: &mut Option<S>,
+        data: &mut S::Data,
+        config: &S::Config,
+    ) -> Result<(), Error> {
+        while let Some(msg) = self.handshake_joiner.frames.pop_front() {
+            self.process_main_protocol(msg, state, data, &config)?;
+        }
+
+        Ok(())
+    }
+
     /// Process `msg`.  First, we get the current state.  Then we ask what messages
     /// that state expects, enforced via `check_message`.  Finally, we ask the handler
     /// to handle the message.

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -41,6 +41,26 @@ pub(super) trait State {
     fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
 }
 
+impl<'a> crate::conn::HandleState for Box<dyn State + Send + Sync> {
+    type Config = ServerConfig;
+    type Data = ServerConnectionData;
+
+    fn handle(
+        self,
+        message: Message,
+        data: &mut Self::Data,
+        common: &mut ConnectionCommon,
+        config: &Self::Config,
+    ) -> Result<Self, Error> {
+        let mut cx = ServerContext {
+            common,
+            data,
+            config,
+        };
+        self.handle(&mut cx, message)
+    }
+}
+
 pub(super) struct ServerContext<'a> {
     pub(super) common: &'a mut ConnectionCommon,
     pub(super) data: &'a mut ServerConnectionData,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -149,7 +149,7 @@ impl ExtensionProcessing {
                         && resume.version == conn.common.negotiated_version.unwrap()
                         && resume.cipher_suite == suite.suite
                         && resume.alpn.as_ref().map(|x| &x.0) == conn.common.alpn_protocol.as_ref()
-                        && !conn.reject_early_data
+                        && !conn.data.reject_early_data
                     {
                         self.exts
                             .push(ServerExtension::EarlyData);
@@ -368,9 +368,9 @@ impl State for ExpectClientHello {
         if let (Some(sni), false) = (&sni, self.done_retry) {
             // Save the SNI into the session.
             // The SNI hostname is immutable once set.
-            assert!(conn.sni.is_none());
-            conn.sni = Some(sni.clone());
-        } else if conn.sni != sni {
+            assert!(conn.data.sni.is_none());
+            conn.data.sni = Some(sni.clone());
+        } else if conn.data.sni != sni {
             return Err(Error::PeerIncompatibleError(
                 "SNI differed on retry".to_string(),
             ));

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -23,10 +23,10 @@ use crate::server::{tls12, tls13, ServerConnectionData};
 
 use std::convert::TryFrom;
 
-pub(super) type NextState = Box<dyn State + Send + Sync>;
+pub(super) type NextState = Box<dyn State>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
 
-pub(super) trait State {
+pub(super) trait State: Send + Sync {
     fn handle(self: Box<Self>, conn: &mut ServerContext<'_>, m: Message) -> NextStateOrError;
 
     fn export_keying_material(
@@ -41,7 +41,7 @@ pub(super) trait State {
     fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
 }
 
-impl<'a> crate::conn::HandleState for Box<dyn State + Send + Sync> {
+impl<'a> crate::conn::HandleState for Box<dyn State> {
     type Config = ServerConfig;
     type Data = ServerConnectionData;
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -345,7 +345,7 @@ impl ServerConfig {
 pub struct ServerConnection {
     config: Arc<ServerConfig>,
     common: ConnectionCommon,
-    state: Option<Box<dyn hs::State + Send + Sync>>,
+    state: Option<Box<dyn hs::State>>,
     data: ServerConnectionData,
 }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -418,12 +418,9 @@ impl ServerConnection {
     /// The SNI hostname is also used to match sessions during session
     /// resumption.
     pub fn sni_hostname(&self) -> Option<&str> {
-        self.get_sni()
+        self.data
+            .get_sni()
             .map(|s| s.as_ref().into())
-    }
-
-    fn get_sni(&self) -> Option<&webpki::DnsName> {
-        self.data.sni.as_ref()
     }
 
     /// Application-controlled portion of the resumption ticket supplied by the client, if any.
@@ -616,6 +613,12 @@ struct ServerConnectionData {
     client_cert_chain: Option<Vec<key::Certificate>>,
     /// Whether to reject early data even if it would otherwise be accepted
     reject_early_data: bool,
+}
+
+impl ServerConnectionData {
+    fn get_sni(&self) -> Option<&webpki::DnsName> {
+        self.sni.as_ref()
+    }
 }
 
 #[cfg(feature = "quic")]

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -378,8 +378,14 @@ impl ServerConnection {
             return Ok(());
         }
 
+        let mut cx = hs::ServerContext {
+            common: &mut self.common,
+            data: &mut self.data,
+            config: &self.config,
+        };
+
         let state = self.state.take().unwrap();
-        let maybe_next_state = state.handle(self, msg);
+        let maybe_next_state = state.handle(&mut cx, msg);
         let next_state = self
             .common
             .maybe_send_unexpected_alert(maybe_next_state)?;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -464,7 +464,7 @@ impl ServerConnection {
     fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
         let mut st = self.state.take();
         if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(self);
+            st.perhaps_write_key_update(&mut self.common);
         }
         self.state = st;
         self.common.send_some_plaintext(buf)

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -1,6 +1,4 @@
-use crate::conn::{
-    Connection, ConnectionCommon, IoState, MessageType, PlaintextSink, Reader, Writer,
-};
+use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Reader, Writer};
 use crate::error::Error;
 use crate::key;
 use crate::keylog::{KeyLog, NoKeyLog};
@@ -448,47 +446,8 @@ impl Connection for ServerConnection {
     }
 
     fn process_new_packets(&mut self) -> Result<IoState, Error> {
-        if let Some(ref err) = self.common.error {
-            return Err(err.clone());
-        }
-
-        if self.common.message_deframer.desynced {
-            return Err(Error::CorruptMessage);
-        }
-
-        while let Some(msg) = self
-            .common
-            .message_deframer
-            .frames
-            .pop_front()
-        {
-            let result = self
-                .common
-                .process_msg(msg)
-                .and_then(|val| match val {
-                    Some(MessageType::Handshake) => self
-                        .common
-                        .process_new_handshake_messages(
-                            &mut self.state,
-                            &mut self.data,
-                            &self.config,
-                        ),
-                    Some(MessageType::Data(msg)) => self.common.process_main_protocol(
-                        msg,
-                        &mut self.state,
-                        &mut self.data,
-                        &self.config,
-                    ),
-                    None => Ok(()),
-                });
-
-            if let Err(err) = result {
-                self.common.error = Some(err.clone());
-                return Err(err);
-            }
-        }
-
-        Ok(self.common.current_io_state())
+        self.common
+            .process_new_packets(&mut self.state, &mut self.data, &self.config)
     }
 
     fn wants_read(&self) -> bool {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -135,7 +135,7 @@ mod client_hello {
                 .filter(|resumedata| {
                     hs::can_resume(
                         self.suite.supported_suite(),
-                        &conn.sni,
+                        &conn.data.sni,
                         self.using_ems,
                         resumedata,
                     )
@@ -273,7 +273,7 @@ mod client_hello {
             );
             conn.common
                 .start_encryption_tls12(&secrets);
-            conn.client_cert_chain = resumedata.client_cert_chain;
+            conn.data.client_cert_chain = resumedata.client_cert_chain;
 
             if self.send_ticket {
                 emit_ticket(&secrets, &mut self.transcript, self.using_ems, conn);
@@ -662,7 +662,7 @@ impl hs::State for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        conn.client_cert_chain = Some(self.client_cert);
+        conn.data.client_cert_chain = Some(self.client_cert);
 
         self.transcript.add_message(&m);
         Ok(Box::new(ExpectCcs {
@@ -722,9 +722,9 @@ fn get_server_connion_value_tls12(
         version,
         secrets.suite().supported_suite().suite,
         secret,
-        &conn.client_cert_chain,
+        &conn.data.client_cert_chain,
         conn.common.alpn_protocol.clone(),
-        conn.resumption_data.clone(),
+        conn.data.resumption_data.clone(),
     );
 
     if using_ems {

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -535,9 +535,9 @@ impl hs::State for ExpectCertificate {
                 cx.config
                     .verifier
                     .verify_client_cert(end_entity, intermediates, cx.data.get_sni(), now)
-                    .or_else(|err| {
+                    .map_err(|err| {
                         hs::incompatible(&mut cx.common, "certificate invalid");
-                        Err(err)
+                        err
                     })?;
 
                 Some(cert_chain)

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -803,9 +803,9 @@ impl hs::State for ExpectCertificate {
         cx.config
             .get_verifier()
             .verify_client_cert(end_entity, intermediates, cx.data.get_sni(), now)
-            .or_else(|err| {
+            .map_err(|err| {
                 hs::incompatible(&mut cx.common, "certificate invalid");
-                Err(err)
+                err
             })?;
 
         Ok(Box::new(ExpectCertificateVerify {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -221,7 +221,7 @@ mod client_hello {
                     let resume = match self
                         .attempt_tls13_ticket_decryption(conn, &psk_id.identity.0)
                         .filter(|resumedata| {
-                            hs::can_resume(self.suite, &conn.sni, false, resumedata)
+                            hs::can_resume(self.suite, &conn.data.sni, false, resumedata)
                         }) {
                         Some(resume) => resume,
                         None => continue,
@@ -256,8 +256,8 @@ mod client_hello {
             }
 
             if let Some(ref resume) = resumedata {
-                conn.received_resumption_data = Some(resume.application_data.0.clone());
-                conn.client_cert_chain = resume.client_cert_chain.clone();
+                conn.data.received_resumption_data = Some(resume.application_data.0.clone());
+                conn.data.client_cert_chain = resume.client_cert_chain.clone();
             }
 
             let full_handshake = resumedata.is_none();
@@ -850,7 +850,7 @@ impl hs::State for ExpectCertificateVerify {
         }
 
         trace!("client CertificateVerify OK");
-        conn.client_cert_chain = Some(self.client_cert);
+        conn.data.client_cert_chain = Some(self.client_cert);
 
         self.transcript.add_message(&m);
         Ok(Box::new(ExpectFinished {
@@ -883,9 +883,9 @@ fn get_server_session_value(
         version,
         suite.suite,
         secret,
-        &conn.client_cert_chain,
+        &conn.data.client_cert_chain,
         conn.common.alpn_protocol.clone(),
-        conn.resumption_data.clone(),
+        conn.data.resumption_data.clone(),
     )
 }
 


### PR DESCRIPTION
We go through the following steps:

- Move side-specific data fields into a separate type (`*ConnectionData`)
- Introduce side-specific context types that are passed to `State::handle()`, to prevent borrowing all of the `*Connection`
- Introduce a new trait (currently called `HandleState`) that allows the `ConnectionCommon` to run through the state machine with minimal knowledge of the underlying types
- Move core state machine driver methods into `ConnectionCommon`

With the following advantages:

* Core state machine driving logic is no longer duplicated
* Privatize more of the `ConnectionCommon` interface
* ~90 lines less code
* Keep client and server state machine types separate