### PR TITLE
Borrow Message payloads from OpaqueMessage

### DIFF
--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -16,6 +16,6 @@ fuzz_target!(|data: &[u8]| {
 
     while !dfm.frames.is_empty() {
         let msg = dfm.frames.pop_front().unwrap();
-        Message::try_from(msg).ok();
+        Message::try_from(&msg).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -15,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let msg = match message::Message::try_from(msg) {
+    let msg = match message::Message::try_from(&msg) {
         Ok(msg) => msg,
         Err(_) => return,
     };
@@ -25,6 +25,6 @@ fuzz_target!(|data: &[u8]| {
     frg.fragment(message::OpaqueMessage::from(msg), &mut out);
 
     for msg in out {
-        message::Message::try_from(msg).ok();
+        message::Message::try_from(&msg).ok();
     }
 });

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
     if let Ok(m) = OpaqueMessage::read(&mut rdr) {
-        let msg = match Message::try_from(m) {
+        let msg = match Message::try_from(&m) {
             Ok(msg) => msg,
             Err(_) => return,
         };

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -5,7 +5,7 @@ extern crate rustls;
 use rustls::internal::msgs::persist;
 use rustls::internal::msgs::codec::{Reader, Codec};
 
-fn try_type<T>(data: &[u8]) where T: Codec {
+fn try_type<'a, T>(data: &'a [u8]) where T: Codec<'a> {
     let mut rdr = Reader::init(data);
     T::read(&mut rdr);
 }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -262,7 +262,7 @@ impl PersistCache {
         while rd.any_left() {
             let key_pl = PayloadU16::read(&mut rd).unwrap();
             let val_pl = PayloadU16::read(&mut rd).unwrap();
-            cache.insert(key_pl.0, val_pl.0);
+            cache.insert(key_pl.0.to_vec(), val_pl.0.to_vec());
         }
     }
 }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -407,13 +407,13 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
     out
 }
 
-fn load_certs(filename: &str) -> Vec<rustls::Certificate> {
+fn load_certs(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -515,13 +515,13 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
     out
 }
 
-fn load_certs(filename: &str) -> Vec<rustls::Certificate> {
+fn load_certs(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -229,13 +229,13 @@ impl KeyType {
         }
     }
 
-    fn get_chain(&self) -> Vec<rustls::Certificate> {
+    fn get_chain(&self) -> Vec<rustls::Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(
             fs::File::open(self.path_for("end.fullchain")).unwrap(),
         ))
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
     }
 
@@ -249,13 +249,13 @@ impl KeyType {
         )
     }
 
-    fn get_client_chain(&self) -> Vec<rustls::Certificate> {
+    fn get_client_chain(&self) -> Vec<rustls::Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(
             fs::File::open(self.path_for("client.fullchain")).unwrap(),
         ))
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
     }
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -143,13 +143,13 @@ impl Options {
     }
 }
 
-fn load_cert(filename: &str) -> Vec<rustls::Certificate> {
+fn load_cert(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 
@@ -355,7 +355,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
         .unwrap()
         .with_client_cert_verifier(client_auth)
         .with_single_cert_with_ocsp_and_sct(
-            cert.clone(),
+            cert,
             key,
             opts.server_ocsp_response.clone(),
             opts.server_sct_list.clone(),

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -118,7 +118,7 @@ impl RootCertStore {
 
         for der_cert in der_certs {
             #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-            match self.add(&key::Certificate(der_cert.clone())) {
+            match self.add(&key::Certificate(der_cert.clone().into())) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
                     trace!("invalid cert der {:?}", der_cert);

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -109,7 +109,7 @@ impl ClientConfigBuilderWithCertVerifier {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
     ) -> Result<ClientConfig, Error> {
         let resolver = handy::AlwaysResolvesClientCert::new(cert_chain, &key_der)?;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -12,14 +12,14 @@ use std::sync::Arc;
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
     pub ocsp_response: Vec<u8>,
-    pub scts: Option<SCTList>,
+    pub scts: Option<SCTList<'static>>,
 }
 
 impl ServerCertDetails {
     pub fn new(
         cert_chain: CertificatePayload,
         ocsp_response: Vec<u8>,
-        scts: Option<SCTList>,
+        scts: Option<SCTList<'static>>,
     ) -> ServerCertDetails {
         ServerCertDetails {
             cert_chain,
@@ -33,17 +33,17 @@ impl ServerCertDetails {
             .as_deref()
             .unwrap_or(&[])
             .iter()
-            .map(|payload| payload.0.as_slice())
+            .map(|payload| payload.0.as_ref())
     }
 }
 
 pub struct ServerKxDetails {
     pub kx_params: Vec<u8>,
-    pub kx_sig: DigitallySignedStruct,
+    pub kx_sig: DigitallySignedStruct<'static>,
 }
 
 impl ServerKxDetails {
-    pub fn new(params: Vec<u8>, sig: DigitallySignedStruct) -> ServerKxDetails {
+    pub fn new(params: Vec<u8>, sig: DigitallySignedStruct<'static>) -> ServerKxDetails {
         ServerKxDetails {
             kx_params: params,
             kx_sig: sig,

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -10,14 +10,14 @@ use crate::sign;
 use std::sync::Arc;
 
 pub struct ServerCertDetails {
-    pub cert_chain: CertificatePayload,
+    pub cert_chain: CertificatePayload<'static>,
     pub ocsp_response: Vec<u8>,
     pub scts: Option<SCTList<'static>>,
 }
 
 impl ServerCertDetails {
     pub fn new(
-        cert_chain: CertificatePayload,
+        cert_chain: CertificatePayload<'static>,
         ocsp_response: Vec<u8>,
         scts: Option<SCTList<'static>>,
     ) -> ServerCertDetails {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -76,7 +76,7 @@ pub struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
     pub fn new(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesClientCert, Error> {
         let key = sign::any_supported_type(priv_key)

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -602,8 +602,8 @@ pub trait ClientQuicExt {
         }
 
         let ext = match quic_version {
-            quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params),
-            quic::Version::V1 => ClientExtension::TransportParameters(params),
+            quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params.into()),
+            quic::Version::V1 => ClientExtension::TransportParameters(params.into()),
         };
 
         ClientConnection::new_inner(config, hostname, vec![ext], Protocol::Quic)

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -349,7 +349,7 @@ impl ClientConnection {
     fn new_inner(
         config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
-        extra_exts: Vec<ClientExtension>,
+        extra_exts: Vec<ClientExtension<'static>>,
         proto: Protocol,
     ) -> Result<Self, Error> {
         let mut new = ClientConnection {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -470,7 +470,7 @@ impl Connection for ClientConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
+    fn peer_certificates(&self) -> Option<&[key::Certificate<'static>]> {
         if self.data.server_cert_chain.is_empty() {
             return None;
         }
@@ -532,7 +532,7 @@ impl PlaintextSink for ClientConnection {
 }
 
 struct ClientConnectionData {
-    server_cert_chain: CertificatePayload,
+    server_cert_chain: CertificatePayload<'static>,
     early_data: EarlyData,
     resumption_ciphersuite: Option<&'static SupportedCipherSuite>,
 }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -625,7 +625,7 @@ impl hs::State for ExpectCertificateRequest {
                 .choose_scheme(&compat_sigschemes);
             client_auth.certkey = Some(certkey);
             client_auth.signer = maybe_signer;
-            client_auth.auth_context = Some(certreq.context.0.clone());
+            client_auth.auth_context = Some(certreq.context.0.to_vec());
         } else {
             debug!("Client auth requested but no cert selected");
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -465,7 +465,9 @@ impl hs::State for ExpectEncryptedExtensions {
 
             cx.data.server_cert_chain = resuming_session
                 .server_cert_chain
-                .clone();
+                .iter()
+                .map(|x| x.to_owned())
+                .collect();
 
             // We *don't* reverify the certificate chain here: resumption is a
             // continuation of the previous session in terms of security policy.
@@ -812,7 +814,7 @@ fn emit_certificate_tls13(
         for cert in &cert_key.cert {
             cert_payload
                 .entries
-                .push(CertificateEntry::new(cert.clone()));
+                .push(CertificateEntry::new(cert.to_owned()));
         }
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -656,7 +656,7 @@ impl ConnectionCommon {
         }
 
         // Now we can fully parse the message payload.
-        let msg = Message::try_from(msg)?;
+        let msg = Message::try_from(&msg)?;
 
         // For alerts, we have separate logic.
         if let MessagePayload::Alert(alert) = &msg.payload {
@@ -706,7 +706,7 @@ impl ConnectionCommon {
     /// to handle the message.
     fn process_main_protocol<S: HandleState>(
         &mut self,
-        msg: Message,
+        msg: Message<'_>,
         state: &mut Option<S>,
         data: &mut S::Data,
     ) -> Result<(), Error> {
@@ -972,7 +972,7 @@ impl ConnectionCommon {
     }
 
     /// Send a raw TLS message, fragmenting it if needed.
-    pub fn send_msg(&mut self, m: Message, must_encrypt: bool) {
+    pub fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
         #[cfg(feature = "quic")]
         {
             if let Protocol::Quic = self.protocol {
@@ -1004,7 +1004,7 @@ impl ConnectionCommon {
         }
     }
 
-    pub fn take_received_plaintext(&mut self, bytes: Payload) {
+    pub fn take_received_plaintext(&mut self, bytes: Payload<'_>) {
         self.received_plaintext
             .append(bytes.0.into_owned());
     }
@@ -1076,7 +1076,7 @@ pub(crate) trait HandleState: Sized {
 
     fn handle(
         self,
-        message: Message,
+        message: Message<'_>,
         data: &mut Self::Data,
         common: &mut ConnectionCommon,
     ) -> Result<Self, Error>;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1005,7 +1005,8 @@ impl ConnectionCommon {
     }
 
     pub fn take_received_plaintext(&mut self, bytes: Payload) {
-        self.received_plaintext.append(bytes.0);
+        self.received_plaintext
+            .append(bytes.0.into_owned());
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -20,13 +20,13 @@ pub struct PrivateKey(pub Vec<u8>);
 #[derive(Clone, Eq, PartialEq)]
 pub struct Certificate(pub Vec<u8>);
 
-impl Codec for Certificate {
+impl<'a> Codec<'a> for Certificate {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.0.len() as u32).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Certificate> {
+    fn read(r: &mut Reader<'a>) -> Option<Certificate> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();

--- a/rustls/src/key_schedule.rs
+++ b/rustls/src/key_schedule.rs
@@ -517,7 +517,7 @@ impl hkdf::KeyType for PayloadU8Len {
     }
 }
 
-impl From<hkdf::Okm<'_, PayloadU8Len>> for PayloadU8 {
+impl From<hkdf::Okm<'_, PayloadU8Len>> for PayloadU8<'static> {
     fn from(okm: hkdf::Okm<PayloadU8Len>) -> Self {
         let mut r = vec![0u8; okm.len().0];
         okm.fill(&mut r[..]).unwrap();

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -7,13 +7,13 @@ pub struct AlertMessagePayload {
     pub description: AlertDescription,
 }
 
-impl Codec for AlertMessagePayload {
+impl<'a> Codec<'a> for AlertMessagePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.level.encode(bytes);
         self.description.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<AlertMessagePayload> {
+    fn read(r: &mut Reader<'a>) -> Option<AlertMessagePayload> {
         let level = AlertLevel::read(r)?;
         let description = AlertDescription::read(r)?;
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,6 +1,6 @@
-use crate::key;
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
+
 /// An externally length'd payload
 #[derive(Debug, Clone, PartialEq)]
 pub struct Payload(pub Vec<u8>);
@@ -26,20 +26,6 @@ impl Payload {
 
     pub fn read(r: &mut Reader) -> Self {
         Self(r.rest().to_vec())
-    }
-}
-
-impl Codec for key::Certificate {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        codec::u24(self.0.len() as u32).encode(bytes);
-        bytes.extend_from_slice(&self.0);
-    }
-
-    fn read(r: &mut Reader) -> Option<key::Certificate> {
-        let len = codec::u24::read(r)?.0 as usize;
-        let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(key::Certificate(body))
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -4,66 +4,74 @@ use crate::msgs::codec::{Codec, Reader};
 use std::borrow::Cow;
 
 /// An externally length'd payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct Payload(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct Payload<'a>(pub Cow<'a, [u8]>);
 
-impl Codec for Payload {
+impl<'a> Codec<'a> for Payload<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Payload> {
+    fn read(r: &mut Reader<'a>) -> Option<Payload<'a>> {
         Some(Payload::read(r))
     }
 }
 
-impl Payload {
-    pub fn new(bytes: impl Into<Vec<u8>>) -> Payload {
-        Payload(bytes.into().into())
+impl<'a> Payload<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> Self {
+        Payload(bytes.into())
     }
 
-    pub fn empty() -> Payload {
+    pub fn empty() -> Payload<'static> {
         Payload::new(Vec::new())
     }
 
-    pub fn read(r: &mut Reader) -> Self {
-        Self::new(r.rest().to_vec())
+    pub fn to_owned(&self) -> Payload<'static> {
+        Payload::new(self.0.to_vec())
+    }
+
+    pub fn read(r: &mut Reader<'a>) -> Self {
+        Self::new(r.rest())
     }
 }
 
 /// An arbitrary, unknown-content, u24-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU24(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU24<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU24 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU24 {
+impl<'a> PayloadU24<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU24<'a> {
         PayloadU24(bytes.into())
+    }
+
+    pub fn to_owned(&self) -> PayloadU24<'static> {
+        PayloadU24::new(self.0.to_vec())
     }
 }
 
-impl Codec for PayloadU24 {
+impl<'a> Codec<'a> for PayloadU24<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.0.len() as u32).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU24> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU24<'a>> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
-        Some(PayloadU24::new(sub.rest().to_vec()))
+        Some(PayloadU24::new(sub.rest()))
     }
 }
 
 /// An arbitrary, unknown-content, u16-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU16(pub Vec<u8>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU16<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU16 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU16 {
-        PayloadU16(bytes)
+impl<'a> PayloadU16<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU16<'a> {
+        PayloadU16(bytes.into())
     }
 
-    pub fn empty() -> PayloadU16 {
+    pub fn empty() -> PayloadU16<'static> {
         PayloadU16::new(Vec::new())
     }
 
@@ -71,49 +79,55 @@ impl PayloadU16 {
         (slice.len() as u16).encode(bytes);
         bytes.extend_from_slice(slice);
     }
+
+    pub fn to_owned(&self) -> PayloadU16<'static> {
+        PayloadU16::new(self.0.to_vec())
+    }
 }
 
-impl Codec for PayloadU16 {
+impl<'a> Codec<'a> for PayloadU16<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         Self::encode_slice(&self.0, bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU16> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU16<'a>> {
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(PayloadU16(body))
+        Some(PayloadU16::new(sub.rest()))
     }
 }
 
 /// An arbitrary, unknown-content, u8-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU8(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU8<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU8 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU8 {
+impl<'a> PayloadU8<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU8<'a> {
         PayloadU8(bytes.into())
     }
 
-    pub fn empty() -> PayloadU8 {
-        PayloadU8::new(Vec::new())
+    pub fn empty() -> PayloadU8<'static> {
+        PayloadU8(Vec::new().into())
     }
 
     pub fn into_inner(self) -> Vec<u8> {
         self.0.into_owned()
     }
+
+    pub fn to_owned(&self) -> PayloadU8<'static> {
+        PayloadU8::new(self.0.to_vec())
+    }
 }
 
-impl Codec for PayloadU8 {
+impl<'a> Codec<'a> for PayloadU8<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         (self.0.len() as u8).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU8> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU8<'a>> {
         let len = u8::read(r)? as usize;
         let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(PayloadU8::new(body))
+        Some(PayloadU8::new(sub.rest()))
     }
 }

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -3,12 +3,12 @@ use crate::msgs::codec::{Codec, Reader};
 #[derive(Debug)]
 pub struct ChangeCipherSpecPayload;
 
-impl Codec for ChangeCipherSpecPayload {
+impl<'a> Codec<'a> for ChangeCipherSpecPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         1u8.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<ChangeCipherSpecPayload> {
+    fn read(r: &mut Reader<'a>) -> Option<ChangeCipherSpecPayload> {
         let typ = u8::read(r)?;
 
         if typ == 1 && !r.any_left() {

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -49,13 +49,13 @@ impl<'a> Reader<'a> {
 }
 
 /// Things we can encode and read from a Reader.
-pub trait Codec: Debug + Sized {
+pub trait Codec<'a>: Debug + Sized {
     /// Encode yourself by appending onto `bytes`.
     fn encode(&self, bytes: &mut Vec<u8>);
 
     /// Decode yourself by fiddling with the `Reader`.
     /// Return Some if it worked, None if not.
-    fn read(_: &mut Reader) -> Option<Self>;
+    fn read(_: &mut Reader<'a>) -> Option<Self>;
 
     /// Convenience function to get the results of `encode()`.
     fn get_encoding(&self) -> Vec<u8> {
@@ -66,7 +66,7 @@ pub trait Codec: Debug + Sized {
 
     /// Read one of these from the front of `bytes` and
     /// return it.
-    fn read_bytes(bytes: &[u8]) -> Option<Self> {
+    fn read_bytes(bytes: &'a [u8]) -> Option<Self> {
         let mut rd = Reader::init(bytes);
         Self::read(&mut rd)
     }
@@ -78,7 +78,7 @@ fn decode_u8(bytes: &[u8]) -> Option<u8> {
     Some(value)
 }
 
-impl Codec for u8 {
+impl<'a> Codec<'a> for u8 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.push(*self);
     }
@@ -96,7 +96,7 @@ pub fn decode_u16(bytes: &[u8]) -> Option<u16> {
     Some(u16::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u16 {
+impl<'a> Codec<'a> for u16 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let mut b16 = [0u8; 2];
         put_u16(*self, &mut b16);
@@ -128,7 +128,7 @@ impl From<u24> for usize {
     }
 }
 
-impl Codec for u24 {
+impl<'a> Codec<'a> for u24 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let be_bytes = u32::to_be_bytes(self.0);
         bytes.extend_from_slice(&be_bytes[1..])
@@ -143,7 +143,7 @@ pub fn decode_u32(bytes: &[u8]) -> Option<u32> {
     Some(u32::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u32 {
+impl<'a> Codec<'a> for u32 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend(&u32::to_be_bytes(*self))
     }
@@ -162,7 +162,7 @@ pub fn decode_u64(bytes: &[u8]) -> Option<u64> {
     Some(u64::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u64 {
+impl<'a> Codec<'a> for u64 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let mut b64 = [0u8; 8];
         put_u64(*self, &mut b64);
@@ -174,7 +174,10 @@ impl Codec for u64 {
     }
 }
 
-pub fn encode_vec_u8<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u8<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -185,7 +188,10 @@ pub fn encode_vec_u8<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn encode_vec_u16<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u16<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -196,7 +202,10 @@ pub fn encode_vec_u16<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn encode_vec_u24<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u24<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -207,7 +216,7 @@ pub fn encode_vec_u24<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u8<'a, T: Codec<'a>>(r: &mut Reader<'a>) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u8::read(r)?);
     let mut sub = r.sub(len)?;
@@ -219,7 +228,7 @@ pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
     Some(ret)
 }
 
-pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u16<'a, T: Codec<'a>>(r: &mut Reader<'a>) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u16::read(r)?);
     let mut sub = r.sub(len)?;
@@ -231,7 +240,10 @@ pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
     Some(ret)
 }
 
-pub fn read_vec_u24_limited<T: Codec>(r: &mut Reader, max_bytes: usize) -> Option<Vec<T>> {
+pub fn read_vec_u24_limited<'a, T: Codec<'a>>(
+    r: &mut Reader<'a>,
+    max_bytes: usize,
+) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = u24::read(r)?.0 as usize;
     if len > max_bytes {

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -8,20 +8,20 @@ pub struct Reader<'a> {
 }
 
 impl<'a> Reader<'a> {
-    pub fn init(bytes: &[u8]) -> Reader {
+    pub fn init(bytes: &'a [u8]) -> Reader<'a> {
         Reader {
             buf: bytes,
             offs: 0,
         }
     }
 
-    pub fn rest(&mut self) -> &[u8] {
+    pub fn rest(&mut self) -> &'a [u8] {
         let ret = &self.buf[self.offs..];
         self.offs = self.buf.len();
         ret
     }
 
-    pub fn take(&mut self, len: usize) -> Option<&[u8]> {
+    pub fn take(&mut self, len: usize) -> Option<&'a [u8]> {
         if self.left() < len {
             return None;
         }
@@ -43,7 +43,7 @@ impl<'a> Reader<'a> {
         self.offs
     }
 
-    pub fn sub(&mut self, len: usize) -> Option<Reader> {
+    pub fn sub(&mut self, len: usize) -> Option<Reader<'a>> {
         self.take(len).map(Reader::init)
     }
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -243,13 +243,13 @@ mod tests {
     fn pop_first(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Handshake);
-        Message::try_from(m).unwrap();
+        Message::try_from(&m).unwrap();
     }
 
     fn pop_second(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Alert);
-        Message::try_from(m).unwrap();
+        Message::try_from(&m).unwrap();
     }
 
     #[test]

--- a/rustls/src/msgs/enums_test.rs
+++ b/rustls/src/msgs/enums_test.rs
@@ -3,19 +3,28 @@
 use super::codec::Codec;
 use super::enums::*;
 
-fn get8<T: Codec>(enum_value: &T) -> u8 {
+fn get8<T>(enum_value: &T) -> u8
+where
+    for<'a> T: Codec<'a>,
+{
     let enc = enum_value.get_encoding();
     assert_eq!(enc.len(), 1);
     enc[0]
 }
 
-fn get16<T: Codec>(enum_value: &T) -> u16 {
+fn get16<T>(enum_value: &T) -> u16
+where
+    for<'a> T: Codec<'a>,
+{
     let enc = enum_value.get_encoding();
     assert_eq!(enc.len(), 2);
     (enc[0] as u16 >> 8) | (enc[1] as u16)
 }
 
-fn test_enum16<T: Codec>(first: T, last: T) {
+fn test_enum16<T>(first: T, last: T)
+where
+    for<'a> T: Codec<'a>,
+{
     let first_v = get16(&first);
     let last_v = get16(&last);
 
@@ -29,7 +38,10 @@ fn test_enum16<T: Codec>(first: T, last: T) {
     }
 }
 
-fn test_enum8<T: Codec>(first: T, last: T) {
+fn test_enum8<T>(first: T, last: T)
+where
+    for<'a> T: Codec<'a>,
+{
     let first_v = get8(&first);
     let last_v = get8(&last);
 

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -1,4 +1,3 @@
-use crate::msgs::base::Payload;
 use crate::msgs::enums::{ContentType, ProtocolVersion};
 use crate::msgs::message::{BorrowedOpaqueMessage, OpaqueMessage};
 use std::collections::VecDeque;
@@ -28,16 +27,16 @@ impl MessageFragmenter {
     /// Payloads are copied.
     pub fn fragment(&self, msg: OpaqueMessage, out: &mut VecDeque<OpaqueMessage>) {
         // Non-fragment path
-        if msg.payload.0.len() <= self.max_frag {
+        if msg.payload.len() <= self.max_frag {
             out.push_back(msg);
             return;
         }
 
-        for chunk in msg.payload.0.chunks(self.max_frag) {
+        for chunk in msg.payload.chunks(self.max_frag) {
             out.push_back(OpaqueMessage {
                 typ: msg.typ,
                 version: msg.version,
-                payload: Payload(chunk.to_vec()),
+                payload: chunk.to_vec(),
             });
         }
     }
@@ -65,7 +64,6 @@ impl MessageFragmenter {
 #[cfg(test)]
 mod tests {
     use super::{MessageFragmenter, PACKET_OVERHEAD};
-    use crate::msgs::base::Payload;
     use crate::msgs::enums::{ContentType, ProtocolVersion};
     use crate::msgs::message::OpaqueMessage;
     use std::collections::VecDeque;
@@ -82,7 +80,7 @@ mod tests {
 
         assert_eq!(&m.typ, typ);
         assert_eq!(&m.version, version);
-        assert_eq!(m.payload.0, bytes.to_vec());
+        assert_eq!(m.payload, bytes.to_vec());
 
         assert_eq!(total_len, buf.len());
     }
@@ -94,7 +92,7 @@ mod tests {
         let m = OpaqueMessage {
             typ,
             version,
-            payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
+            payload: b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec(),
         };
 
         let frag = MessageFragmenter::new(3);
@@ -129,7 +127,7 @@ mod tests {
         let m = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
+            payload: b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec(),
         };
 
         let frag = MessageFragmenter::new(8);

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -76,7 +76,7 @@ mod tests {
         bytes: &[u8],
     ) {
         let m = mm.unwrap();
-        let buf = m.clone().encode();
+        let buf = m.to_owned().encode();
 
         assert_eq!(&m.typ, typ);
         assert_eq!(&m.version, version);

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1322,7 +1322,7 @@ impl CertificateExtension {
         CertificateExtension::SignedCertificateTimestamp(sctl)
     }
 
-    pub fn get_cert_status(&self) -> Option<&Vec<u8>> {
+    pub fn get_cert_status(&self) -> Option<&[u8]> {
         match *self {
             CertificateExtension::CertificateStatus(ref cs) => Some(&cs.ocsp_response.0),
             _ => None,
@@ -1424,7 +1424,7 @@ impl CertificateEntry {
         })
     }
 
-    pub fn get_ocsp_response(&self) -> Option<&Vec<u8>> {
+    pub fn get_ocsp_response(&self) -> Option<&[u8]> {
         self.exts
             .iter()
             .find(|ext| ext.get_type() == ExtensionType::StatusRequest)
@@ -1501,7 +1501,7 @@ impl CertificatePayloadTLS13 {
         self.entries
             .first()
             .and_then(CertificateEntry::get_ocsp_response)
-            .cloned()
+            .map(|bytes| bytes.to_vec())
             .unwrap_or_else(Vec::new)
     }
 
@@ -2100,7 +2100,7 @@ impl CertificateStatus {
     }
 
     pub fn into_inner(self) -> Vec<u8> {
-        self.ocsp_response.0
+        self.ocsp_response.0.into_owned()
     }
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -370,8 +370,8 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             ClientExtension::make_sni(DnsNameRef::try_from_ascii_str("hello").unwrap()),
             ClientExtension::SessionTicketRequest,
-            ClientExtension::SessionTicketOffer(Payload(vec![])),
-            ClientExtension::Protocols(vec![PayloadU8(vec![0])]),
+            ClientExtension::SessionTicketOffer(Payload(vec![].into())),
+            ClientExtension::Protocols(vec![PayloadU8(vec![0].into())]),
             ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
             ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])]),
             ClientExtension::PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
@@ -392,7 +392,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::TransportParameters(vec![1, 2, 3]),
             ClientExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -500,7 +500,7 @@ fn test_client_extension_getter(typ: ExtensionType, getter: fn(&ClientHelloPaylo
 
     chp.extensions = vec![ClientExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&chp));
 }
@@ -619,7 +619,7 @@ fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRe
 
     hrr.extensions = vec![HelloRetryExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&hrr));
 }
@@ -688,7 +688,7 @@ fn test_server_extension_getter(typ: ExtensionType, getter: fn(&ServerHelloPaylo
 
     shp.extensions = vec![ServerExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&shp));
 }
@@ -738,7 +738,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
 
     ce.exts = vec![CertificateExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&ce));
 }
@@ -766,8 +766,8 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::ECPointFormats(ECPointFormatList::supported()),
             ServerExtension::ServerNameAck,
             ServerExtension::SessionTicketAck,
-            ServerExtension::RenegotiationInfo(PayloadU8(vec![0])),
-            ServerExtension::Protocols(vec![PayloadU8(vec![0])]),
+            ServerExtension::RenegotiationInfo(PayloadU8(vec![0].into())),
+            ServerExtension::Protocols(vec![PayloadU8(vec![0].into())]),
             ServerExtension::KeyShare(KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])),
             ServerExtension::PresharedKey(3),
             ServerExtension::ExtendedMasterSecretAck,
@@ -777,7 +777,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::TransportParameters(vec![1, 2, 3]),
             ServerExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -806,7 +806,7 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
             HelloRetryExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
             HelloRetryExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -814,17 +814,17 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
 
 fn get_sample_certificatepayloadtls13() -> CertificatePayloadTLS13 {
     CertificatePayloadTLS13 {
-        context: PayloadU8(vec![1, 2, 3]),
+        context: PayloadU8(vec![1, 2, 3].into()),
         entries: vec![CertificateEntry {
             cert: Certificate(vec![3, 4, 5]),
             exts: vec![
                 CertificateExtension::CertificateStatus(CertificateStatus {
-                    ocsp_response: PayloadU24(vec![1, 2, 3]),
+                    ocsp_response: PayloadU24(vec![1, 2, 3].into()),
                 }),
                 CertificateExtension::SignedCertificateTimestamp(vec![PayloadU16(vec![0])]),
                 CertificateExtension::Unknown(UnknownExtension {
                     typ: ExtensionType::Unknown(12345),
-                    payload: Payload(vec![1, 2, 3]),
+                    payload: Payload(vec![1, 2, 3].into()),
                 }),
             ],
         }],
@@ -838,7 +838,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
                 curve_type: ECCurveType::NamedCurve,
                 named_group: NamedGroup::X25519,
             },
-            public: PayloadU8(vec![1, 2, 3]),
+            public: PayloadU8(vec![1, 2, 3].into()),
         },
         dss: DigitallySignedStruct {
             scheme: SignatureScheme::RSA_PSS_SHA256,
@@ -848,7 +848,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
 }
 
 fn get_sample_serverkeyexchangepayload_unknown() -> ServerKeyExchangePayload {
-    ServerKeyExchangePayload::Unknown(Payload(vec![1, 2, 3]))
+    ServerKeyExchangePayload::Unknown(Payload(vec![1, 2, 3].into()))
 }
 
 fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
@@ -861,13 +861,13 @@ fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
 
 fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTLS13 {
     CertificateRequestPayloadTLS13 {
-        context: PayloadU8(vec![1, 2, 3]),
+        context: PayloadU8(vec![1, 2, 3].into()),
         extensions: vec![
             CertReqExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             CertReqExtension::AuthorityNames(vec![PayloadU16(vec![1, 2, 3])]),
             CertReqExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -884,11 +884,11 @@ fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTLS13 {
     NewSessionTicketPayloadTLS13 {
         lifetime: 123,
         age_add: 1234,
-        nonce: PayloadU8(vec![1, 2, 3]),
+        nonce: PayloadU8(vec![1, 2, 3].into()),
         ticket: PayloadU16(vec![4, 5, 6]),
         exts: vec![NewSessionTicketExtension::Unknown(UnknownExtension {
             typ: ExtensionType::Unknown(12345),
-            payload: Payload(vec![1, 2, 3]),
+            payload: Payload(vec![1, 2, 3].into()),
         })],
     }
 }
@@ -899,7 +899,7 @@ fn get_sample_encryptedextensions() -> EncryptedExtensions {
 
 fn get_sample_certificatestatus() -> CertificateStatus {
     CertificateStatus {
-        ocsp_response: PayloadU24(vec![1, 2, 3]),
+        ocsp_response: PayloadU24(vec![1, 2, 3].into()),
     }
 }
 
@@ -947,7 +947,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -967,7 +967,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -975,7 +975,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3].into())),
         },
     ]
 }
@@ -1086,7 +1086,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -1108,7 +1108,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -1116,7 +1116,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3].into())),
         },
     ]
 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -389,7 +389,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload<'static> {
             ClientExtension::ExtendedMasterSecretRequest,
             ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()),
             ClientExtension::SignedCertificateTimestampRequest,
-            ClientExtension::TransportParameters(vec![1, 2, 3]),
+            ClientExtension::TransportParameters(vec![1, 2, 3].into()),
             ClientExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
                 payload: Payload(vec![1, 2, 3].into()),
@@ -773,7 +773,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload<'static> {
             ServerExtension::CertificateStatusAck,
             ServerExtension::SignedCertificateTimestamp(vec![PayloadU16(vec![0].into())]),
             ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
-            ServerExtension::TransportParameters(vec![1, 2, 3]),
+            ServerExtension::TransportParameters(vec![1, 2, 3].into()),
             ServerExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
                 payload: Payload(vec![1, 2, 3].into()),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -808,7 +808,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTLS13<'static> {
     CertificatePayloadTLS13 {
         context: PayloadU8(vec![1, 2, 3].into()),
         entries: vec![CertificateEntry {
-            cert: Certificate(vec![3, 4, 5]),
+            cert: Certificate(vec![3, 4, 5].into()),
             exts: vec![
                 CertificateExtension::CertificateStatus(CertificateStatus {
                     ocsp_response: PayloadU24(vec![1, 2, 3].into()),

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -13,7 +13,7 @@ const HEADER_SIZE: usize = 1 + 3;
 /// one handshake payload.
 pub struct HandshakeJoiner {
     /// Completed handshake frames for output.
-    pub frames: VecDeque<Message>,
+    pub frames: VecDeque<Message<'static>>,
 
     /// The message payload we're currently accumulating.
     buf: Vec<u8>,
@@ -103,7 +103,7 @@ impl HandshakeJoiner {
 
             let m = Message {
                 version,
-                payload: MessagePayload::Handshake(payload),
+                payload: MessagePayload::Handshake(payload.to_owned()),
             };
 
             self.frames.push_back(m);

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -56,10 +56,10 @@ impl HandshakeJoiner {
         // handshake messages arrive in a single fragment. Avoid allocating and
         // copying in that common case.
         if self.buf.is_empty() {
-            self.buf = msg.payload.0;
+            self.buf = msg.payload;
         } else {
             self.buf
-                .extend_from_slice(&msg.payload.0[..]);
+                .extend_from_slice(&msg.payload[..]);
         }
 
         let mut count = 0;
@@ -118,7 +118,6 @@ impl HandshakeJoiner {
 mod tests {
     use super::HandshakeJoiner;
     use crate::msgs::base::Payload;
-    use crate::msgs::codec::Codec;
     use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
     use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
     use crate::msgs::message::{Message, MessagePayload, OpaqueMessage};
@@ -131,13 +130,13 @@ mod tests {
         let wanted = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"hello world".to_vec()),
+            payload: b"hello world".to_vec(),
         };
 
         let unwanted = OpaqueMessage {
             typ: ContentType::Alert,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"ponytown".to_vec()),
+            payload: b"ponytown".to_vec(),
         };
 
         assert_eq!(hj.want_message(&wanted), true);
@@ -151,7 +150,7 @@ mod tests {
 
         let (mut left, mut right) = (Vec::new(), Vec::new());
         got.payload.encode(&mut left);
-        expect.payload.encode(&mut right);
+        right.extend(&expect.payload);
 
         assert_eq!(left, right);
     }
@@ -165,7 +164,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec()),
+            payload: b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -194,7 +193,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x01\x00\x00\x02\xff\xff".to_vec()),
+            payload: b"\x01\x00\x00\x02\xff\xff".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -211,7 +210,7 @@ mod tests {
         let mut msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec()),
+            payload: b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -222,7 +221,7 @@ mod tests {
         msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec()),
+            payload: b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -233,7 +232,7 @@ mod tests {
         msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x0f".to_vec()),
+            payload: b"\x0f".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -259,7 +258,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x0b\x01\x00\x04\x01\x00\x01\x00\xff\xfe".to_vec()),
+            payload: b"\x0b\x01\x00\x04\x01\x00\x01\x00\xff\xfe".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -270,7 +269,7 @@ mod tests {
             let msg = OpaqueMessage {
                 typ: ContentType::Handshake,
                 version: ProtocolVersion::TLSv1_2,
-                payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
+                payload: b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec(),
             };
 
             assert_eq!(hj.want_message(&msg), true);
@@ -282,7 +281,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x01\x02\x03\x04\x05\x06".to_vec()),
+            payload: b"\x01\x02\x03\x04\x05\x06".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -21,12 +21,12 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl<'a> Codec<'a> for $enum_name {
             fn encode(&self, bytes: &mut Vec<u8>) {
                 self.get_u8().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
+            fn read(r: &mut Reader<'a>) -> Option<Self> {
                 u8::read(r).map($enum_name::from)
             }
         }
@@ -60,12 +60,12 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl<'a> Codec<'a> for $enum_name {
             fn encode(&self, bytes: &mut Vec<u8>) {
                 self.get_u16().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
+            fn read(r: &mut Reader<'a>) -> Option<Self> {
                 u16::read(r).map($enum_name::from)
             }
         }

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -109,7 +109,7 @@ impl OpaqueMessage {
         Ok(OpaqueMessage {
             typ,
             version,
-            payload: payload.0,
+            payload: payload.0.into_owned(),
         })
     }
 
@@ -146,7 +146,7 @@ impl From<Message> for OpaqueMessage {
     fn from(msg: Message) -> OpaqueMessage {
         let typ = msg.payload.content_type();
         let payload = match msg.payload {
-            MessagePayload::ApplicationData(payload) => payload.0,
+            MessagePayload::ApplicationData(payload) => payload.0.into_owned(),
             _ => {
                 let mut buf = Vec::new();
                 msg.payload.encode(&mut buf);

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -29,7 +29,7 @@ fn test_read_fuzz_corpus() {
         let msg = OpaqueMessage::read(&mut rd).unwrap();
         println!("{:?}", msg);
 
-        let msg = match Message::try_from(msg) {
+        let msg = match Message::try_from(&msg) {
             Ok(msg) => msg,
             Err(_) => continue,
         };
@@ -65,7 +65,7 @@ fn can_read_safari_client_hello() {
     let mut rd = Reader::init(bytes);
     let m = OpaqueMessage::read(&mut rd).unwrap();
     println!("m = {:?}", m);
-    assert!(Message::try_from(m).is_err());
+    assert!(Message::try_from(&m).is_err());
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn construct_all_types() {
     for &bytes in samples.iter() {
         let m = OpaqueMessage::read(&mut Reader::init(bytes)).unwrap();
         println!("m = {:?}", m);
-        let m = Message::try_from(m);
+        let m = Message::try_from(&m);
         println!("m' = {:?}", m);
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -43,10 +43,10 @@ mod test {
         while r.any_left() {
             let m = OpaqueMessage::read(&mut r).unwrap();
 
-            let out = m.clone().encode();
+            let out = m.to_owned().encode();
             assert!(out.len() > 0);
 
-            Message::try_from(m).unwrap();
+            Message::try_from(&m).unwrap();
         }
     }
 }

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -29,7 +29,10 @@ fn clientsessionvalue_is_debug() {
         &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],
-        &vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
+        &vec![
+            Certificate(b"abc".to_vec().into()),
+            Certificate(b"def".to_vec().into()),
+        ],
         TimeBase::now().unwrap(),
     );
     println!("{:?}", csv);

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -3,7 +3,6 @@ pub use crate::client::ClientQuicExt;
 use crate::conn::ConnectionCommon;
 use crate::error::Error;
 use crate::key_schedule::hkdf_expand;
-use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::msgs::message::OpaqueMessage;
 pub use crate::server::ServerQuicExt;
@@ -190,7 +189,7 @@ pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(
         .take_message(OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
-            payload: Payload::new(plaintext.to_vec()),
+            payload: plaintext.to_vec(),
         })
         .is_none()
     {

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -102,7 +102,7 @@ impl ServerConfigBuilderWithClientAuth {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
     ) -> Result<ServerConfig, Error> {
         let resolver = handy::AlwaysResolvesChain::new(cert_chain, &key_der)?;
@@ -122,7 +122,7 @@ impl ServerConfigBuilderWithClientAuth {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert_with_ocsp_and_sct(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
         ocsp: Vec<u8>,
         scts: Vec<u8>,

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -88,7 +88,7 @@ impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private
     /// key type and encoding.
     pub fn new(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesChain, Error> {
         let key = sign::any_supported_type(priv_key)
@@ -103,7 +103,7 @@ impl AlwaysResolvesChain {
     ///
     /// If non-empty, the given OCSP response and SCTs are attached.
     pub fn new_with_extras(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
         ocsp: Vec<u8>,
         scts: Vec<u8>,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -172,7 +172,11 @@ impl ExtensionProcessing {
                         && hello.early_data_extension_offered()
                         && resume.version == cx.common.negotiated_version.unwrap()
                         && resume.cipher_suite == suite.suite
-                        && resume.alpn.as_ref().map(|x| &x.0) == cx.common.alpn_protocol.as_ref()
+                        && resume
+                            .alpn
+                            .as_ref()
+                            .map(|x| x.0.as_ref())
+                            == cx.common.alpn_protocol.as_deref()
                         && !cx.data.reject_early_data
                     {
                         self.exts

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -231,7 +231,7 @@ impl ServerConnection {
         Self::from_config(config, vec![])
     }
 
-    fn from_config(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> Self {
+    fn from_config(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension<'static>>) -> Self {
         ServerConnection {
             common: ConnectionCommon::new(config.mtu, false),
             state: Some(Box::new(hs::ExpectClientHello::new(config, extra_exts))),

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -488,8 +488,8 @@ pub trait ServerQuicExt {
         }
 
         let ext = match quic_version {
-            quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params),
-            quic::Version::V1 => ServerExtension::TransportParameters(params),
+            quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params.into()),
+            quic::Version::V1 => ServerExtension::TransportParameters(params.into()),
         };
         let mut new = ServerConnection::from_config(config, vec![ext]);
         new.common.protocol = Protocol::Quic;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -350,7 +350,7 @@ impl Connection for ServerConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
+    fn peer_certificates(&self) -> Option<&[key::Certificate<'static>]> {
         self.data.client_cert_chain.as_deref()
     }
 
@@ -417,7 +417,7 @@ struct ServerConnectionData {
     sni: Option<webpki::DnsName>,
     received_resumption_data: Option<Vec<u8>>,
     resumption_data: Vec<u8>,
-    client_cert_chain: Option<Vec<key::Certificate>>,
+    client_cert_chain: Option<Vec<key::Certificate<'static>>>,
     /// Whether to reject early data even if it would otherwise be accepted
     reject_early_data: bool,
 }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -51,7 +51,7 @@ mod client_hello {
         pub(in crate::server) using_ems: bool,
         pub(in crate::server) randoms: ConnectionRandoms,
         pub(in crate::server) send_ticket: bool,
-        pub(in crate::server) extra_exts: Vec<ServerExtension>,
+        pub(in crate::server) extra_exts: Vec<ServerExtension<'static>>,
     }
 
     impl CompleteClientHelloHandling {
@@ -326,7 +326,7 @@ mod client_hello {
         hello: &ClientHelloPayload,
         resumedata: Option<&persist::ServerSessionValue>,
         randoms: &ConnectionRandoms,
-        extra_exts: Vec<ServerExtension>,
+        extra_exts: Vec<ServerExtension<'static>>,
     ) -> Result<bool, Error> {
         let mut ep = hs::ExtensionProcessing::new();
         ep.process_common(
@@ -510,7 +510,11 @@ struct ExpectCertificate {
 }
 
 impl hs::State for ExpectCertificate {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         self.transcript.add_message(&m);
         let cert_chain = require_handshake_msg_move!(
             m,
@@ -891,7 +895,7 @@ struct ExpectTraffic {
 impl ExpectTraffic {}
 
 impl hs::State for ExpectTraffic {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -371,7 +371,12 @@ mod client_hello {
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
-                payload: HandshakePayload::Certificate(cert_chain.to_owned()),
+                payload: HandshakePayload::Certificate(
+                    cert_chain
+                        .iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
             }),
         };
 
@@ -569,7 +574,7 @@ impl hs::State for ExpectCertificate {
             suite: self.suite,
             using_ems: self.using_ems,
             server_kx: self.server_kx,
-            client_cert,
+            client_cert: client_cert.map(|x| x.iter().map(|y| y.to_owned()).collect()),
             send_ticket: self.send_ticket,
         }))
     }
@@ -584,7 +589,7 @@ struct ExpectClientKx {
     suite: Tls12CipherSuite,
     using_ems: bool,
     server_kx: kx::KeyExchange,
-    client_cert: Option<Vec<Certificate>>,
+    client_cert: Option<Vec<Certificate<'static>>>,
     send_ticket: bool,
 }
 
@@ -653,7 +658,7 @@ struct ExpectCertificateVerify {
     transcript: HandshakeHash,
     session_id: SessionID,
     using_ems: bool,
-    client_cert: Vec<Certificate>,
+    client_cert: Vec<Certificate<'static>>,
     send_ticket: bool,
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -275,7 +275,10 @@ mod client_hello {
 
             if let Some(ref resume) = resumedata {
                 cx.data.received_resumption_data = Some(resume.application_data.0.to_vec());
-                cx.data.client_cert_chain = resume.client_cert_chain.clone();
+                cx.data.client_cert_chain = resume
+                    .client_cert_chain
+                    .as_ref()
+                    .map(|x| x.iter().map(|y| y.to_owned()).collect());
             }
 
             let full_handshake = resumedata.is_none();
@@ -835,7 +838,7 @@ struct ExpectCertificateVerify {
     suite: &'static SupportedCipherSuite,
     randoms: ConnectionRandoms,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    client_cert: Vec<Certificate>,
+    client_cert: Vec<Certificate<'static>>,
     send_ticket: bool,
     hash_at_server_fin: Digest,
 }

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -30,10 +30,9 @@ pub trait Signer: Send + Sync {
 
 /// A packaged-together certificate chain, matching `SigningKey` and
 /// optional stapled OCSP response and/or SCT list.
-#[derive(Clone)]
 pub struct CertifiedKey {
     /// The certificate chain.
-    pub cert: Vec<key::Certificate>,
+    pub cert: Vec<key::Certificate<'static>>,
 
     /// The certified key.
     pub key: Arc<dyn SigningKey>,
@@ -53,7 +52,7 @@ impl CertifiedKey {
     ///
     /// The cert chain must not be empty. The first certificate in the chain
     /// must be the end-entity certificate.
-    pub fn new(cert: Vec<key::Certificate>, key: Arc<dyn SigningKey>) -> CertifiedKey {
+    pub fn new(cert: Vec<key::Certificate<'static>>, key: Arc<dyn SigningKey>) -> CertifiedKey {
         CertifiedKey {
             cert,
             key,
@@ -115,6 +114,21 @@ impl CertifiedKey {
         }
 
         Ok(())
+    }
+}
+
+impl Clone for CertifiedKey {
+    fn clone(&self) -> Self {
+        CertifiedKey {
+            cert: self
+                .cert
+                .iter()
+                .map(|x| x.to_owned())
+                .collect(),
+            key: Arc::clone(&self.key),
+            ocsp: self.ocsp.clone(),
+            sct_list: self.sct_list.clone(),
+        }
     }
 }
 

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -4,9 +4,9 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, ContentType};
 use crate::Error;
 
-pub fn decode_ecdh_params<T: Codec>(
+pub fn decode_ecdh_params<'a, T: Codec<'a>>(
     conn: &mut ConnectionCommon,
-    kx_params: &[u8],
+    kx_params: &'a [u8],
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
         conn.send_fatal_alert(AlertDescription::DecodeError);
@@ -14,7 +14,7 @@ pub fn decode_ecdh_params<T: Codec>(
     })
 }
 
-fn decode_ecdh_params_<T: Codec>(kx_params: &[u8]) -> Option<T> {
+fn decode_ecdh_params_<'a, T: Codec<'a>>(kx_params: &'a [u8]) -> Option<T> {
     let mut rd = Reader::init(kx_params);
     let ecdh_params = T::read(&mut rd)?;
     match rd.any_left() {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -182,7 +182,7 @@ struct Context {
     name: &'static str,
     domain: &'static str,
     roots: anchors::RootCertStore,
-    chain: Vec<key::Certificate>,
+    chain: Vec<key::Certificate<'static>>,
     now: SystemTime,
 }
 
@@ -197,7 +197,7 @@ impl Context {
             chain: certs
                 .iter()
                 .copied()
-                .map(|bytes| key::Certificate(bytes.to_vec()))
+                .map(|bytes| key::Certificate(bytes.to_vec().into()))
                 .collect(),
             now: SystemTime::UNIX_EPOCH + Duration::from_secs(1617300000),
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2126,7 +2126,7 @@ fn sni_resolver_rejects_bad_certs() {
         )
     );
 
-    let bad_chain = vec![rustls::Certificate(vec![0xa0])];
+    let bad_chain = vec![rustls::Certificate(vec![0xa0].into())];
     assert_eq!(
         Err(Error::General(
             "End-entity certificate in certificate chain is syntactically invalid".into()

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -806,7 +806,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -830,7 +836,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: Some(vec![]),
             };
@@ -927,7 +939,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_unreachable,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -961,7 +979,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_err,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -989,7 +1013,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: None,
                 offered_schemes: None,
             };
@@ -3410,7 +3440,7 @@ fn test_client_does_not_offer_sha1() {
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
             let msg = OpaqueMessage::read(&mut Reader::init(&buf[..sz])).unwrap();
-            let msg = Message::try_from(msg).unwrap();
+            let msg = Message::try_from(&msg).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 
             let client_hello = match msg.payload {
@@ -3678,7 +3708,7 @@ fn test_server_rejects_duplicate_sni_names() {
             if let HandshakePayload::ClientHello(ch) = &mut hs.payload {
                 for mut ext in ch.extensions.iter_mut() {
                     if let ClientExtension::ServerName(snr) = &mut ext {
-                        snr.push(snr[0].clone());
+                        snr.push(snr[0].to_owned());
                     }
                 }
             }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -186,11 +186,11 @@ impl KeyType {
         }
     }
 
-    pub fn get_chain(&self) -> Vec<Certificate> {
+    pub fn get_chain(&self) -> Vec<Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(self.bytes_for("end.fullchain")))
             .unwrap()
             .iter()
-            .map(|v| Certificate(v.clone()))
+            .map(|v| Certificate(v.clone().into()))
             .collect()
     }
 
@@ -202,11 +202,11 @@ impl KeyType {
         )
     }
 
-    pub fn get_client_chain(&self) -> Vec<Certificate> {
+    pub fn get_client_chain(&self) -> Vec<Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(self.bytes_for("client.fullchain")))
             .unwrap()
             .iter()
-            .map(|v| Certificate(v.clone()))
+            .map(|v| Certificate(v.clone().into()))
             .collect()
     }
 


### PR DESCRIPTION
The "Borrow Message payloads from OpaqueMessage" commit is very large, though most of it is very repetitive code in `msgs::handshake`, adding `to_owned()` methods to many of the payload types and their constituent types.

The idea here is to make `Payload`, `PayloadU8`, `PayloadU16` and `PayloadU24` contain a `Cow<'a, [u8]>` instead of a `Vec<u8>` and work from there to allow `Message` to borrow most of its data. There are some parts here that are not yet borrowed, but I think this proves that it can be made to work.

This does not yet touch folding the deframer and the handshake joiner, though I did explore that part as well. I think that can be made to work such that we can borrow `OpaqueMessage` and `Message` straight from the deframer buffer.

In the `read_tls with EWOULDBLOCK` benchmark, this shows up as a 5% performance improvement.