### PR TITLE
Increase MSRV to 1.51.0.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.47.0 # our MSRV
+          - 1.51.0 # our MSRV
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:


### PR DESCRIPTION
Rust 1.51.0 was released 2021-03-25 which is very recently. However,
it is the first stable release that supports the `min_const_generics`
feature. Many Rust-based projects have upgraded their MSRV to 1.51.0
for this reason. Cargo 1.51.0 now also supports the new feature
resolver for the first time, which is another very important change
that will likely be useful for us.

I would like to use the `min_const_generics` feature in *ring*, and I
expect the new feature resolver will be useful for webpki and/or *ring*
soon, if not also by Rustls.

Rust 1.50.0 added `bool.and_then` which will allow us to simplify some
of the state machine logic. (Though, we can polyfill this.)