### PR TITLE
Improve type clarity for message and payloads

### DIFF
--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -3,6 +3,8 @@
 extern crate rustls;
 
 use rustls::internal::msgs::deframer;
+use rustls::internal::msgs::message::Message;
+use std::convert::TryFrom;
 use std::io;
 
 fuzz_target!(|data: &[u8]| {
@@ -13,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
     dfm.has_pending();
 
     while !dfm.frames.is_empty() {
-        let mut msg = dfm.frames.pop_front().unwrap();
-        msg.decode_payload();
+        let msg = dfm.frames.pop_front().unwrap();
+        Message::try_from(msg).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -2,24 +2,29 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
+use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::fragmenter;
 use rustls::internal::msgs::message;
-use rustls::internal::msgs::codec::{Codec, Reader};
 use std::collections::VecDeque;
+use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
-    let mut msg = match message::Message::read(&mut rdr) {
-        Some(msg) => msg,
-        None => return
+    let msg = match message::OpaqueMessage::read(&mut rdr) {
+        Ok(msg) => msg,
+        Err(_) => return,
     };
-    msg.decode_payload();
+
+    let msg = match message::Message::try_from(msg) {
+        Ok(msg) => msg,
+        Err((msg, _)) => msg,
+    };
 
     let frg = fragmenter::MessageFragmenter::new(5);
     let mut out = VecDeque::new();
-    frg.fragment(msg, &mut out);
+    frg.fragment(msg.into_opaque(), &mut out);
 
-    for mut msg in out {
-        msg.decode_payload();
+    for msg in out {
+        message::Message::try_from(msg).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -17,7 +17,7 @@ fuzz_target!(|data: &[u8]| {
 
     let msg = match message::Message::try_from(msg) {
         Ok(msg) => msg,
-        Err((msg, _)) => msg,
+        Err(_) => return,
     };
 
     let frg = fragmenter::MessageFragmenter::new(5);

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -22,7 +22,7 @@ fuzz_target!(|data: &[u8]| {
 
     let frg = fragmenter::MessageFragmenter::new(5);
     let mut out = VecDeque::new();
-    frg.fragment(msg.into_opaque(), &mut out);
+    frg.fragment(message::OpaqueMessage::from(msg), &mut out);
 
     for msg in out {
         message::Message::try_from(msg).ok();

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -2,15 +2,19 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::internal::msgs::message::Message;
-use rustls::internal::msgs::codec::{Reader, Codec};
+use rustls::internal::msgs::codec::{Codec, Reader};
+use rustls::internal::msgs::message::{Message, OpaqueMessage};
+use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
-    if let Some(mut m) = Message::read(&mut rdr) {
-        m.decode_payload();
+    if let Ok(m) = OpaqueMessage::read(&mut rdr) {
+        let msg = match Message::try_from(m) {
+            Ok(msg) => msg,
+            Err((msg, _)) => msg,
+        };
         //println!("msg = {:#?}", m);
-        let enc = m.get_encoding();
+        let enc = msg.into_opaque().get_encoding();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..rdr.used()]);
     }

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -2,7 +2,7 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::internal::msgs::codec::{Codec, Reader};
+use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage};
 use std::convert::TryFrom;
 
@@ -14,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
             Err((msg, _)) => msg,
         };
         //println!("msg = {:#?}", m);
-        let enc = OpaqueMessage::from(msg).get_encoding();
+        let enc = OpaqueMessage::from(msg).encode();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..rdr.used()]);
     }

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(m) = OpaqueMessage::read(&mut rdr) {
         let msg = match Message::try_from(m) {
             Ok(msg) => msg,
-            Err((msg, _)) => msg,
+            Err(_) => return,
         };
         //println!("msg = {:#?}", m);
         let enc = OpaqueMessage::from(msg).encode();

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -14,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
             Err((msg, _)) => msg,
         };
         //println!("msg = {:#?}", m);
-        let enc = msg.into_opaque().get_encoding();
+        let enc = OpaqueMessage::from(msg).get_encoding();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..rdr.used()]);
     }

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -20,7 +20,7 @@ macro_rules! require_handshake_msg(
         }
         _ => Err(Error::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.content_type()})
+                 got_type: $m.payload.content_type()})
     }
   )
 );
@@ -37,7 +37,7 @@ macro_rules! require_handshake_msg_move(
         }
         _ => Err(Error::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.content_type()})
+                 got_type: $m.payload.content_type()})
     }
   )
 );
@@ -52,7 +52,7 @@ pub fn check_message(
     content_types: &[ContentType],
     handshake_types: &[HandshakeType],
 ) -> Result<(), Error> {
-    if !content_types.contains(&m.content_type()) {
+    if !content_types.contains(&m.payload.content_type()) {
         return Err(inappropriate_message(m, content_types));
     }
 
@@ -68,12 +68,12 @@ pub fn check_message(
 pub fn inappropriate_message(m: &Message, content_types: &[ContentType]) -> Error {
     warn!(
         "Received a {:?} message while expecting {:?}",
-        m.content_type(),
+        m.payload.content_type(),
         content_types
     );
     Error::InappropriateMessage {
         expect_types: content_types.to_vec(),
-        got_type: m.content_type(),
+        got_type: m.payload.content_type(),
     }
 }
 

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -19,7 +19,7 @@ macro_rules! require_handshake_msg(
         }
         _ => Err(Error::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.typ})
+                 got_type: $m.content_type()})
     }
   )
 );
@@ -36,7 +36,7 @@ macro_rules! require_handshake_msg_move(
         }
         _ => Err(Error::InappropriateMessage {
                  expect_types: vec![ ContentType::Handshake ],
-                 got_type: $m.typ})
+                 got_type: $m.content_type()})
     }
   )
 );
@@ -51,14 +51,14 @@ pub fn check_message(
     content_types: &[ContentType],
     handshake_types: &[HandshakeType],
 ) -> Result<(), Error> {
-    if !content_types.contains(&m.typ) {
+    if !content_types.contains(&m.content_type()) {
         warn!(
             "Received a {:?} message while expecting {:?}",
-            m.typ, content_types
+            m.content_type(), content_types
         );
         return Err(Error::InappropriateMessage {
             expect_types: content_types.to_vec(),
-            got_type: m.typ,
+            got_type: m.content_type(),
         });
     }
 

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 #[cfg(feature = "logging")]
 use crate::log::warn;
 use crate::msgs::enums::{ContentType, HandshakeType};
+use crate::msgs::handshake::HandshakeMessagePayload;
 use crate::msgs::message::{Message, MessagePayload};
 
 /// For a Message $m, and a HandshakePayload enum member $payload_type,
@@ -52,28 +53,40 @@ pub fn check_message(
     handshake_types: &[HandshakeType],
 ) -> Result<(), Error> {
     if !content_types.contains(&m.content_type()) {
-        warn!(
-            "Received a {:?} message while expecting {:?}",
-            m.content_type(), content_types
-        );
-        return Err(Error::InappropriateMessage {
-            expect_types: content_types.to_vec(),
-            got_type: m.content_type(),
-        });
+        return Err(inappropriate_message(m, content_types));
     }
 
     if let MessagePayload::Handshake(ref hsp) = m.payload {
         if !handshake_types.is_empty() && !handshake_types.contains(&hsp.typ) {
-            warn!(
-                "Received a {:?} handshake message while expecting {:?}",
-                hsp.typ, handshake_types
-            );
-            return Err(Error::InappropriateHandshakeMessage {
-                expect_types: handshake_types.to_vec(),
-                got_type: hsp.typ,
-            });
+            return Err(inappropriate_handshake_message(hsp, handshake_types));
         }
     }
 
     Ok(())
+}
+
+pub fn inappropriate_message(m: &Message, content_types: &[ContentType]) -> Error {
+    warn!(
+        "Received a {:?} message while expecting {:?}",
+        m.content_type(),
+        content_types
+    );
+    Error::InappropriateMessage {
+        expect_types: content_types.to_vec(),
+        got_type: m.content_type(),
+    }
+}
+
+pub fn inappropriate_handshake_message(
+    hsp: &HandshakeMessagePayload,
+    handshake_types: &[HandshakeType],
+) -> Error {
+    warn!(
+        "Received a {:?} handshake message while expecting {:?}",
+        hsp.typ, handshake_types
+    );
+    Error::InappropriateHandshakeMessage {
+        expect_types: handshake_types.to_vec(),
+        got_type: hsp.typ,
+    }
 }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -367,7 +367,6 @@ fn emit_client_hello_for_retry(
     };
 
     let ch = Message {
-        typ: ContentType::Handshake,
         // "This value MUST be set to 0x0303 for all records generated
         //  by a TLS 1.3 implementation other than an initial ClientHello
         //  (i.e., one not generated after a HelloRetryRequest)"

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -259,7 +259,6 @@ fn emit_certificate(
     common: &mut ConnectionCommon,
 ) {
     let cert = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::Certificate,
@@ -282,7 +281,6 @@ fn emit_clientkx(
     let pubkey = Payload::new(buf);
 
     let ckx = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
@@ -314,7 +312,6 @@ fn emit_certverify(
     let body = DigitallySignedStruct::new(scheme, sig);
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::CertificateVerify,
@@ -329,7 +326,6 @@ fn emit_certverify(
 
 fn emit_ccs(common: &mut ConnectionCommon) {
     let ccs = Message {
-        typ: ContentType::ChangeCipherSpec,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
     };
@@ -347,7 +343,6 @@ fn emit_finished(
     let verify_data_payload = Payload::new(verify_data);
 
     let f = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::Finished,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,4 +1,4 @@
-use crate::check::check_message;
+use crate::check::{check_message, inappropriate_message};
 use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
@@ -879,10 +879,15 @@ struct ExpectTraffic {
 }
 
 impl hs::State for ExpectTraffic {
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, mut m: Message) -> hs::NextStateOrError {
-        check_message(&m, &[ContentType::ApplicationData], &[])?;
-        cx.common
-            .take_received_plaintext(m.take_app_data_payload().unwrap());
+    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+        match m.payload {
+            MessagePayload::ApplicationData(payload) => cx
+                .common
+                .take_received_plaintext(payload),
+            _ => {
+                return Err(inappropriate_message(&m, &[ContentType::ApplicationData]));
+            }
+        }
         Ok(self)
     }
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -887,7 +887,7 @@ impl hs::State for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, mut m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ApplicationData], &[])?;
         cx.common
-            .take_received_plaintext(m.take_opaque_payload().unwrap());
+            .take_received_plaintext(m.take_app_data_payload().unwrap());
         Ok(self)
     }
 

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -369,7 +369,6 @@ pub fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut ConnectionComm
     }
 
     let m = Message {
-        typ: ContentType::ChangeCipherSpec,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
     };
@@ -810,7 +809,6 @@ fn emit_certificate_tls13(
     }
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::Certificate,
@@ -841,7 +839,6 @@ fn emit_certverify_tls13(
     let dss = DigitallySignedStruct::new(scheme, sig);
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::CertificateVerify,
@@ -864,7 +861,6 @@ fn emit_finished_tls13(
     let verify_data_payload = Payload::new(verify_data.as_ref());
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::Finished,
@@ -882,7 +878,6 @@ fn emit_end_of_early_data_tls13(transcript: &mut HandshakeHash, common: &mut Con
     }
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_3,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::EndOfEarlyData,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1180,7 +1180,7 @@ impl hs::State for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify().into_opaque());
+            common.send_msg_encrypt(Message::build_key_update_notify().into());
 
             let write_key = self
                 .key_schedule

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,4 +1,4 @@
-use crate::check::check_message;
+use crate::check::{check_message, inappropriate_handshake_message, inappropriate_message};
 use crate::conn::{ConnectionCommon, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
@@ -1133,30 +1133,31 @@ impl ExpectTraffic {
 }
 
 impl hs::State for ExpectTraffic {
-    fn handle(
-        mut self: Box<Self>,
-        cx: &mut ClientContext<'_>,
-        mut m: Message,
-    ) -> hs::NextStateOrError {
-        if m.is_content_type(ContentType::ApplicationData) {
-            cx.common
-                .take_received_plaintext(m.take_app_data_payload().unwrap());
-        } else if let Ok(ref new_ticket) = require_handshake_msg!(
-            m,
-            HandshakeType::NewSessionTicket,
-            HandshakePayload::NewSessionTicketTLS13
-        ) {
-            self.handle_new_ticket_tls13(cx, new_ticket)?;
-        } else if let Ok(ref key_update) =
-            require_handshake_msg!(m, HandshakeType::KeyUpdate, HandshakePayload::KeyUpdate)
-        {
-            self.handle_key_update(cx.common, key_update)?;
-        } else {
-            check_message(
-                &m,
-                &[ContentType::ApplicationData, ContentType::Handshake],
-                &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
-            )?;
+    fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
+        match m.payload {
+            MessagePayload::ApplicationData(payload) => cx
+                .common
+                .take_received_plaintext(payload),
+            MessagePayload::Handshake(payload) => match payload.payload {
+                HandshakePayload::NewSessionTicketTLS13(new_ticket) => {
+                    self.handle_new_ticket_tls13(cx, &new_ticket)?
+                }
+                HandshakePayload::KeyUpdate(key_update) => {
+                    self.handle_key_update(cx.common, &key_update)?
+                }
+                _ => {
+                    return Err(inappropriate_handshake_message(
+                        &payload,
+                        &[HandshakeType::NewSessionTicket, HandshakeType::KeyUpdate],
+                    ));
+                }
+            },
+            _ => {
+                return Err(inappropriate_message(
+                    &m,
+                    &[ContentType::ApplicationData, ContentType::Handshake],
+                ));
+            }
         }
 
         Ok(self)

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1145,7 +1145,7 @@ impl hs::State for ExpectTraffic {
     ) -> hs::NextStateOrError {
         if m.is_content_type(ContentType::ApplicationData) {
             cx.common
-                .take_received_plaintext(m.take_opaque_payload().unwrap());
+                .take_received_plaintext(m.take_app_data_payload().unwrap());
         } else if let Ok(ref new_ticket) = require_handshake_msg!(
             m,
             HandshakeType::NewSessionTicket,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1180,7 +1180,7 @@ impl hs::State for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify());
+            common.send_msg_encrypt(Message::build_key_update_notify().into_opaque());
 
             let write_key = self
                 .key_schedule

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -620,7 +620,7 @@ impl ConnectionCommon {
         // - prior to determining the version (it's illegal as a first message)
         // - if it's not a CCS at all
         // - if we've finished the handshake
-        if msg.is_content_type(ContentType::ChangeCipherSpec) && !self.traffic && self.is_tls13() {
+        if msg.typ == ContentType::ChangeCipherSpec && !self.traffic && self.is_tls13() {
             if self.received_middlebox_ccs {
                 return Err(Error::PeerMisbehavedError(
                     "illegal middlebox CCS received".into(),

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -649,13 +649,8 @@ impl ConnectionCommon {
             return Ok(Some(MessageType::Handshake));
         }
 
-        // Now we can fully parse the message payload. We only return an error
-        // on the client, or we fail a bogo test (WrongMessageType-TLS13-ServerHello-TLS).
-        let msg = match Message::try_from(msg) {
-            Ok(msg) => msg,
-            Err((_, err)) if self.is_client => return Err(err),
-            Err((msg, _)) => msg,
-        };
+        // Now we can fully parse the message payload.
+        let msg = Message::try_from(msg)?;
 
         // For alerts, we have separate logic.
         if msg.is_content_type(ContentType::Alert) {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -986,8 +986,7 @@ impl ConnectionCommon {
 
     // Put m into sendable_tls for writing.
     fn queue_tls_message(&mut self, m: OpaqueMessage) {
-        self.sendable_tls
-            .append(m.get_encoding());
+        self.sendable_tls.append(m.encode());
     }
 
     /// Send a raw TLS message, fragmenting it if needed.

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1014,12 +1014,12 @@ impl ConnectionCommon {
         if !must_encrypt {
             let mut to_send = VecDeque::new();
             self.message_fragmenter
-                .fragment(m.into_opaque(), &mut to_send);
+                .fragment(m.into(), &mut to_send);
             for mm in to_send {
                 self.queue_tls_message(mm);
             }
         } else {
-            self.send_msg_encrypt(m.into_opaque());
+            self.send_msg_encrypt(m.into());
         }
     }
 

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -34,7 +34,11 @@ impl MessageFragmenter {
 
         let typ = msg.typ;
         let version = msg.version;
-        let payload = msg.take_payload();
+        let payload = msg
+            .into_opaque()
+            .take_opaque_payload()
+            .unwrap()
+            .0;
 
         for chunk in payload.chunks(self.max_frag) {
             let m = Message {

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -66,7 +66,6 @@ impl MessageFragmenter {
 mod tests {
     use super::{MessageFragmenter, PACKET_OVERHEAD};
     use crate::msgs::base::Payload;
-    use crate::msgs::codec::Codec;
     use crate::msgs::enums::{ContentType, ProtocolVersion};
     use crate::msgs::message::OpaqueMessage;
     use std::collections::VecDeque;
@@ -79,9 +78,7 @@ mod tests {
         bytes: &[u8],
     ) {
         let m = mm.unwrap();
-
-        let mut buf = Vec::new();
-        m.encode(&mut buf);
+        let buf = m.clone().encode();
 
         assert_eq!(&m.typ, typ);
         assert_eq!(&m.version, version);

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -36,7 +36,7 @@ impl HandshakeJoiner {
 
     /// Do we want to process this message?
     pub fn want_message(&self, msg: &OpaqueMessage) -> bool {
-        msg.is_content_type(ContentType::Handshake)
+        msg.typ == ContentType::Handshake
     }
 
     /// Do we have any buffered data?

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -102,7 +102,6 @@ impl HandshakeJoiner {
             };
 
             let m = Message {
-                typ: ContentType::Handshake,
                 version,
                 payload: MessagePayload::Handshake(payload),
             };
@@ -147,7 +146,7 @@ mod tests {
 
     fn pop_eq(expect: &OpaqueMessage, hj: &mut HandshakeJoiner) {
         let got = hj.frames.pop_front().unwrap();
-        assert_eq!(got.typ, expect.typ);
+        assert_eq!(got.content_type(), expect.typ);
         assert_eq!(got.version, expect.version);
 
         let (mut left, mut right) = (Vec::new(), Vec::new());
@@ -174,7 +173,6 @@ mod tests {
         assert_eq!(hj.is_empty(), true);
 
         let expect = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::HelloRequest,
@@ -244,7 +242,6 @@ mod tests {
 
         let payload = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f".to_vec();
         let expect = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Finished,

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -181,7 +181,7 @@ mod tests {
                 payload: HandshakePayload::HelloRequest,
             }),
         }
-        .into_opaque();
+        .into();
 
         pop_eq(&expect, &mut hj);
         pop_eq(&expect, &mut hj);
@@ -251,7 +251,7 @@ mod tests {
                 payload: HandshakePayload::Finished(Payload::new(payload)),
             }),
         }
-        .into_opaque();
+        .into();
 
         pop_eq(&expect, &mut hj);
     }

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -146,7 +146,7 @@ mod tests {
 
     fn pop_eq(expect: &OpaqueMessage, hj: &mut HandshakeJoiner) {
         let got = hj.frames.pop_front().unwrap();
-        assert_eq!(got.content_type(), expect.typ);
+        assert_eq!(got.payload.content_type(), expect.typ);
         assert_eq!(got.version, expect.version);
 
         let (mut left, mut right) = (Vec::new(), Vec::new());

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -172,10 +172,6 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn content_type(&self) -> ContentType {
-        self.payload.content_type()
-    }
-
     pub fn is_handshake_type(&self, hstyp: HandshakeType) -> bool {
         // Bit of a layering violation, but OK.
         if let MessagePayload::Handshake(ref hsp) = self.payload {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -176,10 +176,6 @@ impl Message {
         self.payload.content_type()
     }
 
-    pub fn is_content_type(&self, typ: ContentType) -> bool {
-        self.payload.content_type() == typ
-    }
-
     pub fn is_handshake_type(&self, hstyp: HandshakeType) -> bool {
         // Bit of a layering violation, but OK.
         if let MessagePayload::Handshake(ref hsp) = self.payload {

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -9,7 +9,6 @@ use crate::msgs::enums::{ContentType, ProtocolVersion};
 use crate::msgs::handshake::HandshakeMessagePayload;
 
 use std::convert::TryFrom;
-use std::mem;
 
 #[derive(Debug)]
 pub enum MessagePayload {
@@ -187,14 +186,6 @@ impl Message {
             hsp.typ == hstyp
         } else {
             false
-        }
-    }
-
-    pub fn take_app_data_payload(&mut self) -> Option<Payload> {
-        if let MessagePayload::ApplicationData(ref mut op) = self.payload {
-            Some(mem::replace(op, Payload::empty()))
-        } else {
-            None
         }
     }
 

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -128,10 +128,6 @@ impl OpaqueMessage {
         }
     }
 
-    pub fn is_content_type(&self, typ: ContentType) -> bool {
-        self.typ == typ
-    }
-
     /// This is the maximum on-the-wire size of a TLSCiphertext.
     /// That's 2^14 payload bytes, a header, and a 2KB allowance
     /// for ciphertext overheads.

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -141,6 +141,25 @@ impl Codec for OpaqueMessage {
     }
 }
 
+impl From<Message> for OpaqueMessage {
+    fn from(msg: Message) -> OpaqueMessage {
+        let payload = match msg.payload {
+            MessagePayload::Opaque(payload) => payload,
+            _ => {
+                let mut buf = Vec::new();
+                msg.payload.encode(&mut buf);
+                Payload(buf)
+            }
+        };
+
+        OpaqueMessage {
+            typ: msg.typ,
+            version: msg.version,
+            payload,
+        }
+    }
+}
+
 /// A message with decoded payload
 #[derive(Debug)]
 pub struct Message {
@@ -168,23 +187,6 @@ impl Message {
             Some(mem::replace(op, Payload::empty()))
         } else {
             None
-        }
-    }
-
-    pub fn into_opaque(self: Message) -> OpaqueMessage {
-        let payload = match self.payload {
-            MessagePayload::Opaque(payload) => payload,
-            _ => {
-                let mut buf = Vec::new();
-                self.payload.encode(&mut buf);
-                Payload(buf)
-            }
-        };
-
-        OpaqueMessage {
-            typ: self.typ,
-            version: self.version,
-            payload,
         }
     }
 

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -181,13 +181,6 @@ impl Message {
         }
     }
 
-    pub fn take_payload(self) -> Vec<u8> {
-        self.into_opaque()
-            .take_opaque_payload()
-            .unwrap()
-            .0
-    }
-
     pub fn take_opaque_payload(&mut self) -> Option<Payload> {
         if let MessagePayload::Opaque(ref mut op) = self.payload {
             Some(mem::replace(op, Payload::empty()))

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -35,7 +35,7 @@ fn test_read_fuzz_corpus() {
             Err((msg, _)) => msg,
         };
 
-        let enc = msg.into_opaque().get_encoding();
+        let enc = OpaqueMessage::from(msg).get_encoding();
         assert_eq!(bytes.to_vec(), enc);
         assert_eq!(bytes[..rd.used()].to_vec(), enc);
     }

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -1,4 +1,3 @@
-use super::codec::Codec;
 use super::codec::Reader;
 use super::enums::{AlertDescription, AlertLevel, HandshakeType};
 use super::message::{Message, OpaqueMessage};
@@ -35,7 +34,7 @@ fn test_read_fuzz_corpus() {
             Err((msg, _)) => msg,
         };
 
-        let enc = OpaqueMessage::from(msg).get_encoding();
+        let enc = OpaqueMessage::from(msg).encode();
         assert_eq!(bytes.to_vec(), enc);
         assert_eq!(bytes[..rd.used()].to_vec(), enc);
     }
@@ -91,8 +90,8 @@ fn construct_all_types() {
         &b"\x17\x03\x04\x00\x04\x11\x22\x33\x44"[..],
         &b"\x18\x03\x04\x00\x04\x11\x22\x33\x44"[..],
     ];
-    for bytes in samples.iter() {
-        let m = OpaqueMessage::read_bytes(bytes).unwrap();
+    for &bytes in samples.iter() {
+        let m = OpaqueMessage::read(&mut Reader::init(bytes)).unwrap();
         println!("m = {:?}", m);
         let m = Message::try_from(m);
         println!("m' = {:?}", m);

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -76,8 +76,7 @@ fn alert_is_not_handshake() {
 
 #[test]
 fn alert_is_not_opaque() {
-    let mut m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
-    assert_eq!(None, m.take_app_data_payload());
+    let m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
     assert!(Message::try_from(m).is_ok());
 }
 

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -77,7 +77,7 @@ fn alert_is_not_handshake() {
 #[test]
 fn alert_is_not_opaque() {
     let mut m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
-    assert_eq!(None, m.take_opaque_payload());
+    assert_eq!(None, m.take_app_data_payload());
     assert!(Message::try_from(m).is_ok());
 }
 

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -31,7 +31,7 @@ fn test_read_fuzz_corpus() {
 
         let msg = match Message::try_from(msg) {
             Ok(msg) => msg,
-            Err((msg, _)) => msg,
+            Err(_) => continue,
         };
 
         let enc = OpaqueMessage::from(msg).encode();

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -1,8 +1,9 @@
 use super::codec::Codec;
 use super::codec::Reader;
 use super::enums::{AlertDescription, AlertLevel, HandshakeType};
-use super::message::Message;
+use super::message::{Message, OpaqueMessage};
 
+use std::convert::TryFrom;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -26,10 +27,15 @@ fn test_read_fuzz_corpus() {
         f.read_to_end(&mut bytes).unwrap();
 
         let mut rd = Reader::init(&bytes);
-        let mut msg = Message::read(&mut rd).unwrap();
+        let msg = OpaqueMessage::read(&mut rd).unwrap();
         println!("{:?}", msg);
-        msg.decode_payload();
-        let enc = msg.get_encoding();
+
+        let msg = match Message::try_from(msg) {
+            Ok(msg) => msg,
+            Err((msg, _)) => msg,
+        };
+
+        let enc = msg.into_opaque().get_encoding();
         assert_eq!(bytes.to_vec(), enc);
         assert_eq!(bytes[..rd.used()].to_vec(), enc);
     }
@@ -58,9 +64,9 @@ fn can_read_safari_client_hello() {
         \x79\x2f\x33\x08\x68\x74\x74\x70\x2f\x31\x2e\x31\x00\x0b\x00\x02\
         \x01\x00\x00\x0a\x00\x0a\x00\x08\x00\x1d\x00\x17\x00\x18\x00\x19";
     let mut rd = Reader::init(bytes);
-    let mut m = Message::read(&mut rd).unwrap();
+    let m = OpaqueMessage::read(&mut rd).unwrap();
     println!("m = {:?}", m);
-    assert_eq!(m.decode_payload(), false);
+    assert!(Message::try_from(m).is_err());
 }
 
 #[test]
@@ -73,7 +79,7 @@ fn alert_is_not_handshake() {
 fn alert_is_not_opaque() {
     let mut m = Message::build_alert(AlertLevel::Fatal, AlertDescription::DecodeError);
     assert_eq!(None, m.take_opaque_payload());
-    assert_eq!(false, m.decode_payload());
+    assert!(Message::try_from(m).is_ok());
 }
 
 #[test]
@@ -86,9 +92,9 @@ fn construct_all_types() {
         &b"\x18\x03\x04\x00\x04\x11\x22\x33\x44"[..],
     ];
     for bytes in samples.iter() {
-        let mut m = Message::read_bytes(bytes).unwrap();
+        let m = OpaqueMessage::read_bytes(bytes).unwrap();
         println!("m = {:?}", m);
-        m.decode_payload();
+        let m = Message::try_from(m);
         println!("m' = {:?}", m);
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -31,22 +31,24 @@ mod message_test;
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryFrom;
+
     #[test]
     fn smoketest() {
         use super::codec::Codec;
         use super::codec::Reader;
-        use super::message::Message;
+        use super::message::{Message, OpaqueMessage};
         let bytes = include_bytes!("handshake-test.1.bin");
         let mut r = Reader::init(bytes);
 
         while r.any_left() {
-            let mut m = Message::read(&mut r).unwrap();
+            let m = OpaqueMessage::read(&mut r).unwrap();
 
             let mut out: Vec<u8> = vec![];
             m.encode(&mut out);
             assert!(out.len() > 0);
 
-            m.decode_payload();
+            Message::try_from(m).unwrap();
         }
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -35,7 +35,6 @@ mod test {
 
     #[test]
     fn smoketest() {
-        use super::codec::Codec;
         use super::codec::Reader;
         use super::message::{Message, OpaqueMessage};
         let bytes = include_bytes!("handshake-test.1.bin");
@@ -44,8 +43,7 @@ mod test {
         while r.any_left() {
             let m = OpaqueMessage::read(&mut r).unwrap();
 
-            let mut out: Vec<u8> = vec![];
-            m.encode(&mut out);
+            let out = m.clone().encode();
             assert!(out.len() > 0);
 
             Message::try_from(m).unwrap();

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -3,8 +3,9 @@ pub use crate::client::ClientQuicExt;
 use crate::conn::ConnectionCommon;
 use crate::error::Error;
 use crate::key_schedule::hkdf_expand;
+use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
-use crate::msgs::message::{Message, MessagePayload};
+use crate::msgs::message::OpaqueMessage;
 pub use crate::server::ServerQuicExt;
 use crate::suites::{BulkAlgorithm, SupportedCipherSuite, TLS13_AES_128_GCM_SHA256};
 
@@ -186,10 +187,10 @@ impl Keys {
 pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(), Error> {
     if this
         .handshake_joiner
-        .take_message(Message {
+        .take_message(OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
-            payload: MessagePayload::new_opaque(plaintext.into()),
+            payload: Payload::new(plaintext.to_vec()),
         })
         .is_none()
     {

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,6 +1,6 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
-use crate::msgs::message::{BorrowMessage, Message};
+use crate::msgs::message::{BorrowedOpaqueMessage, OpaqueMessage};
 
 static SEQ_SOFT_LIMIT: u64 = 0xffff_ffff_ffff_0000u64;
 static SEQ_HARD_LIMIT: u64 = 0xffff_ffff_ffff_fffeu64;
@@ -119,7 +119,7 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub fn decrypt_incoming(&mut self, encr: Message) -> Result<Message, Error> {
+    pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<OpaqueMessage, Error> {
         debug_assert!(self.decrypt_state == DirectionState::Active);
         let seq = self.read_seq;
         self.read_seq += 1;
@@ -131,7 +131,7 @@ impl RecordLayer {
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub fn encrypt_outgoing(&mut self, plain: BorrowMessage) -> Message {
+    pub fn encrypt_outgoing(&mut self, plain: BorrowedOpaqueMessage) -> OpaqueMessage {
         debug_assert!(self.encrypt_state == DirectionState::Active);
         assert!(!self.encrypt_exhausted());
         let seq = self.write_seq;

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -870,7 +870,7 @@ impl hs::State for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, mut m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ApplicationData], &[])?;
         cx.common
-            .take_received_plaintext(m.take_opaque_payload().unwrap());
+            .take_received_plaintext(m.take_app_data_payload().unwrap());
         Ok(self)
     }
 

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -325,7 +325,6 @@ mod client_hello {
         ep.process_tls12(&cx.config, hello, using_ems);
 
         let sh = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerHello,
@@ -352,7 +351,6 @@ mod client_hello {
         cert_chain: &[Certificate],
     ) {
         let c = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
@@ -372,7 +370,6 @@ mod client_hello {
         let st = CertificateStatus::new(ocsp.to_owned());
 
         let c = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateStatus,
@@ -412,7 +409,6 @@ mod client_hello {
         });
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerKeyExchange,
@@ -456,7 +452,6 @@ mod client_hello {
         };
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateRequest,
@@ -472,7 +467,6 @@ mod client_hello {
 
     fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut ConnectionCommon) {
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerHelloDone,
@@ -747,7 +741,6 @@ fn emit_ticket(
     let ticket_lifetime = cx.config.ticketer.lifetime();
 
     let m = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -764,7 +757,6 @@ fn emit_ticket(
 
 fn emit_ccs(common: &mut ConnectionCommon) {
     let m = Message {
-        typ: ContentType::ChangeCipherSpec,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
     };
@@ -782,7 +774,6 @@ fn emit_finished(
     let verify_data_payload = Payload::new(verify_data);
 
     let f = Message {
-        typ: ContentType::Handshake,
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::Handshake(HandshakeMessagePayload {
             typ: HandshakeType::Finished,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -383,7 +383,6 @@ mod client_hello {
         }
 
         let sh = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ServerHello,
@@ -466,7 +465,6 @@ mod client_hello {
             return;
         }
         let m = Message {
-            typ: ContentType::ChangeCipherSpec,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
         };
@@ -494,7 +492,6 @@ mod client_hello {
             ));
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::HelloRetryRequest,
@@ -530,7 +527,6 @@ mod client_hello {
         )?;
 
         let ee = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::EncryptedExtensions,
@@ -581,7 +577,6 @@ mod client_hello {
         }
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateRequest,
@@ -632,7 +627,6 @@ mod client_hello {
 
         let cert_body = CertificatePayloadTLS13::new(cert_entries);
         let c = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
@@ -663,7 +657,6 @@ mod client_hello {
         let cv = DigitallySignedStruct::new(scheme, sig);
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::CertificateVerify,
@@ -689,7 +682,6 @@ mod client_hello {
         let verify_data_payload = Payload::new(verify_data.as_ref());
 
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Finished,
@@ -949,7 +941,6 @@ impl ExpectFinished {
             }
         }
         let m = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::NewSessionTicket,

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1114,7 +1114,7 @@ impl hs::State for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify());
+            common.send_msg_encrypt(Message::build_key_update_notify().into_opaque());
 
             let write_key = self
                 .key_schedule

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1037,9 +1037,9 @@ struct ExpectTraffic {
 }
 
 impl ExpectTraffic {
-    fn handle_traffic(&self, cx: &mut ServerContext<'_>, mut m: Message) {
+    fn handle_traffic(&self, cx: &mut ServerContext, mut m: Message) {
         cx.common
-            .take_received_plaintext(m.take_opaque_payload().unwrap());
+            .take_received_plaintext(m.take_app_data_payload().unwrap());
     }
 
     fn handle_key_update(

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1114,7 +1114,7 @@ impl hs::State for ExpectTraffic {
     fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
-            common.send_msg_encrypt(Message::build_key_update_notify().into_opaque());
+            common.send_msg_encrypt(Message::build_key_update_notify().into());
 
             let write_key = self
                 .key_schedule

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3177,6 +3177,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
+        use rustls::internal::msgs::message::OpaqueMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3213,7 +3214,7 @@ mod test_quic {
         };
 
         let mut buf = Vec::new();
-        client_hello.into_opaque().encode(&mut buf);
+        OpaqueMessage::from(client_hello).encode(&mut buf);
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3240,6 +3241,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
+        use rustls::internal::msgs::message::OpaqueMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3282,7 +3284,7 @@ mod test_quic {
         };
 
         let mut buf = Vec::new();
-        client_hello.into_opaque().encode(&mut buf);
+        OpaqueMessage::from(client_hello).encode(&mut buf);
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3213,8 +3213,7 @@ mod test_quic {
             }),
         };
 
-        let mut buf = Vec::new();
-        OpaqueMessage::from(client_hello).encode(&mut buf);
+        let buf = OpaqueMessage::from(client_hello).encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3283,8 +3282,7 @@ mod test_quic {
             }),
         };
 
-        let mut buf = Vec::new();
-        OpaqueMessage::from(client_hello).encode(&mut buf);
+        let buf = OpaqueMessage::from(client_hello).encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3315,7 +3313,7 @@ mod test_quic {
 #[test]
 fn test_client_does_not_offer_sha1() {
     use rustls::internal::msgs::{
-        codec::Codec, enums::HandshakeType, handshake::HandshakePayload, message::MessagePayload,
+        codec::Reader, enums::HandshakeType, handshake::HandshakePayload, message::MessagePayload,
         message::OpaqueMessage,
     };
 
@@ -3328,7 +3326,7 @@ fn test_client_does_not_offer_sha1() {
             let sz = client
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
-            let msg = OpaqueMessage::read_bytes(&buf[..sz]).unwrap();
+            let msg = OpaqueMessage::read(&mut Reader::init(&buf[..sz])).unwrap();
             let msg = Message::try_from(msg).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3172,7 +3172,7 @@ mod test_quic {
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{
-            CipherSuite, Compression, ContentType, HandshakeType, NamedGroup, SignatureScheme,
+            CipherSuite, Compression, HandshakeType, NamedGroup, SignatureScheme,
         };
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
@@ -3190,7 +3190,6 @@ mod test_quic {
             .unwrap();
 
         let client_hello = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ClientHello,
@@ -3235,7 +3234,7 @@ mod test_quic {
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
         use rustls::internal::msgs::enums::{
-            CipherSuite, Compression, ContentType, HandshakeType, NamedGroup, SignatureScheme,
+            CipherSuite, Compression, HandshakeType, NamedGroup, SignatureScheme,
         };
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
@@ -3260,7 +3259,6 @@ mod test_quic {
         .unwrap();
 
         let client_hello = Message {
-            typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::ClientHello,

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -156,7 +156,7 @@ where
             let message = OpaqueMessage::read(&mut reader).unwrap();
             let mut message = Message::try_from(message).unwrap();
             filter(&mut message);
-            let message_enc = message.into_opaque().get_encoding();
+            let message_enc = OpaqueMessage::from(message).get_encoding();
             let message_enc_reader: &mut dyn io::Read = &mut &message_enc[..];
             let len = right
                 .read_tls(message_enc_reader)

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use rustls;
 use rustls_pemfile;
 
+use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage};
-use rustls::internal::msgs::{codec::Codec, codec::Reader};
 use rustls::Connection;
 use rustls::Error;
 use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore};
@@ -156,7 +156,7 @@ where
             let message = OpaqueMessage::read(&mut reader).unwrap();
             let mut message = Message::try_from(message).unwrap();
             filter(&mut message);
-            let message_enc = OpaqueMessage::from(message).get_encoding();
+            let message_enc = OpaqueMessage::from(message).encode();
             let message_enc_reader: &mut dyn io::Read = &mut &message_enc[..];
             let len = right
                 .read_tls(message_enc_reader)

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,10 +1,12 @@
+use std::convert::TryFrom;
 use std::io;
 use std::sync::Arc;
 
 use rustls;
 use rustls_pemfile;
 
-use rustls::internal::msgs::{codec::Codec, codec::Reader, message::Message};
+use rustls::internal::msgs::message::{Message, OpaqueMessage};
+use rustls::internal::msgs::{codec::Codec, codec::Reader};
 use rustls::Connection;
 use rustls::Error;
 use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore};
@@ -151,10 +153,10 @@ where
 
         let mut reader = Reader::init(&buf[..sz]);
         while reader.any_left() {
-            let mut message = Message::read(&mut reader).unwrap();
-            message.decode_payload();
+            let message = OpaqueMessage::read(&mut reader).unwrap();
+            let mut message = Message::try_from(message).unwrap();
             filter(&mut message);
-            let message_enc = message.get_encoding();
+            let message_enc = message.into_opaque().get_encoding();
             let message_enc_reader: &mut dyn io::Read = &mut &message_enc[..];
             let len = right
                 .read_tls(message_enc_reader)


### PR DESCRIPTION
Here we split an `OpaqueMessage` type out of the `Message` type. The `OpaqueMessage` type is read/written from/to I/O buffers, decrypted/encrypted and fragmented/joined. When that is done, it can be converted into a `Message` using a `TryFrom` impl. We remove the redundant `typ` field from the `Message` type to prevent redundant/inconsistent encoding of the content type, which is part of the `MessagePayload` enum. -40 lines net change and removes 4 unwraps.