### PR TITLE
Leave allocation to caller for Session::peer_certificates()

### DIFF
--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -463,12 +463,12 @@ impl Connection for ClientConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<Vec<key::Certificate>> {
+    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
         if self.data.server_cert_chain.is_empty() {
             return None;
         }
 
-        Some(self.data.server_cert_chain.to_vec())
+        Some(&self.data.server_cert_chain)
     }
 
     fn alpn_protocol(&self) -> Option<&[u8]> {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -226,7 +226,7 @@ pub trait Connection: quic::QuicExt + Send + Sync {
     /// if client authentication was completed.
     ///
     /// The return value is None until this value is available.
-    fn peer_certificates(&self) -> Option<Vec<key::Certificate>>;
+    fn peer_certificates(&self) -> Option<&[key::Certificate]>;
 
     /// Retrieves the protocol agreed with the peer via ALPN.
     ///

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -350,11 +350,8 @@ impl Connection for ServerConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<Vec<key::Certificate>> {
-        self.data
-            .client_cert_chain
-            .as_ref()
-            .map(|chain| chain.to_vec())
+    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
+        self.data.client_cert_chain.as_deref()
     }
 
     fn alpn_protocol(&self) -> Option<&[u8]> {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -322,7 +322,7 @@ fn client_can_get_server_cert() {
             do_handshake(&mut client, &mut server);
 
             let certs = client.peer_certificates();
-            assert_eq!(certs, Some(kt.get_chain()));
+            assert_eq!(certs, Some(kt.get_chain().as_slice()));
         }
     }
 }
@@ -361,7 +361,7 @@ fn server_can_get_client_cert() {
             do_handshake(&mut client, &mut server);
 
             let certs = server.peer_certificates();
-            assert_eq!(certs, Some(kt.get_client_chain()));
+            assert_eq!(certs, Some(kt.get_client_chain().as_slice()));
         }
     }
 }


### PR DESCRIPTION
This is a small change, but since it affects the public API, would be good to get it in.