### PR TITLE
Thread config through handshake states

### DIFF
--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -15,6 +15,6 @@ fuzz_target!(|data: &[u8]| {
         .with_root_certificates(root_store, &[])
         .with_no_client_auth());
     let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
-    let mut client = ClientConnection::new(&config, example_com).unwrap();
+    let mut client = ClientConnection::new(config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));
 });

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -20,6 +20,6 @@ fuzz_target!(|data: &[u8]| {
                           .unwrap()
                           .with_no_client_auth()
                           .with_cert_resolver(Arc::new(Fail)));
-    let mut server= ServerConnection::new(&config);
+    let mut server = ServerConnection::new(config);
     let _ = server.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -45,7 +45,7 @@ impl TlsClient {
             socket: sock,
             closing: false,
             clean_closure: false,
-            tls_conn: rustls::ClientConnection::new(&cfg, hostname).unwrap(),
+            tls_conn: rustls::ClientConnection::new(cfg, hostname).unwrap(),
         }
     }
 

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -71,7 +71,7 @@ impl TlsServer {
                 Ok((socket, addr)) => {
                     debug!("Accepting new connection from {:?}", addr);
 
-                    let tls_conn = rustls::ServerConnection::new(&self.tls_config);
+                    let tls_conn = rustls::ServerConnection::new(Arc::clone(&self.tls_config));
                     let mode = self.mode.clone();
 
                     let token = mio::Token(self.next_id);

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -372,7 +372,7 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
     for _ in 0..rounds {
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
-        let mut server = ServerConnection::new(&server_config);
+        let mut server = ServerConnection::new(Arc::clone(&server_config));
 
         server_time += time(|| {
             transfer(&mut client, &mut server);
@@ -447,7 +447,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, mtu: Option<usize>) 
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
     let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
-    let mut server = ServerConnection::new(&server_config);
+    let mut server = ServerConnection::new(Arc::clone(&server_config));
 
     do_handshake(&mut client, &mut server);
 
@@ -515,7 +515,7 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
     let mut clients = Vec::with_capacity(conn_count);
 
     for _i in 0..conn_count {
-        servers.push(ServerConnection::new(&server_config));
+        servers.push(ServerConnection::new(Arc::clone(&server_config)));
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
         clients.push(ClientConnection::new(&client_config, dns_name).unwrap());
     }

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -371,7 +371,7 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
 
     for _ in 0..rounds {
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
+        let mut client = ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap();
         let mut server = ServerConnection::new(Arc::clone(&server_config));
 
         server_time += time(|| {
@@ -446,7 +446,7 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, mtu: Option<usize>) 
     ));
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-    let mut client = ClientConnection::new(&client_config, dns_name).unwrap();
+    let mut client = ClientConnection::new(client_config, dns_name).unwrap();
     let mut server = ServerConnection::new(Arc::clone(&server_config));
 
     do_handshake(&mut client, &mut server);
@@ -517,7 +517,7 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
     for _i in 0..conn_count {
         servers.push(ServerConnection::new(Arc::clone(&server_config)));
         let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        clients.push(ClientConnection::new(&client_config, dns_name).unwrap());
+        clients.push(ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap());
     }
 
     for _step in 0..5 {

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -1103,11 +1103,12 @@ fn main() {
             ClientOrServer::Server(s)
         } else {
             let dns_name = webpki::DnsNameRef::try_from_ascii_str(&opts.host_name).unwrap();
+            let ccfg = Arc::clone(ccfg.as_ref().unwrap());
             let c = if opts.quic_transport_params.is_empty() {
-                rustls::ClientConnection::new(ccfg.as_ref().unwrap(), dns_name)
+                rustls::ClientConnection::new(ccfg, dns_name)
             } else {
                 rustls::ClientConnection::new_quic(
-                    ccfg.as_ref().unwrap(),
+                    ccfg,
                     quic::Version::V1,
                     dns_name,
                     opts.quic_transport_params.clone(),

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -1089,11 +1089,12 @@ fn main() {
         ccfg: &Option<Arc<rustls::ClientConfig>>,
     ) -> ClientOrServer {
         if opts.server {
+            let scfg = Arc::clone(scfg.as_ref().unwrap());
             let s = if opts.quic_transport_params.is_empty() {
-                rustls::ServerConnection::new(scfg.as_ref().unwrap())
+                rustls::ServerConnection::new(scfg)
             } else {
                 rustls::ServerConnection::new_quic(
-                    scfg.as_ref().unwrap(),
+                    scfg,
                     quic::Version::V1,
                     opts.quic_transport_params.clone(),
                 )

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -53,7 +53,7 @@ fn communicate(
 ) -> Result<Verdict, Box<dyn StdError>> {
     let dns_name = webpki::DnsNameRef::try_from_ascii_str(&host).unwrap();
     let rc_config = Arc::new(config);
-    let mut client = ClientConnection::new(&rc_config, dns_name).unwrap();
+    let mut client = ClientConnection::new(rc_config, dns_name).unwrap();
     let mut stream = TcpStream::connect((&*host, port))?;
 
     client

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -26,7 +26,7 @@ fn main() {
     .with_no_client_auth();
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -11,7 +11,7 @@ use webpki_roots;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
     let dns_name = webpki::DnsNameRef::try_from_ascii_str(domain_name).unwrap();
-    let mut conn = rustls::ClientConnection::new(config, dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::clone(&config), dns_name).unwrap();
     let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -28,7 +28,7 @@ fn main() {
         .with_no_client_auth();
 
     let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(&Arc::new(config), dns_name).unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -113,7 +113,7 @@ fn find_session(
 pub(super) fn start_handshake(
     dns_name: webpki::DnsName,
     extra_exts: Vec<ClientExtension>,
-    config: &Arc<ClientConfig>,
+    config: Arc<ClientConfig>,
     cx: &mut ClientContext<'_>,
 ) -> NextStateOrError {
     let mut transcript = HandshakeHash::new();
@@ -129,13 +129,13 @@ pub(super) fn start_handshake(
     let mut session_id: Option<SessionID> = None;
     let mut resuming_session = find_session(
         dns_name.as_ref(),
-        config,
+        &config,
         #[cfg(feature = "quic")]
         cx,
     );
 
     let key_share = if support_tls13 {
-        Some(tls13::initial_key_share(config, dns_name.as_ref())?)
+        Some(tls13::initial_key_share(&config, dns_name.as_ref())?)
     } else {
         None
     };
@@ -167,7 +167,7 @@ pub(super) fn start_handshake(
     let sent_tls13_fake_ccs = false;
     let may_send_sct_list = config.verifier.request_scts();
     Ok(emit_client_hello_for_retry(
-        config.clone(),
+        config,
         cx,
         resuming_session,
         randoms,

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -333,14 +333,14 @@ impl ClientConnection {
     /// we behave in the TLS protocol, `hostname` is the
     /// hostname of who we want to talk to.
     pub fn new(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
     ) -> Result<ClientConnection, Error> {
         Self::new_inner(config, hostname, Vec::new(), Protocol::Tcp)
     }
 
     fn new_inner(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
         extra_exts: Vec<ClientExtension>,
         proto: Protocol,
@@ -583,7 +583,7 @@ pub trait ClientQuicExt {
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
     fn new_quic(
-        config: &Arc<ClientConfig>,
+        config: Arc<ClientConfig>,
         quic_version: quic::Version,
         hostname: webpki::DnsNameRef,
         params: Vec<u8>,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -130,7 +130,7 @@
 //! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);
 //! let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
-//! let mut client = rustls::ClientConnection::new(&rc_config, example_com);
+//! let mut client = rustls::ClientConnection::new(rc_config, example_com);
 //! ```
 //!
 //! Now you should do appropriate IO for the `client` object.  If `client.wants_read()` yields

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -227,17 +227,14 @@ pub struct ServerConnection {
 impl ServerConnection {
     /// Make a new ServerConnection.  `config` controls how
     /// we behave in the TLS protocol.
-    pub fn new(config: &Arc<ServerConfig>) -> ServerConnection {
+    pub fn new(config: Arc<ServerConfig>) -> ServerConnection {
         Self::from_config(config, vec![])
     }
 
-    fn from_config(config: &Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
+    fn from_config(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
         ServerConnection {
             common: ConnectionCommon::new(config.mtu, false),
-            state: Some(Box::new(hs::ExpectClientHello::new(
-                config.clone(),
-                extra_exts,
-            ))),
+            state: Some(Box::new(hs::ExpectClientHello::new(config, extra_exts))),
             data: ServerConnectionData::default(),
         }
     }
@@ -477,7 +474,7 @@ pub trait ServerQuicExt {
     /// in that it takes an extra argument, `params`, which contains the
     /// TLS-encoded transport parameters to send.
     fn new_quic(
-        config: &Arc<ServerConfig>,
+        config: Arc<ServerConfig>,
         quic_version: quic::Version,
         params: Vec<u8>,
     ) -> Result<ServerConnection, Error> {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -527,8 +527,7 @@ fn server_cert_resolve_with_sni() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("the-value-from-sni"))
-                .unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("the-value-from-sni")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -549,7 +548,7 @@ fn server_cert_resolve_with_alpn() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("sni-value")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("sni-value")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -569,7 +568,7 @@ fn client_trims_terminating_dot() {
         });
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("some-host.com.")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("some-host.com.")).unwrap();
         let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
@@ -592,8 +591,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
         ..Default::default()
     });
 
-    let mut client =
-        ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+    let mut client = ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
     let mut server = ServerConnection::new(Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
@@ -651,8 +649,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
 
         for client_config in AllClientVersions::new(client_config) {
             let mut client =
-                ClientConnection::new(&Arc::new(client_config), dns_name("value-not-sent"))
-                    .unwrap();
+                ClientConnection::new(Arc::new(client_config), dns_name("value-not-sent")).unwrap();
             let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
@@ -669,7 +666,7 @@ fn client_checks_server_certificate_with_given_name() {
 
         for client_config in AllClientVersions::new(client_config) {
             let mut client = ClientConnection::new(
-                &Arc::new(client_config),
+                Arc::new(client_config),
                 dns_name("not-the-right-hostname.com"),
             )
             .unwrap();
@@ -874,7 +871,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
+                    ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
@@ -908,7 +905,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
+                    ClientConnection::new(Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
@@ -943,7 +940,7 @@ mod test_clientverifier {
                 println!("Failing: {:?}", client_config.versions);
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
                     errs,
@@ -976,7 +973,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let err = do_handshake_until_error(&mut client, &mut server);
                 assert_eq!(
                     err,
@@ -1004,7 +1001,7 @@ mod test_clientverifier {
             for client_config in AllClientVersions::new(client_config) {
                 let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
-                    ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+                    ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
                 assert_eq!(
                     errs,
@@ -1962,7 +1959,7 @@ fn server_exposes_offered_sni() {
     let kt = KeyType::RSA;
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("second.testserver.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("second.testserver.com"))
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
@@ -1978,7 +1975,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
     let kt = KeyType::RSA;
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
                 .unwrap();
         let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
@@ -2000,7 +1997,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     for client_config in AllClientVersions::new(make_client_config(kt)) {
         let mut server = ServerConnection::new(Arc::clone(&server_config));
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
+            ClientConnection::new(Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
                 .unwrap();
 
         assert_eq!(None, server.sni_hostname());
@@ -2034,13 +2031,13 @@ fn sni_resolver_works() {
 
     let mut server1 = ServerConnection::new(Arc::clone(&server_config));
     let mut client1 =
-        ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
+        ClientConnection::new(Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
     let mut server2 = ServerConnection::new(Arc::clone(&server_config));
     let mut client2 =
-        ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
+        ClientConnection::new(Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
     let err = do_handshake_until_error(&mut client2, &mut server2);
     assert_eq!(
         err,
@@ -2982,7 +2979,7 @@ mod test_quic {
 
         // full handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            Arc::clone(&client_config),
             quic::Version::V1,
             dns_name("localhost"),
             client_params.into(),
@@ -3034,7 +3031,7 @@ mod test_quic {
 
         // 0-RTT handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            Arc::clone(&client_config),
             quic::Version::V1,
             dns_name("localhost"),
             client_params.into(),
@@ -3076,7 +3073,7 @@ mod test_quic {
             let mut client_config = (*client_config).clone();
             client_config.alpn_protocols = vec!["foo".into()];
             let mut client = ClientConnection::new_quic(
-                &Arc::new(client_config),
+                Arc::new(client_config),
                 quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
@@ -3108,7 +3105,7 @@ mod test_quic {
 
         // failed handshake
         let mut client = ClientConnection::new_quic(
-            &client_config,
+            client_config,
             quic::Version::V1,
             dns_name("example.com"),
             client_params.into(),
@@ -3151,7 +3148,7 @@ mod test_quic {
             let server_config = Arc::new(server_config);
 
             let mut client = ClientConnection::new_quic(
-                &client_config,
+                client_config,
                 quic::Version::V1,
                 dns_name("localhost"),
                 client_params.into(),
@@ -3186,7 +3183,7 @@ mod test_quic {
 
         assert!(
             ClientConnection::new_quic(
-                &client_config,
+                client_config,
                 quic::Version::V1,
                 dns_name("localhost"),
                 b"client params".to_vec(),
@@ -3582,7 +3579,7 @@ fn test_client_mtu_reduction() {
         client_config.set_mtu(&Some(64));
 
         let mut client =
-            ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
+            ClientConnection::new(Arc::new(client_config), dns_name("localhost")).unwrap();
         let writes = collect_write_lengths(&mut client);
         println!("writes at mtu=64: {:?}", writes);
         assert!(writes.iter().all(|x| *x <= 64));

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -529,7 +529,7 @@ fn server_cert_resolve_with_sni() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("the-value-from-sni"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -550,7 +550,7 @@ fn server_cert_resolve_with_alpn() {
 
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("sni-value")).unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -570,7 +570,7 @@ fn client_trims_terminating_dot() {
 
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("some-host.com.")).unwrap();
-        let mut server = ServerConnection::new(&Arc::new(server_config));
+        let mut server = ServerConnection::new(Arc::new(server_config));
 
         let err = do_handshake_until_error(&mut client, &mut server);
         assert_eq!(err.is_err(), true);
@@ -594,7 +594,7 @@ fn check_sigalgs_reduced_by_ciphersuite(
 
     let mut client =
         ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
-    let mut server = ServerConnection::new(&Arc::new(server_config));
+    let mut server = ServerConnection::new(Arc::new(server_config));
 
     let err = do_handshake_until_error(&mut client, &mut server);
     assert_eq!(err.is_err(), true);
@@ -653,7 +653,7 @@ fn client_with_sni_disabled_does_not_send_sni() {
             let mut client =
                 ClientConnection::new(&Arc::new(client_config), dns_name("value-not-sent"))
                     .unwrap();
-            let mut server = ServerConnection::new(&server_config);
+            let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(err.is_err(), true);
@@ -673,7 +673,7 @@ fn client_checks_server_certificate_with_given_name() {
                 dns_name("not-the-right-hostname.com"),
             )
             .unwrap();
-            let mut server = ServerConnection::new(&server_config);
+            let mut server = ServerConnection::new(Arc::clone(&server_config));
 
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
@@ -872,7 +872,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
@@ -906,7 +906,7 @@ mod test_clientverifier {
             let client_config = make_client_config(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("notlocalhost"))
                         .unwrap();
@@ -941,7 +941,7 @@ mod test_clientverifier {
 
             for client_config in AllClientVersions::new(client_config) {
                 println!("Failing: {:?}", client_config.versions);
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
@@ -974,7 +974,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let err = do_handshake_until_error(&mut client, &mut server);
@@ -1002,7 +1002,7 @@ mod test_clientverifier {
             let client_config = make_client_config_with_auth(*kt);
 
             for client_config in AllClientVersions::new(client_config) {
-                let mut server = ServerConnection::new(&server_config);
+                let mut server = ServerConnection::new(Arc::clone(&server_config));
                 let mut client =
                     ClientConnection::new(&Arc::new(client_config), dns_name("localhost")).unwrap();
                 let errs = do_handshake_until_both_error(&mut client, &mut server);
@@ -1964,7 +1964,7 @@ fn server_exposes_offered_sni() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("second.testserver.com"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(make_server_config(kt)));
+        let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
         assert_eq!(None, server.sni_hostname());
         do_handshake(&mut client, &mut server);
@@ -1980,7 +1980,7 @@ fn server_exposes_offered_sni_smashed_to_lowercase() {
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("SECOND.TESTServer.com"))
                 .unwrap();
-        let mut server = ServerConnection::new(&Arc::new(make_server_config(kt)));
+        let mut server = ServerConnection::new(Arc::new(make_server_config(kt)));
 
         assert_eq!(None, server.sni_hostname());
         do_handshake(&mut client, &mut server);
@@ -1998,7 +1998,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
     let server_config = Arc::new(server_config);
 
     for client_config in AllClientVersions::new(make_client_config(kt)) {
-        let mut server = ServerConnection::new(&server_config);
+        let mut server = ServerConnection::new(Arc::clone(&server_config));
         let mut client =
             ClientConnection::new(&Arc::new(client_config), dns_name("thisdoesNOTexist.com"))
                 .unwrap();
@@ -2032,13 +2032,13 @@ fn sni_resolver_works() {
     server_config.cert_resolver = Arc::new(resolver);
     let server_config = Arc::new(server_config);
 
-    let mut server1 = ServerConnection::new(&server_config);
+    let mut server1 = ServerConnection::new(Arc::clone(&server_config));
     let mut client1 =
         ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("localhost")).unwrap();
     let err = do_handshake_until_error(&mut client1, &mut server1);
     assert_eq!(err, Ok(()));
 
-    let mut server2 = ServerConnection::new(&server_config);
+    let mut server2 = ServerConnection::new(Arc::clone(&server_config));
     let mut client2 =
         ClientConnection::new(&Arc::new(make_client_config(kt)), dns_name("notlocalhost")).unwrap();
     let err = do_handshake_until_error(&mut client2, &mut server2);
@@ -2989,9 +2989,12 @@ mod test_quic {
         )
         .unwrap();
 
-        let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                .unwrap();
+        let mut server = ServerConnection::new_quic(
+            Arc::clone(&server_config),
+            quic::Version::V1,
+            server_params.into(),
+        )
+        .unwrap();
 
         let client_initial = step(&mut client, &mut server).unwrap();
         assert!(client_initial.is_none());
@@ -3043,9 +3046,12 @@ mod test_quic {
                 .is_some()
         );
 
-        let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                .unwrap();
+        let mut server = ServerConnection::new_quic(
+            Arc::clone(&server_config),
+            quic::Version::V1,
+            server_params.into(),
+        )
+        .unwrap();
 
         step(&mut client, &mut server).unwrap();
         assert_eq!(client.quic_transport_parameters(), Some(server_params));
@@ -3077,9 +3083,12 @@ mod test_quic {
             )
             .unwrap();
 
-            let mut server =
-                ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
-                    .unwrap();
+            let mut server = ServerConnection::new_quic(
+                Arc::clone(&server_config),
+                quic::Version::V1,
+                server_params.into(),
+            )
+            .unwrap();
 
             step(&mut client, &mut server).unwrap();
             assert_eq!(client.quic_transport_parameters(), Some(server_params));
@@ -3107,7 +3116,7 @@ mod test_quic {
         .unwrap();
 
         let mut server =
-            ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
+            ServerConnection::new_quic(server_config, quic::Version::V1, server_params.into())
                 .unwrap();
 
         step(&mut client, &mut server).unwrap();
@@ -3149,7 +3158,7 @@ mod test_quic {
             )
             .unwrap();
             let mut server =
-                ServerConnection::new_quic(&server_config, quic::Version::V1, server_params.into())
+                ServerConnection::new_quic(server_config, quic::Version::V1, server_params.into())
                     .unwrap();
 
             assert_eq!(
@@ -3194,7 +3203,7 @@ mod test_quic {
 
         assert!(
             ServerConnection::new_quic(
-                &server_config,
+                server_config,
                 quic::Version::V1,
                 b"server params".to_vec(),
             )
@@ -3225,7 +3234,7 @@ mod test_quic {
 
             let wrapped = Arc::new(server_config.clone());
             assert_eq!(
-                ServerConnection::new_quic(&wrapped, quic::Version::V1, b"server params".to_vec(),)
+                ServerConnection::new_quic(wrapped, quic::Version::V1, b"server params".to_vec(),)
                     .is_ok(),
                 ok
             );
@@ -3241,12 +3250,9 @@ mod test_quic {
         server_config.alpn_protocols = vec!["foo".into()];
         let server_config = Arc::new(server_config);
 
-        let mut server = ServerConnection::new_quic(
-            &server_config,
-            quic::Version::V1,
-            b"server params".to_vec(),
-        )
-        .unwrap();
+        let mut server =
+            ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())
+                .unwrap();
 
         use ring::rand::SecureRandom;
         use rustls::internal::msgs::base::PayloadU16;
@@ -3332,12 +3338,9 @@ mod test_quic {
             .compute_public_key()
             .unwrap();
 
-        let mut server = ServerConnection::new_quic(
-            &server_config,
-            quic::Version::V1,
-            b"server params".to_vec(),
-        )
-        .unwrap();
+        let mut server =
+            ServerConnection::new_quic(server_config, quic::Version::V1, b"server params".to_vec())
+                .unwrap();
 
         let client_hello = Message {
             version: ProtocolVersion::TLSv1_2,

--- a/rustls/tests/benchmarks.rs
+++ b/rustls/tests/benchmarks.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 fn bench_ewouldblock(c: &mut Criterion) {
     let server_config = make_server_config(KeyType::RSA);
-    let mut server = ServerConnection::new(&Arc::new(server_config));
+    let mut server = ServerConnection::new(Arc::new(server_config));
     let mut read_ewouldblock = FailsReads::new(io::ErrorKind::WouldBlock);
     c.bench_function("read_tls with EWOULDBLOCK", move |b| {
         b.iter(|| server.read_tls(&mut read_ewouldblock))

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -293,8 +293,8 @@ pub fn make_pair_for_arc_configs(
     server_config: &Arc<ServerConfig>,
 ) -> (ClientConnection, ServerConnection) {
     (
-        ClientConnection::new(client_config, dns_name("localhost")).unwrap(),
-        ServerConnection::new(server_config),
+        ClientConnection::new(&client_config, dns_name("localhost")).unwrap(),
+        ServerConnection::new(Arc::clone(server_config)),
     )
 }
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -293,7 +293,7 @@ pub fn make_pair_for_arc_configs(
     server_config: &Arc<ServerConfig>,
 ) -> (ClientConnection, ServerConnection) {
     (
-        ClientConnection::new(&client_config, dns_name("localhost")).unwrap(),
+        ClientConnection::new(Arc::clone(&client_config), dns_name("localhost")).unwrap(),
         ServerConnection::new(Arc::clone(server_config)),
     )
 }


### PR DESCRIPTION
As suggested in #665. This does not yet make the cache interface write only. It also makes obvious that we don't actually log keys after the initial handshake; ~~I'll file an issue for that~~ I think that's correct since the master secret is logged and other secrets are derived from it anyway?