### PR TITLE
Further simplifications to the state machine

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, Context, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key_schedule::KeyScheduleEarly;
@@ -32,44 +32,9 @@ use crate::client::{tls12, tls13, ClientConfig, ClientConnectionData};
 
 use std::sync::Arc;
 
-pub(super) type NextState = Box<dyn State>;
+pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
-
-pub(super) trait State: Send + Sync {
-    /// Each handle() implementation consumes a whole TLS message, and returns
-    /// either an error or the next state.
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
-    fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
-}
-
-impl crate::conn::HandleState for Box<dyn State> {
-    type Data = ClientConnectionData;
-
-    fn handle(
-        self,
-        message: Message,
-        data: &mut Self::Data,
-        common: &mut ConnectionCommon,
-    ) -> Result<Self, Error> {
-        let mut cx = ClientContext { common, data };
-        self.handle(&mut cx, message)
-    }
-}
-
-pub(super) struct ClientContext<'a> {
-    pub(super) common: &'a mut ConnectionCommon,
-    pub(super) data: &'a mut ClientConnectionData,
-}
+pub(super) type ClientContext<'a> = Context<'a, ClientConnectionData>;
 
 fn find_session(
     dns_name: webpki::DnsNameRef,
@@ -465,7 +430,7 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
     scts.is_empty() || scts.iter().any(|sct| sct.0.is_empty())
 }
 
-impl State for ExpectServerHello {
+impl State<ClientConnectionData> for ExpectServerHello {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         let server_hello =
             require_handshake_msg!(m, HandshakeType::ServerHello, HandshakePayload::ServerHello)?;
@@ -761,7 +726,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-impl State for ExpectServerHelloOrHelloRetryRequest {
+impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         check_message(
             &m,

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -417,16 +417,6 @@ impl ClientConnection {
                     .send_early_plaintext(&data[..sz])
             })
     }
-
-    fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
-        let mut st = self.state.take();
-        if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(&mut self.common);
-        }
-        self.state = st;
-
-        self.common.send_some_plaintext(buf)
-    }
 }
 
 impl Connection for ClientConnection {
@@ -513,13 +503,17 @@ impl Connection for ClientConnection {
 
 impl PlaintextSink for ClientConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Ok(self.send_some_plaintext(buf))
+        Ok(self
+            .common
+            .send_some_plaintext(buf, &mut self.state))
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let mut sz = 0;
         for buf in bufs {
-            sz += self.send_some_plaintext(buf);
+            sz += self
+                .common
+                .send_some_plaintext(buf, &mut self.state);
         }
         Ok(sz)
     }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -492,10 +492,8 @@ impl Connection for ClientConnection {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.state
-            .as_ref()
-            .ok_or(Error::HandshakeNotComplete)
-            .and_then(|st| st.export_keying_material(output, label, context))
+        self.common
+            .export_keying_material(output, label, context, &self.state)
     }
 
     fn negotiated_cipher_suite(&self) -> Option<&'static SupportedCipherSuite> {

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -20,9 +20,10 @@ use crate::verify;
 use crate::{kx, tls12};
 
 use super::hs::ClientContext;
+use super::{ClientConfig, ClientConnectionData};
 use crate::client::common::{ClientAuthDetails, ReceivedTicketDetails};
 use crate::client::common::{ServerCertDetails, ServerKxDetails};
-use crate::client::{hs, ClientConfig};
+use crate::client::hs;
 
 use crate::suites::Tls12CipherSuite;
 use crate::ticketer::TimeBase;
@@ -216,7 +217,7 @@ struct ExpectCertificate {
     server_cert_sct_list: Option<SCTList>,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -277,7 +278,7 @@ struct ExpectCertificateStatusOrServerKx {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateStatusOrServerKx {
+impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(
             &m,
@@ -339,7 +340,7 @@ struct ExpectCertificateStatus {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateStatus {
+impl State<ClientConnectionData> for ExpectCertificateStatus {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -392,7 +393,7 @@ struct ExpectServerKx {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerKx {
+impl State<ClientConnectionData> for ExpectServerKx {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let opaque_kx = require_handshake_msg!(
             m,
@@ -552,7 +553,7 @@ struct ExpectServerDoneOrCertReq {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerDoneOrCertReq {
+impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         if require_handshake_msg!(
             m,
@@ -614,7 +615,7 @@ struct ExpectCertificateRequest {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateRequest {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -692,7 +693,7 @@ struct ExpectServerDone {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerDone {
+impl State<ClientConnectionData> for ExpectServerDone {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         check_message(
@@ -868,7 +869,7 @@ pub struct ExpectNewTicket {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl hs::State for ExpectNewTicket {
+impl State<ClientConnectionData> for ExpectNewTicket {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -913,7 +914,7 @@ pub struct ExpectCcs {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl hs::State for ExpectCcs {
+impl State<ClientConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ChangeCipherSpec], &[])?;
         // CCS should not be received interleaved with fragmented handshake-level
@@ -1011,7 +1012,7 @@ impl ExpectFinished {
     }
 }
 
-impl hs::State for ExpectFinished {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
@@ -1065,7 +1066,7 @@ struct ExpectTraffic {
     _fin_verified: verify::FinishedMessageVerified,
 }
 
-impl hs::State for ExpectTraffic {
+impl State<ClientConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -745,6 +745,19 @@ impl ConnectionCommon {
         }
     }
 
+    pub(crate) fn export_keying_material<Data>(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+        state: &Option<Box<dyn State<Data>>>,
+    ) -> Result<(), Error> {
+        state
+            .as_ref()
+            .ok_or(Error::HandshakeNotComplete)
+            .and_then(|st| st.export_keying_material(output, label, context))
+    }
+
     // Changing the keys must not span any fragmented handshake
     // messages.  Otherwise the defragmented messages will have
     // been protected with two different record layer protections,

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -745,6 +745,22 @@ impl ConnectionCommon {
         }
     }
 
+    /// Send plaintext application data, fragmenting and
+    /// encrypting it as it goes out.
+    ///
+    /// If internal buffers are too small, this function will not accept
+    /// all the data.
+    pub(crate) fn send_some_plaintext<Data>(
+        &mut self,
+        buf: &[u8],
+        state: &mut Option<Box<dyn State<Data>>>,
+    ) -> usize {
+        if let Some(st) = state {
+            st.perhaps_write_key_update(self);
+        }
+        self.send_plain(buf, Limit::Yes)
+    }
+
     pub(crate) fn export_keying_material<Data>(
         &self,
         output: &mut [u8],
@@ -916,15 +932,6 @@ impl ConnectionCommon {
 
     pub fn write_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
         self.sendable_tls.write_to(wr)
-    }
-
-    /// Send plaintext application data, fragmenting and
-    /// encrypting it as it goes out.
-    ///
-    /// If internal buffers are too small, this function will not accept
-    /// all the data.
-    pub fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
-        self.send_plain(data, Limit::Yes)
     }
 
     pub fn send_early_plaintext(&mut self, data: &[u8]) -> usize {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "quic")]
 use crate::conn::Protocol;
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, Context, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -24,42 +24,9 @@ use crate::server::{tls12, tls13, ServerConnectionData};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-pub(super) type NextState = Box<dyn State>;
+pub(super) type NextState = Box<dyn State<ServerConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
-
-pub(super) trait State: Send + Sync {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> NextStateOrError;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
-    fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
-}
-
-impl<'a> crate::conn::HandleState for Box<dyn State> {
-    type Data = ServerConnectionData;
-
-    fn handle(
-        self,
-        message: Message,
-        data: &mut Self::Data,
-        common: &mut ConnectionCommon,
-    ) -> Result<Self, Error> {
-        let mut cx = ServerContext { common, data };
-        self.handle(&mut cx, message)
-    }
-}
-
-pub(super) struct ServerContext<'a> {
-    pub(super) common: &'a mut ConnectionCommon,
-    pub(super) data: &'a mut ServerConnectionData,
-}
+pub(super) type ServerContext<'a> = Context<'a, ServerConnectionData>;
 
 pub fn incompatible(common: &mut ConnectionCommon, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::HandshakeFailure);
@@ -304,7 +271,7 @@ impl ExpectClientHello {
     }
 }
 
-impl State for ExpectClientHello {
+impl State<ServerConnectionData> for ExpectClientHello {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> NextStateOrError {
         let client_hello =
             require_handshake_msg!(m, HandshakeType::ClientHello, HandshakePayload::ClientHello)?;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -368,10 +368,8 @@ impl Connection for ServerConnection {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.state
-            .as_ref()
-            .ok_or(Error::HandshakeNotComplete)
-            .and_then(|st| st.export_keying_material(output, label, context))
+        self.common
+            .export_keying_material(output, label, context, &self.state)
     }
 
     fn negotiated_cipher_suite(&self) -> Option<&'static SupportedCipherSuite> {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -220,7 +220,7 @@ impl ServerConfig {
 /// Read data from the peer using the `io::Read` trait implementation.
 pub struct ServerConnection {
     common: ConnectionCommon,
-    state: Option<Box<dyn hs::State>>,
+    state: Option<hs::NextState>,
     data: ServerConnectionData,
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "quic")]
 use crate::check::check_message;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -17,13 +17,13 @@ use crate::msgs::handshake::NewSessionTicketPayloadTLS13;
 use crate::msgs::message::{Message, MessagePayload};
 use crate::msgs::persist;
 use crate::rand;
-use crate::server::ServerConfig;
 use crate::verify;
 use crate::{cipher, SupportedCipherSuite};
 #[cfg(feature = "quic")]
 use crate::{conn::Protocol, msgs::handshake::NewSessionTicketExtension};
 
 use super::hs::{self, ServerContext};
+use super::{ServerConfig, ServerConnectionData};
 
 use std::sync::Arc;
 
@@ -754,7 +754,7 @@ struct ExpectCertificate {
     hash_at_server_fin: Digest,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ServerConnectionData> for ExpectCertificate {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let certp = require_handshake_msg!(
             m,
@@ -840,7 +840,7 @@ struct ExpectCertificateVerify {
     hash_at_server_fin: Digest,
 }
 
-impl hs::State for ExpectCertificateVerify {
+impl State<ServerConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let rc = {
             let sig = require_handshake_msg!(
@@ -975,7 +975,7 @@ impl ExpectFinished {
     }
 }
 
-impl hs::State for ExpectFinished {
+impl State<ServerConnectionData> for ExpectFinished {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -1094,7 +1094,7 @@ impl ExpectTraffic {
     }
 }
 
-impl hs::State for ExpectTraffic {
+impl State<ServerConnectionData> for ExpectTraffic {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext, m: Message) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
@@ -1154,7 +1154,7 @@ struct ExpectQuicTraffic {
 }
 
 #[cfg(feature = "quic")]
-impl hs::State for ExpectQuicTraffic {
+impl State<ServerConnectionData> for ExpectQuicTraffic {
     fn handle(self: Box<Self>, _cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         // reject all messages
         check_message(&m, &[], &[])?;


### PR DESCRIPTION
Reduce code duplication in client/server by flattening the state machine structure to a single `State` trait which is parametrized by the `Data` and `Config` types. This makes all of the `State` methods available to `ConnectionCommon`, which in turn allows moving more duplicate complexity from client/server into `ConnectionCommon` methods.