### PR TITLE
QUIC: improve error handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p rustls -- -D warnings
+          args: -p rustls --all-features -- -D warnings
 
   clippy-nightly:
     name: Clippy (Nightly)
@@ -228,4 +228,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -p rustls
+          args: -p rustls --all-features

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -1091,6 +1091,7 @@ fn main() {
                     quic::Version::V1,
                     opts.quic_transport_params.clone(),
                 )
+                .unwrap()
             };
             ClientOrServer::Server(s)
         } else {

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -713,7 +713,7 @@ fn exec(opts: &Options, mut sess: ClientOrServer, count: usize) {
                 .is_empty()
         {
             let their_transport_params = sess
-                .get_quic_transport_parameters()
+                .quic_transport_parameters()
                 .expect("missing peer quic transport params");
             assert_eq!(opts.expect_quic_transport_params, their_transport_params);
         }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -218,7 +218,8 @@ fn emit_client_hello_for_retry(
 
     let support_tls12 = conn
         .config
-        .supports_version(ProtocolVersion::TLSv1_2);
+        .supports_version(ProtocolVersion::TLSv1_2)
+        && !conn.common.is_quic();
     let support_tls13 = conn
         .config
         .supports_version(ProtocolVersion::TLSv1_3);

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -729,13 +729,12 @@ pub trait ClientQuicExt {
         hostname: webpki::DnsNameRef,
         params: Vec<u8>,
     ) -> Result<ClientConnection, Error> {
-        assert!(
-            config
-                .versions
-                .iter()
-                .all(|x| x.get_u16() >= ProtocolVersion::TLSv1_3.get_u16()),
-            "QUIC requires TLS version >= 1.3"
-        );
+        if !config.supports_version(ProtocolVersion::TLSv1_3) {
+            return Err(Error::General(
+                "TLS 1.3 support is required for QUIC".into(),
+            ));
+        }
+
         let ext = match quic_version {
             quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params),
             quic::Version::V1 => ClientExtension::TransportParameters(params),

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -684,7 +684,7 @@ impl PlaintextSink for ClientConnection {
 
 #[cfg(feature = "quic")]
 impl quic::QuicExt for ClientConnection {
-    fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
+    fn quic_transport_parameters(&self) -> Option<&[u8]> {
         self.common
             .quic
             .params
@@ -692,7 +692,7 @@ impl quic::QuicExt for ClientConnection {
             .map(|v| v.as_ref())
     }
 
-    fn get_0rtt_keys(&self) -> Option<quic::DirectionalKeys> {
+    fn zero_rtt_keys(&self) -> Option<quic::DirectionalKeys> {
         Some(quic::DirectionalKeys::new(
             self.resumption_ciphersuite?,
             self.common.quic.early_secret.as_ref()?,
@@ -708,7 +708,7 @@ impl quic::QuicExt for ClientConnection {
         quic::write_hs(&mut self.common, buf)
     }
 
-    fn get_alert(&self) -> Option<AlertDescription> {
+    fn alert(&self) -> Option<AlertDescription> {
         self.common.quic.alert
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -444,8 +444,15 @@ impl hs::State for ExpectEncryptedExtensions {
         #[cfg(feature = "quic")]
         {
             // QUIC transport parameters
-            if let Some(params) = exts.get_quic_params_extension() {
-                conn.common.quic.params = Some(params);
+            if conn.common.is_quic() {
+                match exts.get_quic_params_extension() {
+                    Some(params) => conn.common.quic.params = Some(params),
+                    None => {
+                        return Err(conn
+                            .common
+                            .missing_extension("QUIC transport parameters not found"));
+                    }
+                }
             }
         }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1055,7 +1055,7 @@ impl hs::State for ExpectFinished {
                     client: write_key,
                     server: read_key,
                 });
-                return Ok(Box::new(ExpectQUICTraffic(st)));
+                return Ok(Box::new(ExpectQuicTraffic(st)));
             }
         }
 
@@ -1105,12 +1105,10 @@ impl ExpectTraffic {
             value.set_max_early_data_size(sz);
             #[cfg(feature = "quic")]
             {
-                if conn.common.protocol == Protocol::Quic {
-                    if sz != 0 && sz != 0xffff_ffff {
-                        return Err(Error::PeerMisbehavedError(
-                            "invalid max_early_data_size".into(),
-                        ));
-                    }
+                if conn.common.protocol == Protocol::Quic && sz != 0 && sz != 0xffff_ffff {
+                    return Err(Error::PeerMisbehavedError(
+                        "invalid max_early_data_size".into(),
+                    ));
                 }
             }
         }
@@ -1246,10 +1244,10 @@ impl hs::State for ExpectTraffic {
 }
 
 #[cfg(feature = "quic")]
-pub struct ExpectQUICTraffic(ExpectTraffic);
+pub struct ExpectQuicTraffic(ExpectTraffic);
 
 #[cfg(feature = "quic")]
-impl hs::State for ExpectQUICTraffic {
+impl hs::State for ExpectQuicTraffic {
     fn handle(
         mut self: Box<Self>,
         conn: &mut ClientConnection,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -334,7 +334,7 @@ pub trait Connection: quic::QuicExt + Send + Sync {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Protocol {
-    Tls13,
+    Tcp,
     #[cfg(feature = "quic")]
     Quic,
 }
@@ -581,7 +581,7 @@ impl ConnectionCommon {
             received_plaintext: ChunkVecBuffer::new(),
             sendable_plaintext: ChunkVecBuffer::new(),
             sendable_tls: ChunkVecBuffer::new(),
-            protocol: Protocol::Tls13,
+            protocol: Protocol::Tcp,
             #[cfg(feature = "quic")]
             quic: Quic::new(),
         }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -915,11 +915,7 @@ impl ConnectionCommon {
                     self.quic.alert = Some(alert.description);
                 } else {
                     debug_assert!(
-                        if let MessagePayload::Handshake(_) = m.payload {
-                            true
-                        } else {
-                            false
-                        },
+                        matches!(m.payload, MessagePayload::Handshake(_)),
                         "QUIC uses TLS for the cryptographic handshake only"
                     );
                     let mut bytes = Vec::new();

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -970,6 +970,12 @@ impl ConnectionCommon {
             .prepare_message_decrypter(dec);
     }
 
+    #[cfg(feature = "quic")]
+    pub fn missing_extension(&mut self, why: &str) -> Error {
+        self.send_fatal_alert(AlertDescription::MissingExtension);
+        Error::PeerMisbehavedError(why.to_string())
+    }
+
     pub fn send_warning_alert(&mut self, desc: AlertDescription) {
         warn!("Sending warning alert {:?}", desc);
         self.send_warning_alert_no_log(desc);

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -38,10 +38,10 @@ pub trait QuicExt {
     /// handshake completes, and reliance on them should be minimized.
     /// However, any tampering with the parameters will cause the handshake
     /// to fail.
-    fn get_quic_transport_parameters(&self) -> Option<&[u8]>;
+    fn quic_transport_parameters(&self) -> Option<&[u8]>;
 
     /// Compute the keys for encrypting/decrypting 0-RTT packets, if available
-    fn get_0rtt_keys(&self) -> Option<DirectionalKeys>;
+    fn zero_rtt_keys(&self) -> Option<DirectionalKeys>;
 
     /// Consume unencrypted TLS handshake data.
     ///
@@ -56,7 +56,7 @@ pub trait QuicExt {
     /// Emit the TLS description code of a fatal alert, if one has arisen.
     ///
     /// Check after `read_hs` returns `Err(_)`.
-    fn get_alert(&self) -> Option<AlertDescription>;
+    fn alert(&self) -> Option<AlertDescription>;
 
     /// Compute the keys to use following a 1-RTT key update
     ///

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -32,6 +32,12 @@ impl Secrets {
 /// Generic methods for QUIC sessions
 pub trait QuicExt {
     /// Return the TLS-encoded transport parameters for the session's peer.
+    ///
+    /// While the transport parameters are technically available prior to the
+    /// completion of the handshake, they cannot be fully trusted until the
+    /// handshake completes, and reliance on them should be minimized.
+    /// However, any tampering with the parameters will cause the handshake
+    /// to fail.
     fn get_quic_transport_parameters(&self) -> Option<&[u8]>;
 
     /// Compute the keys for encrypting/decrypting 0-RTT packets, if available

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -325,6 +325,11 @@ impl State for ExpectClientHello {
                 ProtocolVersion::TLSv1_3
             } else if !versions.contains(&ProtocolVersion::TLSv1_2) || !tls12_enabled {
                 return Err(bad_version(conn, "TLS1.2 not offered/enabled"));
+            } else if conn.common.is_quic() {
+                return Err(bad_version(
+                    conn,
+                    "Expecting QUIC connection, but client does not support TLSv1_3",
+                ));
             } else {
                 ProtocolVersion::TLSv1_2
             }
@@ -334,6 +339,11 @@ impl State for ExpectClientHello {
             return Err(bad_version(
                 conn,
                 "Server requires TLS1.3, but client omitted versions ext",
+            ));
+        } else if conn.common.is_quic() {
+            return Err(bad_version(
+                conn,
+                "Expecting QUIC connection, but client does not support TLSv1_3",
             ));
         } else {
             ProtocolVersion::TLSv1_2

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -137,9 +137,14 @@ impl ExtensionProcessing {
 
         #[cfg(feature = "quic")]
         {
-            if conn.common.protocol == Protocol::Quic {
-                if let Some(params) = hello.get_quic_params_extension() {
-                    conn.common.quic.params = Some(params);
+            if conn.common.is_quic() {
+                match hello.get_quic_params_extension() {
+                    Some(params) => conn.common.quic.params = Some(params),
+                    None => {
+                        return Err(conn
+                            .common
+                            .missing_extension("QUIC transport parameters not found"));
+                    }
                 }
 
                 if let Some(resume) = resumedata {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -668,10 +668,12 @@ pub trait ServerQuicExt {
             ));
         }
 
-        assert!(
-            config.max_early_data_size == 0 || config.max_early_data_size == 0xffff_ffff,
-            "QUIC sessions must set a max early data of 0 or 2^32-1"
-        );
+        if config.max_early_data_size != 0 && config.max_early_data_size != 0xffff_ffff {
+            return Err(Error::General(
+                "QUIC sessions must set a max early data of 0 or 2^32-1".into(),
+            ));
+        }
+
         let ext = match quic_version {
             quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params),
             quic::Version::V1 => ServerExtension::TransportParameters(params),

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -661,14 +661,13 @@ pub trait ServerQuicExt {
         config: &Arc<ServerConfig>,
         quic_version: quic::Version,
         params: Vec<u8>,
-    ) -> ServerConnection {
-        assert!(
-            config
-                .versions
-                .iter()
-                .all(|x| x.get_u16() >= ProtocolVersion::TLSv1_3.get_u16()),
-            "QUIC requires TLS version >= 1.3"
-        );
+    ) -> Result<ServerConnection, Error> {
+        if !config.supports_version(ProtocolVersion::TLSv1_3) {
+            return Err(Error::General(
+                "TLS 1.3 support is required for QUIC".into(),
+            ));
+        }
+
         assert!(
             config.max_early_data_size == 0 || config.max_early_data_size == 0xffff_ffff,
             "QUIC sessions must set a max early data of 0 or 2^32-1"
@@ -679,7 +678,7 @@ pub trait ServerQuicExt {
         };
         let mut new = ServerConnection::from_config(config, vec![ext]);
         new.common.protocol = Protocol::Quic;
-        new
+        Ok(new)
     }
 }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -618,7 +618,7 @@ impl fmt::Debug for ServerConnection {
 
 #[cfg(feature = "quic")]
 impl quic::QuicExt for ServerConnection {
-    fn get_quic_transport_parameters(&self) -> Option<&[u8]> {
+    fn quic_transport_parameters(&self) -> Option<&[u8]> {
         self.common
             .quic
             .params
@@ -626,7 +626,7 @@ impl quic::QuicExt for ServerConnection {
             .map(|v| v.as_ref())
     }
 
-    fn get_0rtt_keys(&self) -> Option<quic::DirectionalKeys> {
+    fn zero_rtt_keys(&self) -> Option<quic::DirectionalKeys> {
         Some(quic::DirectionalKeys::new(
             self.common.get_suite()?,
             self.common.quic.early_secret.as_ref()?,
@@ -642,7 +642,7 @@ impl quic::QuicExt for ServerConnection {
         quic::write_hs(&mut self.common, buf)
     }
 
-    fn get_alert(&self) -> Option<AlertDescription> {
+    fn alert(&self) -> Option<AlertDescription> {
         self.common.quic.alert
     }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1016,7 +1016,7 @@ impl hs::State for ExpectFinished {
         #[cfg(feature = "quic")]
         {
             if conn.common.protocol == Protocol::Quic {
-                return Ok(Box::new(ExpectQUICTraffic {
+                return Ok(Box::new(ExpectQuicTraffic {
                     key_schedule: key_schedule_traffic,
                     _fin_verified: fin,
                 }));
@@ -1138,13 +1138,13 @@ impl hs::State for ExpectTraffic {
 }
 
 #[cfg(feature = "quic")]
-struct ExpectQUICTraffic {
+struct ExpectQuicTraffic {
     key_schedule: KeyScheduleTraffic,
     _fin_verified: verify::FinishedMessageVerified,
 }
 
 #[cfg(feature = "quic")]
-impl hs::State for ExpectQUICTraffic {
+impl hs::State for ExpectQuicTraffic {
     fn handle(self: Box<Self>, _: &mut ServerConnection, m: Message) -> hs::NextStateOrError {
         // reject all messages
         check_message(&m, &[], &[])?;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2883,7 +2883,7 @@ mod test_quic {
         if let Err(e) = recv.read_hs(&buf) {
             return Err(e);
         } else {
-            assert_eq!(recv.get_alert(), None);
+            assert_eq!(recv.alert(), None);
         }
         Ok(secrets)
     }
@@ -2927,12 +2927,12 @@ mod test_quic {
 
         let client_initial = step(&mut client, &mut server).unwrap();
         assert!(client_initial.is_none());
-        assert!(client.get_0rtt_keys().is_none());
-        assert_eq!(server.get_quic_transport_parameters(), Some(client_params));
+        assert!(client.zero_rtt_keys().is_none());
+        assert_eq!(server.quic_transport_parameters(), Some(client_params));
         let server_hs = step(&mut server, &mut client)
             .unwrap()
             .unwrap();
-        assert!(server.get_0rtt_keys().is_none());
+        assert!(server.zero_rtt_keys().is_none());
         let client_hs = step(&mut client, &mut server)
             .unwrap()
             .unwrap();
@@ -2942,7 +2942,7 @@ mod test_quic {
             .unwrap()
             .unwrap();
         assert!(!client.is_handshaking());
-        assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
+        assert_eq!(client.quic_transport_parameters(), Some(server_params));
         assert!(server.is_handshaking());
         let client_1rtt = step(&mut client, &mut server)
             .unwrap()
@@ -2980,10 +2980,10 @@ mod test_quic {
                 .unwrap();
 
         step(&mut client, &mut server).unwrap();
-        assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
+        assert_eq!(client.quic_transport_parameters(), Some(server_params));
         {
-            let client_early = client.get_0rtt_keys().unwrap();
-            let server_early = server.get_0rtt_keys().unwrap();
+            let client_early = client.zero_rtt_keys().unwrap();
+            let server_early = server.zero_rtt_keys().unwrap();
             assert!(equal_dir_keys(&client_early, &server_early));
         }
         step(&mut server, &mut client)
@@ -3014,9 +3014,9 @@ mod test_quic {
                     .unwrap();
 
             step(&mut client, &mut server).unwrap();
-            assert_eq!(client.get_quic_transport_parameters(), Some(server_params));
-            assert!(client.get_0rtt_keys().is_some());
-            assert!(server.get_0rtt_keys().is_none());
+            assert_eq!(client.quic_transport_parameters(), Some(server_params));
+            assert!(client.zero_rtt_keys().is_some());
+            assert!(server.zero_rtt_keys().is_none());
             step(&mut server, &mut client)
                 .unwrap()
                 .unwrap();
@@ -3048,7 +3048,7 @@ mod test_quic {
             .unwrap();
         assert!(step(&mut server, &mut client).is_err());
         assert_eq!(
-            client.get_alert(),
+            client.alert(),
             Some(rustls::internal::msgs::enums::AlertDescription::BadCertificate)
         );
     }
@@ -3088,7 +3088,7 @@ mod test_quic {
             );
 
             assert_eq!(
-                server.get_alert(),
+                server.alert(),
                 Some(rustls::internal::msgs::enums::AlertDescription::NoApplicationProtocol)
             );
         }


### PR DESCRIPTION
Fixes #555.

This adds a bunch of tests for these new error paths. I didn't figure out a way to test that the client will error out when it receives an `EncryptedExtensions` message from the server that does not include the QUIC transport parameters.