### PR TITLE
Make QUIC state optional and boxed

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -97,11 +97,9 @@ fn find_session(
             None
         } else {
             #[cfg(feature = "quic")]
-            {
-                if cx.common.is_quic() {
-                    let params = PayloadU16::read(&mut reader)?;
-                    cx.common.quic.params = Some(params.0);
-                }
+            if let Some(quic) = &mut cx.common.quic {
+                let params = PayloadU16::read(&mut reader)?;
+                quic.params = Some(params.0);
             }
             Some(result)
         }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -561,18 +561,16 @@ impl quic::QuicExt for ClientConnection {
             None => return Ok(()),
         };
 
-        quic::read_hs(plaintext, &mut self.common.handshake_joiner, quic)?;
+        quic.read_hs(plaintext, &mut self.common.handshake_joiner)?;
         self.common
             .process_new_handshake_messages(&mut self.state, &mut self.data)
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::Keys> {
-        quic::write_hs(
-            buf,
-            self.common.quic.as_mut()?,
-            self.common.is_client,
-            &self.common.suite,
-        )
+        self.common
+            .quic
+            .as_mut()?
+            .write_hs(buf, self.common.is_client, &self.common.suite)
     }
 
     fn alert(&self) -> Option<AlertDescription> {
@@ -580,11 +578,10 @@ impl quic::QuicExt for ClientConnection {
     }
 
     fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
-        quic::next_1rtt_keys(
-            self.common.quic.as_mut()?,
-            self.common.is_client,
-            self.common.suite?,
-        )
+        self.common
+            .quic
+            .as_mut()?
+            .next_1rtt_keys(self.common.is_client, self.common.suite?)
     }
 }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -1,4 +1,6 @@
-use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Protocol, Reader, Writer};
+#[cfg(feature = "quic")]
+use crate::conn::Quic;
+use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Reader, Writer};
 use crate::error::Error;
 use crate::key;
 use crate::keylog::KeyLog;
@@ -10,14 +12,15 @@ use crate::msgs::enums::AlertDescription;
 use crate::msgs::enums::CipherSuite;
 use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::SignatureScheme;
-use crate::msgs::handshake::{CertificatePayload, ClientExtension};
+use crate::msgs::handshake::CertificatePayload;
+#[cfg(feature = "quic")]
+use crate::msgs::handshake::ClientExtension;
+#[cfg(feature = "quic")]
+use crate::quic;
 use crate::sign;
 use crate::suites::SupportedCipherSuite;
 use crate::verify;
 use crate::versions;
-
-#[cfg(feature = "quic")]
-use crate::quic;
 
 use std::fmt;
 use std::io::{self, IoSlice};
@@ -336,22 +339,7 @@ impl ClientConnection {
         config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
     ) -> Result<ClientConnection, Error> {
-        Self::new_inner(config, hostname, Vec::new(), Protocol::Tcp)
-    }
-
-    fn new_inner(
-        config: Arc<ClientConfig>,
-        hostname: webpki::DnsNameRef,
-        extra_exts: Vec<ClientExtension>,
-        proto: Protocol,
-    ) -> Result<Self, Error> {
-        let mut new = ClientConnection {
-            common: ConnectionCommon::new(config.mtu, true),
-            state: None,
-            data: ClientConnectionData::new(),
-        };
-        new.common.protocol = proto;
-
+        let mut new = Self::new_inner(config.mtu);
         let mut cx = hs::ClientContext {
             common: &mut new.common,
             data: &mut new.data,
@@ -359,11 +347,19 @@ impl ClientConnection {
 
         new.state = Some(hs::start_handshake(
             hostname.into(),
-            extra_exts,
+            vec![],
             config,
             &mut cx,
         )?);
         Ok(new)
+    }
+
+    fn new_inner(mtu: Option<usize>) -> Self {
+        ClientConnection {
+            common: ConnectionCommon::new(mtu, true),
+            state: None,
+            data: ClientConnectionData::new(),
+        }
     }
 
     /// Returns an `io::Write` implementer you can write bytes to
@@ -545,34 +541,52 @@ impl quic::QuicExt for ClientConnection {
     fn quic_transport_parameters(&self) -> Option<&[u8]> {
         self.common
             .quic
+            .as_ref()?
             .params
-            .as_ref()
-            .map(|v| v.as_ref())
+            .as_deref()
     }
 
     fn zero_rtt_keys(&self) -> Option<quic::DirectionalKeys> {
         Some(quic::DirectionalKeys::new(
             self.data.resumption_ciphersuite?,
-            self.common.quic.early_secret.as_ref()?,
+            self.common
+                .quic
+                .as_ref()?
+                .early_secret
+                .as_ref()?,
         ))
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
-        quic::read_hs(&mut self.common, plaintext)?;
+        let quic = match &mut self.common.quic {
+            Some(quic) => quic,
+            None => return Ok(()),
+        };
+
+        quic::read_hs(plaintext, &mut self.common.handshake_joiner, quic)?;
         self.common
             .process_new_handshake_messages(&mut self.state, &mut self.data)
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::Keys> {
-        quic::write_hs(&mut self.common, buf)
+        quic::write_hs(
+            buf,
+            self.common.quic.as_mut()?,
+            self.common.is_client,
+            &self.common.suite,
+        )
     }
 
     fn alert(&self) -> Option<AlertDescription> {
-        self.common.quic.alert
+        self.common.quic.as_ref()?.alert
     }
 
     fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
-        quic::next_1rtt_keys(&mut self.common)
+        quic::next_1rtt_keys(
+            self.common.quic.as_mut()?,
+            self.common.is_client,
+            self.common.suite?,
+        )
     }
 }
 
@@ -599,7 +613,21 @@ pub trait ClientQuicExt {
             quic::Version::V1 => ClientExtension::TransportParameters(params),
         };
 
-        ClientConnection::new_inner(config, hostname, vec![ext], Protocol::Quic)
+        let mut new = ClientConnection::new_inner(config.mtu);
+        new.common.quic = Some(Box::new(Quic::new()));
+
+        let mut cx = hs::ClientContext {
+            common: &mut new.common,
+            data: &mut new.data,
+        };
+
+        new.state = Some(hs::start_handshake(
+            hostname.into(),
+            vec![ext],
+            config,
+            &mut cx,
+        )?);
+        Ok(new)
     }
 }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "quic")]
-use crate::conn::Quic;
 use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Reader, Writer};
 use crate::error::Error;
 use crate::key;
@@ -16,7 +14,7 @@ use crate::msgs::handshake::CertificatePayload;
 #[cfg(feature = "quic")]
 use crate::msgs::handshake::ClientExtension;
 #[cfg(feature = "quic")]
-use crate::quic;
+use crate::quic::{self, Quic};
 use crate::sign;
 use crate::suites::SupportedCipherSuite;
 use crate::verify;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -14,6 +14,8 @@ use crate::msgs::hsjoiner::HandshakeJoiner;
 use crate::msgs::message::{BorrowedOpaqueMessage, Message, MessagePayload, OpaqueMessage};
 use crate::prf;
 use crate::quic;
+#[cfg(feature = "quic")]
+use crate::quic::Quic;
 use crate::rand;
 use crate::record_layer;
 use crate::suites::{SupportedCipherSuite, Tls12CipherSuite};
@@ -1076,32 +1078,4 @@ pub(crate) trait HandleState: Sized {
 pub enum MessageType {
     Handshake,
     Data(Message),
-}
-
-#[cfg(feature = "quic")]
-pub(crate) struct Quic {
-    /// QUIC transport parameters received from the peer during the handshake
-    pub params: Option<Vec<u8>>,
-    pub alert: Option<AlertDescription>,
-    pub hs_queue: VecDeque<(bool, Vec<u8>)>,
-    pub early_secret: Option<ring::hkdf::Prk>,
-    pub hs_secrets: Option<quic::Secrets>,
-    pub traffic_secrets: Option<quic::Secrets>,
-    /// Whether keys derived from traffic_secrets have been passed to the QUIC implementation
-    pub returned_traffic_keys: bool,
-}
-
-#[cfg(feature = "quic")]
-impl Quic {
-    pub fn new() -> Self {
-        Self {
-            params: None,
-            alert: None,
-            hs_queue: VecDeque::new(),
-            early_secret: None,
-            hs_secrets: None,
-            traffic_secrets: None,
-            returned_traffic_keys: false,
-        }
-    }
 }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -980,7 +980,7 @@ impl ConnectionCommon {
     pub fn send_msg(&mut self, m: Message, must_encrypt: bool) {
         #[cfg(feature = "quic")]
         {
-            if let Protocol::Quic = self.protocol {
+            if self.is_quic() {
                 if let MessagePayload::Alert(alert) = m.payload {
                     self.quic.alert = Some(alert.description);
                 } else {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "quic")]
-use crate::conn::Protocol;
 use crate::conn::{ConnectionCommon, ConnectionRandoms};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
@@ -146,7 +144,7 @@ impl ExtensionProcessing {
                 // For compatibility, strict ALPN validation is not employed unless targeting QUIC
                 #[cfg(feature = "quic")]
                 {
-                    if cx.common.protocol == Protocol::Quic && !our_protocols.is_empty() {
+                    if cx.common.is_quic() && !our_protocols.is_empty() {
                         cx.common
                             .send_fatal_alert(AlertDescription::NoApplicationProtocol);
                         return Err(Error::NoApplicationProtocol);

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "quic")]
-use crate::conn::Quic;
 use crate::conn::{Connection, ConnectionCommon, IoState, PlaintextSink, Reader, Writer};
 use crate::error::Error;
 use crate::key;
@@ -11,7 +9,7 @@ use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::SignatureScheme;
 use crate::msgs::handshake::ServerExtension;
 #[cfg(feature = "quic")]
-use crate::quic;
+use crate::quic::{self, Quic};
 use crate::sign;
 use crate::suites::SupportedCipherSuite;
 use crate::verify;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -458,18 +458,16 @@ impl quic::QuicExt for ServerConnection {
             None => return Ok(()),
         };
 
-        quic::read_hs(plaintext, &mut self.common.handshake_joiner, quic)?;
+        quic.read_hs(plaintext, &mut self.common.handshake_joiner)?;
         self.common
             .process_new_handshake_messages(&mut self.state, &mut self.data)
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::Keys> {
-        quic::write_hs(
-            buf,
-            self.common.quic.as_mut()?,
-            self.common.is_client,
-            &self.common.suite,
-        )
+        self.common
+            .quic
+            .as_mut()?
+            .write_hs(buf, self.common.is_client, &self.common.suite)
     }
 
     fn alert(&self) -> Option<AlertDescription> {
@@ -477,11 +475,10 @@ impl quic::QuicExt for ServerConnection {
     }
 
     fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
-        quic::next_1rtt_keys(
-            self.common.quic.as_mut()?,
-            self.common.is_client,
-            self.common.suite?,
-        )
+        self.common
+            .quic
+            .as_mut()?
+            .next_1rtt_keys(self.common.is_client, self.common.suite?)
     }
 }
 


### PR DESCRIPTION
Addresses the original issue from #520, and avoids allocating memory for QUIC state in non-QUIC connections at the cost of a single extra allocation per initialized QUIC connection.