### PR TITLE
Borrow payloads from the handshake joiner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ admin/rustfmt
 ._.DS_Store
 **/.DS_Store
 **/._.DS_Store
+fuzz/corpus/*

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -16,6 +16,7 @@ fuzz_target!(|data: &[u8]| {
 
     while !dfm.frames.is_empty() {
         let msg = dfm.frames.pop_front().unwrap();
-        Message::try_from(&msg).ok();
+        let plain = msg.into_plain_message();
+        Message::try_from(&plain).ok();
     }
 });

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -16,6 +16,6 @@ fuzz_target!(|data: &[u8]| {
 
     while !dfm.frames.is_empty() {
         let msg = dfm.frames.pop_front().unwrap();
-        Message::try_from(msg).ok();
+        Message::try_from(&msg).ok();
     }
 });

--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
 
     while !dfm.frames.is_empty() {
         let msg = dfm.frames.pop_front().unwrap();
-        let plain = msg.into_plain_message();
+        let plain = msg.to_plain_message();
         Message::try_from(&plain).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -14,14 +14,15 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let msg = match message::Message::try_from(&msg) {
+    let plain = msg.into_plain_message();
+    let msg = match message::Message::try_from(&plain) {
         Ok(msg) => msg,
         Err(_) => return,
     };
 
     let frg = fragmenter::MessageFragmenter::new(Some(32)).unwrap();
     let mut out = VecDeque::new();
-    frg.fragment(message::OpaqueMessage::from(msg), &mut out);
+    frg.fragment(message::PlainMessage::from(msg), &mut out);
 
     for msg in out {
         message::Message::try_from(&msg).ok();

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -15,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let msg = match message::Message::try_from(msg) {
+    let msg = match message::Message::try_from(&msg) {
         Ok(msg) => msg,
         Err(_) => return,
     };
@@ -25,6 +25,6 @@ fuzz_target!(|data: &[u8]| {
     frg.fragment(message::OpaqueMessage::from(msg), &mut out);
 
     for msg in out {
-        message::Message::try_from(msg).ok();
+        message::Message::try_from(&msg).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -14,7 +14,7 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let plain = msg.into_plain_message();
+    let plain = msg.to_plain_message();
     let msg = match message::Message::try_from(&plain) {
         Ok(msg) => msg,
         Err(_) => return,

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -2,16 +2,15 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::fragmenter;
 use rustls::internal::msgs::message;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
-    let mut rdr = Reader::init(data);
-    let msg = match message::OpaqueMessage::read(&mut rdr) {
-        Ok(msg) => msg,
+    let mut buf = data.to_vec();
+    let msg = match message::OpaqueMessage::read(&mut buf) {
+        Ok((msg, _)) => msg,
         Err(_) => return,
     };
 

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -16,7 +16,7 @@ fuzz_target!(|data: &[u8]| {
 
     let mut jnr = hsjoiner::HandshakeJoiner::new();
     if jnr.want_message(&msg) {
-        jnr.take_message(msg);
+        let _ = jnr.take_message(msg);
     }
 
     for msg in jnr.frames {

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -3,14 +3,13 @@
 extern crate rustls;
 
 use std::convert::TryFrom;
-use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::hsjoiner;
 use rustls::internal::msgs::message;
 
 fuzz_target!(|data: &[u8]| {
-    let mut rdr = Reader::init(data);
-    let msg = match message::OpaqueMessage::read(&mut rdr) {
-        Ok(msg) => msg,
+    let mut buf = data.to_vec();
+    let msg = match message::OpaqueMessage::read(&mut buf) {
+        Ok((msg, _)) => msg,
         Err(_) => return,
     };
 

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -13,9 +13,10 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
+    let plain = msg.into_plain_message();
     let mut jnr = hsjoiner::HandshakeJoiner::new();
-    if jnr.want_message(&msg) {
-        jnr.take_message(msg);
+    if jnr.want_message(&plain) {
+        jnr.take_message(plain);
     }
 
     let (mut iter, _) = jnr.iter();

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -16,10 +16,13 @@ fuzz_target!(|data: &[u8]| {
 
     let mut jnr = hsjoiner::HandshakeJoiner::new();
     if jnr.want_message(&msg) {
-        let _ = jnr.take_message(msg);
+        jnr.take_message(msg);
     }
 
-    for msg in jnr.frames {
-        message::Message::try_from(msg).unwrap();
+    let (mut iter, _) = jnr.iter();
+    while let Some(msg) = iter.pop() {
+        if let Ok(msg) = msg {
+            message::Message::try_from(msg).unwrap();
+        }
     }
 });

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -13,7 +13,7 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let plain = msg.into_plain_message();
+    let plain = msg.to_plain_message();
     let mut jnr = hsjoiner::HandshakeJoiner::new();
     if jnr.want_message(&plain) {
         jnr.take_message(plain);

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -2,13 +2,12 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage};
 use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
-    let mut rdr = Reader::init(data);
-    if let Ok(m) = OpaqueMessage::read(&mut rdr) {
+    let mut buf = data.to_vec();
+    if let Ok((m, used)) = OpaqueMessage::read(&mut buf) {
         let msg = match Message::try_from(&m) {
             Ok(msg) => msg,
             Err(_) => return,
@@ -16,6 +15,6 @@ fuzz_target!(|data: &[u8]| {
         //println!("msg = {:#?}", m);
         let enc = OpaqueMessage::from(msg).encode();
         //println!("data = {:?}", &data[..rdr.used()]);
-        assert_eq!(enc, data[..rdr.used()]);
+        assert_eq!(enc, data[..used]);
     }
 });

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
     if let Ok(m) = OpaqueMessage::read(&mut rdr) {
-        let msg = match Message::try_from(m) {
+        let msg = match Message::try_from(&m) {
             Ok(msg) => msg,
             Err(_) => return,
         };

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -1,19 +1,21 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::internal::msgs::message::{Message, OpaqueMessage};
+use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
 use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut buf = data.to_vec();
     if let Ok((m, used)) = OpaqueMessage::read(&mut buf) {
-        let msg = match Message::try_from(&m) {
+        let plain = m.into_plain_message();
+        let msg = match Message::try_from(&plain) {
             Ok(msg) => msg,
             Err(_) => return,
         };
         //println!("msg = {:#?}", m);
-        let enc = OpaqueMessage::from(msg).encode();
+        let enc = PlainMessage::from(msg).into_unencrypted_opaque().encode();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..used]);
     }

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 fuzz_target!(|data: &[u8]| {
     let mut buf = data.to_vec();
     if let Ok((m, used)) = OpaqueMessage::read(&mut buf) {
-        let plain = m.into_plain_message();
+        let plain = m.to_plain_message();
         let msg = match Message::try_from(&plain) {
             Ok(msg) => msg,
             Err(_) => return,

--- a/fuzz/fuzzers/persist.rs
+++ b/fuzz/fuzzers/persist.rs
@@ -5,7 +5,7 @@ extern crate rustls;
 use rustls::internal::msgs::persist;
 use rustls::internal::msgs::codec::{Reader, Codec};
 
-fn try_type<T>(data: &[u8]) where T: Codec {
+fn try_type<'a, T>(data: &'a [u8]) where T: Codec<'a> {
     let mut rdr = Reader::init(data);
     T::read(&mut rdr);
 }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -262,7 +262,7 @@ impl PersistCache {
         while rd.any_left() {
             let key_pl = PayloadU16::read(&mut rd).unwrap();
             let val_pl = PayloadU16::read(&mut rd).unwrap();
-            cache.insert(key_pl.0, val_pl.0);
+            cache.insert(key_pl.0.to_vec(), val_pl.0.to_vec());
         }
     }
 }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -407,13 +407,13 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
     out
 }
 
-fn load_certs(filename: &str) -> Vec<rustls::Certificate> {
+fn load_certs(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -516,13 +516,13 @@ fn lookup_versions(versions: &[String]) -> Vec<&'static rustls::SupportedProtoco
     out
 }
 
-fn load_certs(filename: &str) -> Vec<rustls::Certificate> {
+fn load_certs(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -229,13 +229,13 @@ impl KeyType {
         }
     }
 
-    fn get_chain(&self) -> Vec<rustls::Certificate> {
+    fn get_chain(&self) -> Vec<rustls::Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(
             fs::File::open(self.path_for("end.fullchain")).unwrap(),
         ))
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
     }
 
@@ -249,13 +249,13 @@ impl KeyType {
         )
     }
 
-    fn get_client_chain(&self) -> Vec<rustls::Certificate> {
+    fn get_client_chain(&self) -> Vec<rustls::Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(
             fs::File::open(self.path_for("client.fullchain")).unwrap(),
         ))
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
     }
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -143,13 +143,13 @@ impl Options {
     }
 }
 
-fn load_cert(filename: &str) -> Vec<rustls::Certificate> {
+fn load_cert(filename: &str) -> Vec<rustls::Certificate<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
         .unwrap()
         .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| rustls::Certificate(v.clone().into()))
         .collect()
 }
 
@@ -355,7 +355,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
         .unwrap()
         .with_client_cert_verifier(client_auth)
         .with_single_cert_with_ocsp_and_sct(
-            cert.clone(),
+            cert,
             key,
             opts.server_ocsp_response.clone(),
             opts.server_sct_list.clone(),

--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -118,7 +118,7 @@ impl RootCertStore {
 
         for der_cert in der_certs {
             #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
-            match self.add(&key::Certificate(der_cert.clone())) {
+            match self.add(&key::Certificate(der_cert.clone().into())) {
                 Ok(_) => valid_count += 1,
                 Err(err) => {
                     trace!("invalid cert der {:?}", der_cert);

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -109,7 +109,7 @@ impl ClientConfigBuilderWithCertVerifier {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
     ) -> Result<ClientConfig, Error> {
         let resolver = handy::AlwaysResolvesClientCert::new(cert_chain, &key_der)?;

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -12,14 +12,14 @@ use std::sync::Arc;
 pub struct ServerCertDetails {
     pub cert_chain: CertificatePayload,
     pub ocsp_response: Vec<u8>,
-    pub scts: Option<SCTList>,
+    pub scts: Option<SCTList<'static>>,
 }
 
 impl ServerCertDetails {
     pub fn new(
         cert_chain: CertificatePayload,
         ocsp_response: Vec<u8>,
-        scts: Option<SCTList>,
+        scts: Option<SCTList<'static>>,
     ) -> ServerCertDetails {
         ServerCertDetails {
             cert_chain,
@@ -33,17 +33,17 @@ impl ServerCertDetails {
             .as_deref()
             .unwrap_or(&[])
             .iter()
-            .map(|payload| payload.0.as_slice())
+            .map(|payload| payload.0.as_ref())
     }
 }
 
 pub struct ServerKxDetails {
     pub kx_params: Vec<u8>,
-    pub kx_sig: DigitallySignedStruct,
+    pub kx_sig: DigitallySignedStruct<'static>,
 }
 
 impl ServerKxDetails {
-    pub fn new(params: Vec<u8>, sig: DigitallySignedStruct) -> ServerKxDetails {
+    pub fn new(params: Vec<u8>, sig: DigitallySignedStruct<'static>) -> ServerKxDetails {
         ServerKxDetails {
             kx_params: params,
             kx_sig: sig,

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -10,14 +10,14 @@ use crate::sign;
 use std::sync::Arc;
 
 pub struct ServerCertDetails {
-    pub cert_chain: CertificatePayload,
+    pub cert_chain: CertificatePayload<'static>,
     pub ocsp_response: Vec<u8>,
     pub scts: Option<SCTList<'static>>,
 }
 
 impl ServerCertDetails {
     pub fn new(
-        cert_chain: CertificatePayload,
+        cert_chain: CertificatePayload<'static>,
         ocsp_response: Vec<u8>,
         scts: Option<SCTList<'static>>,
     ) -> ServerCertDetails {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -76,7 +76,7 @@ pub struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
     pub fn new(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesClientCert, Error> {
         let key = sign::any_supported_type(priv_key)

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, Context, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key_schedule::KeyScheduleEarly;
@@ -32,44 +32,9 @@ use crate::client::{tls12, tls13, ClientConfig, ClientConnectionData};
 
 use std::sync::Arc;
 
-pub(super) type NextState = Box<dyn State>;
+pub(super) type NextState = Box<dyn State<ClientConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
-
-pub(super) trait State: Send + Sync {
-    /// Each handle() implementation consumes a whole TLS message, and returns
-    /// either an error or the next state.
-    fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> NextStateOrError;
-
-    fn export_keying_material(
-        &self,
-        _output: &mut [u8],
-        _label: &[u8],
-        _context: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        Err(Error::HandshakeNotComplete)
-    }
-
-    fn perhaps_write_key_update(&mut self, _common: &mut ConnectionCommon) {}
-}
-
-impl crate::conn::HandleState for Box<dyn State> {
-    type Data = ClientConnectionData;
-
-    fn handle(
-        self,
-        message: Message<'_>,
-        data: &mut Self::Data,
-        common: &mut ConnectionCommon,
-    ) -> Result<Self, Error> {
-        let mut cx = ClientContext { common, data };
-        self.handle(&mut cx, message)
-    }
-}
-
-pub(super) struct ClientContext<'a> {
-    pub(super) common: &'a mut ConnectionCommon,
-    pub(super) data: &'a mut ClientConnectionData,
-}
+pub(super) type ClientContext<'a> = Context<'a, ClientConnectionData>;
 
 fn find_session(
     dns_name: webpki::DnsNameRef,
@@ -469,7 +434,7 @@ pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
     scts.is_empty() || scts.iter().any(|sct| sct.0.is_empty())
 }
 
-impl State for ExpectServerHello {
+impl State<ClientConnectionData> for ExpectServerHello {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> NextStateOrError {
         let server_hello =
             require_handshake_msg!(m, HandshakeType::ServerHello, HandshakePayload::ServerHello)?;
@@ -765,7 +730,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-impl State for ExpectServerHelloOrHelloRetryRequest {
+impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> NextStateOrError {
         check_message(
             &m,

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -265,11 +265,7 @@ fn emit_client_hello_for_retry(
     }
 
     // Extra extensions must be placed before the PSK extension
-    exts.extend(
-        extra_exts
-            .iter()
-            .map(|ext| ext.to_owned()),
-    );
+    exts.append(&mut extra_exts.clone());
 
     let fill_in_binder = if support_tls13
         && config.enable_tickets

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "logging")]
 use crate::bs_debug;
 use crate::check::check_message;
-use crate::conn::{ConnectionCommon, ConnectionRandoms, Context, State};
+use crate::conn::{CommonApi, ConnectionRandoms, Context, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key_schedule::KeyScheduleEarly;
@@ -746,7 +746,7 @@ impl State<ClientConnectionData> for ExpectServerHelloOrHelloRetryRequest {
     }
 }
 
-pub(super) fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
+pub(super) fn send_cert_error_alert(common: &mut CommonApi, err: Error) -> Error {
     match err {
         Error::WebPkiError(webpki::Error::BadDer, _) => {
             common.send_fatal_alert(AlertDescription::DecodeError);

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -452,7 +452,7 @@ impl Connection for ClientConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
+    fn peer_certificates(&self) -> Option<&[key::Certificate<'static>]> {
         if self.data.server_cert_chain.is_empty() {
             return None;
         }
@@ -514,7 +514,7 @@ impl PlaintextSink for ClientConnection {
 }
 
 struct ClientConnectionData {
-    server_cert_chain: CertificatePayload,
+    server_cert_chain: CertificatePayload<'static>,
     early_data: EarlyData,
     resumption_ciphersuite: Option<&'static SupportedCipherSuite>,
 }

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -331,7 +331,7 @@ impl ClientConnection {
     fn new_inner(
         config: Arc<ClientConfig>,
         hostname: webpki::DnsNameRef,
-        extra_exts: Vec<ClientExtension>,
+        extra_exts: Vec<ClientExtension<'static>>,
         proto: Protocol,
     ) -> Result<Self, Error> {
         let mut new = ClientConnection {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -584,8 +584,8 @@ pub trait ClientQuicExt {
         }
 
         let ext = match quic_version {
-            quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params),
-            quic::Version::V1 => ClientExtension::TransportParameters(params),
+            quic::Version::V1Draft => ClientExtension::TransportParametersDraft(params.into()),
+            quic::Version::V1 => ClientExtension::TransportParameters(params.into()),
         };
 
         ClientConnection::new_inner(config, hostname, vec![ext], Protocol::Quic)

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -547,13 +547,13 @@ impl quic::QuicExt for ClientConnection {
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
-        quic::read_hs(&mut self.common, plaintext)?;
+        self.common.read_hs(plaintext)?;
         self.common
             .process_new_handshake_messages(&mut self.state, &mut self.data)
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::Keys> {
-        quic::write_hs(&mut self.common, buf)
+        self.common.write_hs(buf)
     }
 
     fn alert(&self) -> Option<AlertDescription> {
@@ -561,7 +561,7 @@ impl quic::QuicExt for ClientConnection {
     }
 
     fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
-        quic::next_1rtt_keys(&mut self.common)
+        self.common.next_1rtt_keys()
     }
 }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -474,10 +474,8 @@ impl Connection for ClientConnection {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.state
-            .as_ref()
-            .ok_or(Error::HandshakeNotComplete)
-            .and_then(|st| st.export_keying_material(output, label, context))
+        self.common
+            .export_keying_material(output, label, context, &self.state)
     }
 
     fn negotiated_cipher_suite(&self) -> Option<&'static SupportedCipherSuite> {

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -399,16 +399,6 @@ impl ClientConnection {
                     .send_early_plaintext(&data[..sz])
             })
     }
-
-    fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
-        let mut st = self.state.take();
-        if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(&mut self.common);
-        }
-        self.state = st;
-
-        self.common.send_some_plaintext(buf)
-    }
 }
 
 impl Connection for ClientConnection {
@@ -495,13 +485,17 @@ impl Connection for ClientConnection {
 
 impl PlaintextSink for ClientConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Ok(self.send_some_plaintext(buf))
+        Ok(self
+            .common
+            .send_some_plaintext(buf, &mut self.state))
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let mut sz = 0;
         for buf in bufs {
-            sz += self.send_some_plaintext(buf);
+            sz += self
+                .common
+                .send_some_plaintext(buf, &mut self.state);
         }
         Ok(sz)
     }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets, State};
+use crate::conn::{CommonApi, ConnectionRandoms, ConnectionSecrets, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -459,7 +459,7 @@ impl State<ClientConnectionData> for ExpectServerKx {
 fn emit_certificate(
     transcript: &mut HandshakeHash,
     cert_chain: CertificatePayload,
-    common: &mut ConnectionCommon,
+    common: &mut CommonApi,
 ) {
     let cert = Message {
         version: ProtocolVersion::TLSv1_2,
@@ -475,7 +475,7 @@ fn emit_certificate(
 
 fn emit_clientkx(
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonApi,
     kxd: &kx::KeyExchangeResult,
 ) {
     let mut buf = Vec::new();
@@ -498,7 +498,7 @@ fn emit_clientkx(
 fn emit_certverify(
     transcript: &mut HandshakeHash,
     client_auth: &mut ClientAuthDetails,
-    common: &mut ConnectionCommon,
+    common: &mut CommonApi,
 ) -> Result<(), Error> {
     let signer = match client_auth.signer.take() {
         None => {
@@ -527,7 +527,7 @@ fn emit_certverify(
     Ok(())
 }
 
-fn emit_ccs(common: &mut ConnectionCommon) {
+fn emit_ccs(common: &mut CommonApi) {
     let ccs = Message {
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
@@ -539,7 +539,7 @@ fn emit_ccs(common: &mut ConnectionCommon) {
 fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonApi,
 ) {
     let vh = transcript.get_current_hash();
     let verify_data = secrets.client_verify_data(&vh);

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -20,9 +20,10 @@ use crate::verify;
 use crate::{kx, tls12};
 
 use super::hs::ClientContext;
+use super::{ClientConfig, ClientConnectionData};
 use crate::client::common::{ClientAuthDetails, ReceivedTicketDetails};
 use crate::client::common::{ServerCertDetails, ServerKxDetails};
-use crate::client::{hs, ClientConfig};
+use crate::client::hs;
 
 use crate::suites::Tls12CipherSuite;
 use crate::ticketer::TimeBase;
@@ -225,7 +226,7 @@ struct ExpectCertificate {
     server_cert_sct_list: Option<SCTList<'static>>,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -295,7 +296,7 @@ struct ExpectCertificateStatusOrServerKx {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateStatusOrServerKx {
+impl State<ClientConnectionData> for ExpectCertificateStatusOrServerKx {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         check_message(
             &m,
@@ -357,7 +358,7 @@ struct ExpectCertificateStatus {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateStatus {
+impl State<ClientConnectionData> for ExpectCertificateStatus {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -410,7 +411,7 @@ struct ExpectServerKx {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerKx {
+impl State<ClientConnectionData> for ExpectServerKx {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let opaque_kx = require_handshake_msg!(
             m,
@@ -570,7 +571,7 @@ struct ExpectServerDoneOrCertReq {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerDoneOrCertReq {
+impl State<ClientConnectionData> for ExpectServerDoneOrCertReq {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         if require_handshake_msg!(
             m,
@@ -632,7 +633,7 @@ struct ExpectCertificateRequest {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateRequest {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -710,7 +711,7 @@ struct ExpectServerDone {
     must_issue_new_ticket: bool,
 }
 
-impl hs::State for ExpectServerDone {
+impl State<ClientConnectionData> for ExpectServerDone {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         check_message(
@@ -894,7 +895,7 @@ pub struct ExpectNewTicket {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl hs::State for ExpectNewTicket {
+impl State<ClientConnectionData> for ExpectNewTicket {
     fn handle(
         mut self: Box<Self>,
         _cx: &mut ClientContext<'_>,
@@ -939,7 +940,7 @@ pub struct ExpectCcs {
     sig_verified: verify::HandshakeSignatureValid,
 }
 
-impl hs::State for ExpectCcs {
+impl State<ClientConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ChangeCipherSpec], &[])?;
         // CCS should not be received interleaved with fragmented handshake-level
@@ -1037,7 +1038,7 @@ impl ExpectFinished {
     }
 }
 
-impl hs::State for ExpectFinished {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
@@ -1091,7 +1092,7 @@ struct ExpectTraffic {
     _fin_verified: verify::FinishedMessageVerified,
 }
 
-impl hs::State for ExpectTraffic {
+impl State<ClientConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key_schedule::{
@@ -32,6 +32,7 @@ use crate::{conn::Protocol, msgs::base::PayloadU16, quic};
 use crate::{sign, KeyLog};
 
 use super::hs::ClientContext;
+use super::ClientConnectionData;
 use crate::client::common::ServerCertDetails;
 use crate::client::common::{ClientAuthDetails, ClientHelloDetails};
 use crate::client::{hs, ClientConfig};
@@ -410,7 +411,7 @@ struct ExpectEncryptedExtensions {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectEncryptedExtensions {
+impl State<ClientConnectionData> for ExpectEncryptedExtensions {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let exts = require_handshake_msg!(
             m,
@@ -515,7 +516,7 @@ struct ExpectCertificateOrCertReq {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectCertificateOrCertReq {
+impl State<ClientConnectionData> for ExpectCertificateOrCertReq {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(
             &m,
@@ -568,7 +569,7 @@ struct ExpectCertificateRequest {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectCertificateRequest {
+impl State<ClientConnectionData> for ExpectCertificateRequest {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let certreq = &require_handshake_msg!(
             m,
@@ -658,7 +659,7 @@ struct ExpectCertificate {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ClientConnectionData> for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -735,7 +736,7 @@ struct ExpectCertificateVerify {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectCertificateVerify {
+impl State<ClientConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let cert_verify = require_handshake_msg!(
             m,
@@ -912,7 +913,7 @@ struct ExpectFinished {
     hash_at_client_recvd_server_hello: Digest,
 }
 
-impl hs::State for ExpectFinished {
+impl State<ClientConnectionData> for ExpectFinished {
     fn handle(self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let mut st = *self;
         let finished =
@@ -1150,7 +1151,7 @@ impl ExpectTraffic {
     }
 }
 
-impl hs::State for ExpectTraffic {
+impl State<ClientConnectionData> for ExpectTraffic {
     fn handle(
         mut self: Box<Self>,
         cx: &mut ClientContext<'_>,
@@ -1214,7 +1215,7 @@ impl hs::State for ExpectTraffic {
 pub struct ExpectQuicTraffic(ExpectTraffic);
 
 #[cfg(feature = "quic")]
-impl hs::State for ExpectQuicTraffic {
+impl State<ClientConnectionData> for ExpectQuicTraffic {
     fn handle(mut self: Box<Self>, cx: &mut ClientContext<'_>, m: Message) -> hs::NextStateOrError {
         let nst = require_handshake_msg!(
             m,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -625,7 +625,7 @@ impl hs::State for ExpectCertificateRequest {
                 .choose_scheme(&compat_sigschemes);
             client_auth.certkey = Some(certkey);
             client_auth.signer = maybe_signer;
-            client_auth.auth_context = Some(certreq.context.0.clone());
+            client_auth.auth_context = Some(certreq.context.0.to_vec());
         } else {
             debug!("Client auth requested but no cert selected");
         }

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -465,7 +465,9 @@ impl hs::State for ExpectEncryptedExtensions {
 
             cx.data.server_cert_chain = resuming_session
                 .server_cert_chain
-                .clone();
+                .iter()
+                .map(|x| x.to_owned())
+                .collect();
 
             // We *don't* reverify the certificate chain here: resumption is a
             // continuation of the previous session in terms of security policy.
@@ -812,7 +814,7 @@ fn emit_certificate_tls13(
         for cert in &cert_key.cert {
             cert_payload
                 .entries
-                .push(CertificateEntry::new(cert.clone()));
+                .push(CertificateEntry::new(cert.to_owned()));
         }
     }
 

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -676,7 +676,7 @@ impl ConnectionCommon {
         }
 
         // Now we can fully parse the message payload.
-        let msg = Message::try_from(msg)?;
+        let msg = Message::try_from(&msg)?;
 
         // For alerts, we have separate logic.
         if let MessagePayload::Alert(alert) = &msg.payload {
@@ -726,7 +726,7 @@ impl ConnectionCommon {
     /// to handle the message.
     fn process_main_protocol<S: HandleState>(
         &mut self,
-        msg: Message,
+        msg: Message<'_>,
         state: &mut Option<S>,
         data: &mut S::Data,
     ) -> Result<(), Error> {
@@ -992,7 +992,7 @@ impl ConnectionCommon {
     }
 
     /// Send a raw TLS message, fragmenting it if needed.
-    pub fn send_msg(&mut self, m: Message, must_encrypt: bool) {
+    pub fn send_msg(&mut self, m: Message<'_>, must_encrypt: bool) {
         #[cfg(feature = "quic")]
         {
             if let Protocol::Quic = self.protocol {
@@ -1024,7 +1024,7 @@ impl ConnectionCommon {
         }
     }
 
-    pub fn take_received_plaintext(&mut self, bytes: Payload) {
+    pub fn take_received_plaintext(&mut self, bytes: Payload<'_>) {
         self.received_plaintext
             .append(bytes.0.into_owned());
     }
@@ -1096,7 +1096,7 @@ pub(crate) trait HandleState: Sized {
 
     fn handle(
         self,
-        message: Message,
+        message: Message<'_>,
         data: &mut Self::Data,
         common: &mut ConnectionCommon,
     ) -> Result<Self, Error>;

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -756,6 +756,22 @@ impl ConnectionCommon {
         }
     }
 
+    /// Send plaintext application data, fragmenting and
+    /// encrypting it as it goes out.
+    ///
+    /// If internal buffers are too small, this function will not accept
+    /// all the data.
+    pub(crate) fn send_some_plaintext<Data>(
+        &mut self,
+        buf: &[u8],
+        state: &mut Option<Box<dyn State<Data>>>,
+    ) -> usize {
+        if let Some(st) = state {
+            st.perhaps_write_key_update(self);
+        }
+        self.send_plain(buf, Limit::Yes)
+    }
+
     pub(crate) fn export_keying_material<Data>(
         &self,
         output: &mut [u8],
@@ -927,15 +943,6 @@ impl ConnectionCommon {
 
     pub fn write_tls(&mut self, wr: &mut dyn io::Write) -> io::Result<usize> {
         self.sendable_tls.write_to(wr)
-    }
-
-    /// Send plaintext application data, fragmenting and
-    /// encrypting it as it goes out.
-    ///
-    /// If internal buffers are too small, this function will not accept
-    /// all the data.
-    pub fn send_some_plaintext(&mut self, data: &[u8]) -> usize {
-        self.send_plain(data, Limit::Yes)
     }
 
     pub fn send_early_plaintext(&mut self, data: &[u8]) -> usize {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -695,11 +695,7 @@ impl ConnectionCommon {
             return Err(err.clone());
         }
 
-        if self.message_deframer.desynced {
-            return Err(Error::CorruptMessage);
-        }
-
-        while let Some(msg) = self.message_deframer.frames.pop_front() {
+        while let Some(msg) = self.message_deframer.pop()? {
             if let Err(err) = self.process_msg(msg, state, data) {
                 self.error = Some(err.clone());
                 return Err(err);

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -11,7 +11,7 @@ use crate::msgs::enums::HandshakeType;
 use crate::msgs::enums::{AlertDescription, AlertLevel, ContentType, ProtocolVersion};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::hsjoiner::HandshakeJoiner;
-use crate::msgs::message::{BorrowedOpaqueMessage, Message, MessagePayload, OpaqueMessage};
+use crate::msgs::message::{Message, MessagePayload, OpaqueMessage, PlainMessage};
 use crate::prf;
 use crate::quic;
 use crate::rand;
@@ -740,9 +740,9 @@ impl ConnectionCommon {
             .map(AsRef::as_ref)
     }
 
-    pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<OpaqueMessage, Error> {
+    fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<PlainMessage<'static>, Error> {
         if !self.api.record_layer.is_decrypting() {
-            return Ok(encr);
+            return Ok(encr.into_plain_message());
         }
 
         if self
@@ -1007,7 +1007,7 @@ impl CommonApi {
             self.message_fragmenter
                 .fragment(m.into(), &mut to_send);
             for mm in to_send {
-                self.queue_tls_message(mm);
+                self.queue_tls_message(mm.into_unencrypted_opaque());
             }
         } else {
             self.send_msg_encrypt(m.into());
@@ -1016,13 +1016,13 @@ impl CommonApi {
 
     /// Fragment `m`, encrypt the fragments, and then queue
     /// the encrypted fragments for sending.
-    pub fn send_msg_encrypt(&mut self, m: OpaqueMessage) {
+    pub fn send_msg_encrypt(&mut self, m: PlainMessage<'static>) {
         let mut plain_messages = VecDeque::new();
         self.message_fragmenter
             .fragment(m, &mut plain_messages);
 
         for m in plain_messages {
-            self.send_single_fragment(m.borrow());
+            self.send_single_fragment(m);
         }
     }
 
@@ -1054,7 +1054,7 @@ impl CommonApi {
         len
     }
 
-    fn send_single_fragment(&mut self, m: BorrowedOpaqueMessage) {
+    fn send_single_fragment(&mut self, m: PlainMessage<'_>) {
         // Close connection once we start to run out of
         // sequence space.
         if self
@@ -1169,10 +1169,10 @@ mod conn_quic {
     impl ConnectionCommon {
         pub(crate) fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
             self.handshake_joiner
-                .take_message(OpaqueMessage {
+                .take_message(PlainMessage {
                     typ: ContentType::Handshake,
                     version: ProtocolVersion::TLSv1_3,
-                    payload: plaintext.to_vec(),
+                    payload: plaintext.into(),
                 });
             Ok(())
         }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -620,7 +620,7 @@ impl ConnectionCommon {
 
     fn process_msg<Data>(
         &mut self,
-        mut msg: OpaqueMessage,
+        msg: OpaqueMessage,
         state: &mut Option<Box<dyn State<Data>>>,
         data: &mut Data,
     ) -> Result<(), Error> {
@@ -642,10 +642,7 @@ impl ConnectionCommon {
         }
 
         // Decrypt if demanded by current state.
-        if self.api.record_layer.is_decrypting() {
-            let dm = self.decrypt_incoming(msg)?;
-            msg = dm;
-        }
+        let msg = self.decrypt_incoming(msg)?;
 
         // For handshake messages, we need to join them before parsing
         // and processing.
@@ -744,6 +741,10 @@ impl ConnectionCommon {
     }
 
     pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<OpaqueMessage, Error> {
+        if !self.api.record_layer.is_decrypting() {
+            return Ok(encr);
+        }
+
         if self
             .api
             .record_layer

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -634,7 +634,12 @@ impl ConnectionCommon {
         matches!(self.negotiated_version, Some(ProtocolVersion::TLSv1_3))
     }
 
-    fn process_msg(&mut self, mut msg: OpaqueMessage) -> Result<Option<MessageType>, Error> {
+    fn process_msg<S: HandleState>(
+        &mut self,
+        mut msg: OpaqueMessage,
+        state: &mut Option<S>,
+        data: &mut S::Data,
+    ) -> Result<(), Error> {
         // pass message to handshake state machine if any of these are true:
         // - TLS1.2 (where it's part of the state machine),
         // - prior to determining the version (it's illegal as a first message)
@@ -648,7 +653,7 @@ impl ConnectionCommon {
             } else {
                 self.received_middlebox_ccs = true;
                 trace!("Dropping CCS");
-                return Ok(None);
+                return Ok(());
             }
         }
 
@@ -667,7 +672,7 @@ impl ConnectionCommon {
                     self.send_fatal_alert(AlertDescription::DecodeError);
                     Error::CorruptMessagePayload(ContentType::Handshake)
                 })?;
-            return Ok(Some(MessageType::Handshake));
+            return self.process_new_handshake_messages(state, data);
         }
 
         // Now we can fully parse the message payload.
@@ -675,10 +680,10 @@ impl ConnectionCommon {
 
         // For alerts, we have separate logic.
         if let MessagePayload::Alert(alert) = &msg.payload {
-            return self.process_alert(alert).map(|()| None);
+            return self.process_alert(alert);
         }
 
-        Ok(Some(MessageType::Data(msg)))
+        self.process_main_protocol(msg, state, data)
     }
 
     pub(crate) fn process_new_packets<S: HandleState>(
@@ -695,17 +700,7 @@ impl ConnectionCommon {
         }
 
         while let Some(msg) = self.message_deframer.frames.pop_front() {
-            let result = self
-                .process_msg(msg)
-                .and_then(|val| match val {
-                    Some(MessageType::Handshake) => {
-                        self.process_new_handshake_messages(state, data)
-                    }
-                    Some(MessageType::Data(msg)) => self.process_main_protocol(msg, state, data),
-                    None => Ok(()),
-                });
-
-            if let Err(err) = result {
+            if let Err(err) = self.process_msg(msg, state, data) {
                 self.error = Some(err.clone());
                 return Err(err);
             }
@@ -1104,11 +1099,6 @@ pub(crate) trait HandleState: Sized {
         data: &mut Self::Data,
         common: &mut ConnectionCommon,
     ) -> Result<Self, Error>;
-}
-
-pub enum MessageType {
-    Handshake,
-    Data(Message),
 }
 
 #[cfg(feature = "quic")]

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -1025,7 +1025,8 @@ impl ConnectionCommon {
     }
 
     pub fn take_received_plaintext(&mut self, bytes: Payload) {
-        self.received_plaintext.append(bytes.0);
+        self.received_plaintext
+            .append(bytes.0.into_owned());
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -756,6 +756,19 @@ impl ConnectionCommon {
         }
     }
 
+    pub(crate) fn export_keying_material<Data>(
+        &self,
+        output: &mut [u8],
+        label: &[u8],
+        context: Option<&[u8]>,
+        state: &Option<Box<dyn State<Data>>>,
+    ) -> Result<(), Error> {
+        state
+            .as_ref()
+            .ok_or(Error::HandshakeNotComplete)
+            .and_then(|st| st.export_keying_material(output, label, context))
+    }
+
     // Changing the keys must not span any fragmented handshake
     // messages.  Otherwise the defragmented messages will have
     // been protected with two different record layer protections,

--- a/rustls/src/key.rs
+++ b/rustls/src/key.rs
@@ -20,13 +20,13 @@ pub struct PrivateKey(pub Vec<u8>);
 #[derive(Clone, Eq, PartialEq)]
 pub struct Certificate(pub Vec<u8>);
 
-impl Codec for Certificate {
+impl<'a> Codec<'a> for Certificate {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.0.len() as u32).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Certificate> {
+    fn read(r: &mut Reader<'a>) -> Option<Certificate> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
         let body = sub.rest().to_vec();

--- a/rustls/src/key_schedule.rs
+++ b/rustls/src/key_schedule.rs
@@ -517,7 +517,7 @@ impl hkdf::KeyType for PayloadU8Len {
     }
 }
 
-impl From<hkdf::Okm<'_, PayloadU8Len>> for PayloadU8 {
+impl From<hkdf::Okm<'_, PayloadU8Len>> for PayloadU8<'static> {
     fn from(okm: hkdf::Okm<PayloadU8Len>) -> Self {
         let mut r = vec![0u8; okm.len().0];
         okm.fill(&mut r[..]).unwrap();

--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -7,13 +7,13 @@ pub struct AlertMessagePayload {
     pub description: AlertDescription,
 }
 
-impl Codec for AlertMessagePayload {
+impl<'a> Codec<'a> for AlertMessagePayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.level.encode(bytes);
         self.description.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<AlertMessagePayload> {
+    fn read(r: &mut Reader<'a>) -> Option<AlertMessagePayload> {
         let level = AlertLevel::read(r)?;
         let description = AlertDescription::read(r)?;
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -1,6 +1,6 @@
-use crate::key;
 use crate::msgs::codec;
 use crate::msgs::codec::{Codec, Reader};
+
 /// An externally length'd payload
 #[derive(Debug, Clone, PartialEq)]
 pub struct Payload(pub Vec<u8>);
@@ -26,20 +26,6 @@ impl Payload {
 
     pub fn read(r: &mut Reader) -> Self {
         Self(r.rest().to_vec())
-    }
-}
-
-impl Codec for key::Certificate {
-    fn encode(&self, bytes: &mut Vec<u8>) {
-        codec::u24(self.0.len() as u32).encode(bytes);
-        bytes.extend_from_slice(&self.0);
-    }
-
-    fn read(r: &mut Reader) -> Option<key::Certificate> {
-        let len = codec::u24::read(r)?.0 as usize;
-        let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(key::Certificate(body))
     }
 }
 

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -4,66 +4,74 @@ use crate::msgs::codec::{Codec, Reader};
 use std::borrow::Cow;
 
 /// An externally length'd payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct Payload(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct Payload<'a>(pub Cow<'a, [u8]>);
 
-impl Codec for Payload {
+impl<'a> Codec<'a> for Payload<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<Payload> {
+    fn read(r: &mut Reader<'a>) -> Option<Payload<'a>> {
         Some(Payload::read(r))
     }
 }
 
-impl Payload {
-    pub fn new(bytes: impl Into<Vec<u8>>) -> Payload {
-        Payload(bytes.into().into())
+impl<'a> Payload<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> Self {
+        Payload(bytes.into())
     }
 
-    pub fn empty() -> Payload {
+    pub fn empty() -> Payload<'static> {
         Payload::new(Vec::new())
     }
 
-    pub fn read(r: &mut Reader) -> Self {
-        Self::new(r.rest().to_vec())
+    pub fn to_owned(&self) -> Payload<'static> {
+        Payload::new(self.0.to_vec())
+    }
+
+    pub fn read(r: &mut Reader<'a>) -> Self {
+        Self::new(r.rest())
     }
 }
 
 /// An arbitrary, unknown-content, u24-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU24(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU24<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU24 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU24 {
+impl<'a> PayloadU24<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU24<'a> {
         PayloadU24(bytes.into())
+    }
+
+    pub fn to_owned(&self) -> PayloadU24<'static> {
+        PayloadU24::new(self.0.to_vec())
     }
 }
 
-impl Codec for PayloadU24 {
+impl<'a> Codec<'a> for PayloadU24<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         codec::u24(self.0.len() as u32).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU24> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU24<'a>> {
         let len = codec::u24::read(r)?.0 as usize;
         let mut sub = r.sub(len)?;
-        Some(PayloadU24::new(sub.rest().to_vec()))
+        Some(PayloadU24::new(sub.rest()))
     }
 }
 
 /// An arbitrary, unknown-content, u16-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU16(pub Vec<u8>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU16<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU16 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU16 {
-        PayloadU16(bytes)
+impl<'a> PayloadU16<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU16<'a> {
+        PayloadU16(bytes.into())
     }
 
-    pub fn empty() -> PayloadU16 {
+    pub fn empty() -> PayloadU16<'static> {
         PayloadU16::new(Vec::new())
     }
 
@@ -71,49 +79,55 @@ impl PayloadU16 {
         (slice.len() as u16).encode(bytes);
         bytes.extend_from_slice(slice);
     }
+
+    pub fn to_owned(&self) -> PayloadU16<'static> {
+        PayloadU16::new(self.0.to_vec())
+    }
 }
 
-impl Codec for PayloadU16 {
+impl<'a> Codec<'a> for PayloadU16<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         Self::encode_slice(&self.0, bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU16> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU16<'a>> {
         let len = u16::read(r)? as usize;
         let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(PayloadU16(body))
+        Some(PayloadU16::new(sub.rest()))
     }
 }
 
 /// An arbitrary, unknown-content, u8-length-prefixed payload
-#[derive(Debug, Clone, PartialEq)]
-pub struct PayloadU8(pub Cow<'static, [u8]>);
+#[derive(Debug, PartialEq)]
+pub struct PayloadU8<'a>(pub Cow<'a, [u8]>);
 
-impl PayloadU8 {
-    pub fn new(bytes: Vec<u8>) -> PayloadU8 {
+impl<'a> PayloadU8<'a> {
+    pub fn new(bytes: impl Into<Cow<'a, [u8]>>) -> PayloadU8<'a> {
         PayloadU8(bytes.into())
     }
 
-    pub fn empty() -> PayloadU8 {
-        PayloadU8::new(Vec::new())
+    pub fn empty() -> PayloadU8<'static> {
+        PayloadU8(Vec::new().into())
     }
 
     pub fn into_inner(self) -> Vec<u8> {
         self.0.into_owned()
     }
+
+    pub fn to_owned(&self) -> PayloadU8<'static> {
+        PayloadU8::new(self.0.to_vec())
+    }
 }
 
-impl Codec for PayloadU8 {
+impl<'a> Codec<'a> for PayloadU8<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         (self.0.len() as u8).encode(bytes);
         bytes.extend_from_slice(&self.0);
     }
 
-    fn read(r: &mut Reader) -> Option<PayloadU8> {
+    fn read(r: &mut Reader<'a>) -> Option<PayloadU8<'a>> {
         let len = u8::read(r)? as usize;
         let mut sub = r.sub(len)?;
-        let body = sub.rest().to_vec();
-        Some(PayloadU8::new(body))
+        Some(PayloadU8::new(sub.rest()))
     }
 }

--- a/rustls/src/msgs/base.rs
+++ b/rustls/src/msgs/base.rs
@@ -4,7 +4,7 @@ use crate::msgs::codec::{Codec, Reader};
 use std::borrow::Cow;
 
 /// An externally length'd payload
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Payload<'a>(pub Cow<'a, [u8]>);
 
 impl<'a> Codec<'a> for Payload<'a> {
@@ -63,7 +63,7 @@ impl<'a> Codec<'a> for PayloadU24<'a> {
 }
 
 /// An arbitrary, unknown-content, u16-length-prefixed payload
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PayloadU16<'a>(pub Cow<'a, [u8]>);
 
 impl<'a> PayloadU16<'a> {
@@ -98,7 +98,7 @@ impl<'a> Codec<'a> for PayloadU16<'a> {
 }
 
 /// An arbitrary, unknown-content, u8-length-prefixed payload
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PayloadU8<'a>(pub Cow<'a, [u8]>);
 
 impl<'a> PayloadU8<'a> {

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -3,12 +3,12 @@ use crate::msgs::codec::{Codec, Reader};
 #[derive(Debug)]
 pub struct ChangeCipherSpecPayload;
 
-impl Codec for ChangeCipherSpecPayload {
+impl<'a> Codec<'a> for ChangeCipherSpecPayload {
     fn encode(&self, bytes: &mut Vec<u8>) {
         1u8.encode(bytes);
     }
 
-    fn read(r: &mut Reader) -> Option<ChangeCipherSpecPayload> {
+    fn read(r: &mut Reader<'a>) -> Option<ChangeCipherSpecPayload> {
         let typ = u8::read(r)?;
 
         if typ == 1 && !r.any_left() {

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -49,13 +49,13 @@ impl<'a> Reader<'a> {
 }
 
 /// Things we can encode and read from a Reader.
-pub trait Codec: Debug + Sized {
+pub trait Codec<'a>: Debug + Sized {
     /// Encode yourself by appending onto `bytes`.
     fn encode(&self, bytes: &mut Vec<u8>);
 
     /// Decode yourself by fiddling with the `Reader`.
     /// Return Some if it worked, None if not.
-    fn read(_: &mut Reader) -> Option<Self>;
+    fn read(_: &mut Reader<'a>) -> Option<Self>;
 
     /// Convenience function to get the results of `encode()`.
     fn get_encoding(&self) -> Vec<u8> {
@@ -66,7 +66,7 @@ pub trait Codec: Debug + Sized {
 
     /// Read one of these from the front of `bytes` and
     /// return it.
-    fn read_bytes(bytes: &[u8]) -> Option<Self> {
+    fn read_bytes(bytes: &'a [u8]) -> Option<Self> {
         let mut rd = Reader::init(bytes);
         Self::read(&mut rd)
     }
@@ -78,7 +78,7 @@ fn decode_u8(bytes: &[u8]) -> Option<u8> {
     Some(value)
 }
 
-impl Codec for u8 {
+impl<'a> Codec<'a> for u8 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.push(*self);
     }
@@ -96,7 +96,7 @@ pub fn decode_u16(bytes: &[u8]) -> Option<u16> {
     Some(u16::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u16 {
+impl<'a> Codec<'a> for u16 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let mut b16 = [0u8; 2];
         put_u16(*self, &mut b16);
@@ -128,7 +128,7 @@ impl From<u24> for usize {
     }
 }
 
-impl Codec for u24 {
+impl<'a> Codec<'a> for u24 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let be_bytes = u32::to_be_bytes(self.0);
         bytes.extend_from_slice(&be_bytes[1..])
@@ -143,7 +143,7 @@ pub fn decode_u32(bytes: &[u8]) -> Option<u32> {
     Some(u32::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u32 {
+impl<'a> Codec<'a> for u32 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend(&u32::to_be_bytes(*self))
     }
@@ -162,7 +162,7 @@ pub fn decode_u64(bytes: &[u8]) -> Option<u64> {
     Some(u64::from_be_bytes(bytes.try_into().ok()?))
 }
 
-impl Codec for u64 {
+impl<'a> Codec<'a> for u64 {
     fn encode(&self, bytes: &mut Vec<u8>) {
         let mut b64 = [0u8; 8];
         put_u64(*self, &mut b64);
@@ -174,7 +174,10 @@ impl Codec for u64 {
     }
 }
 
-pub fn encode_vec_u8<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u8<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -185,7 +188,10 @@ pub fn encode_vec_u8<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn encode_vec_u16<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u16<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -196,7 +202,10 @@ pub fn encode_vec_u16<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn encode_vec_u24<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
+pub fn encode_vec_u24<'a, T>(bytes: &mut Vec<u8>, items: &[T])
+where
+    T: Codec<'a>,
+{
     let mut sub: Vec<u8> = Vec::new();
     for i in items {
         i.encode(&mut sub);
@@ -207,7 +216,7 @@ pub fn encode_vec_u24<T: Codec>(bytes: &mut Vec<u8>, items: &[T]) {
     bytes.append(&mut sub);
 }
 
-pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u8<'a, T: Codec<'a>>(r: &mut Reader<'a>) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u8::read(r)?);
     let mut sub = r.sub(len)?;
@@ -219,7 +228,7 @@ pub fn read_vec_u8<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
     Some(ret)
 }
 
-pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
+pub fn read_vec_u16<'a, T: Codec<'a>>(r: &mut Reader<'a>) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = usize::from(u16::read(r)?);
     let mut sub = r.sub(len)?;
@@ -231,7 +240,10 @@ pub fn read_vec_u16<T: Codec>(r: &mut Reader) -> Option<Vec<T>> {
     Some(ret)
 }
 
-pub fn read_vec_u24_limited<T: Codec>(r: &mut Reader, max_bytes: usize) -> Option<Vec<T>> {
+pub fn read_vec_u24_limited<'a, T: Codec<'a>>(
+    r: &mut Reader<'a>,
+    max_bytes: usize,
+) -> Option<Vec<T>> {
     let mut ret: Vec<T> = Vec::new();
     let len = u24::read(r)?.0 as usize;
     if len > max_bytes {

--- a/rustls/src/msgs/codec.rs
+++ b/rustls/src/msgs/codec.rs
@@ -8,20 +8,20 @@ pub struct Reader<'a> {
 }
 
 impl<'a> Reader<'a> {
-    pub fn init(bytes: &[u8]) -> Reader {
+    pub fn init(bytes: &'a [u8]) -> Reader<'a> {
         Reader {
             buf: bytes,
             offs: 0,
         }
     }
 
-    pub fn rest(&mut self) -> &[u8] {
+    pub fn rest(&mut self) -> &'a [u8] {
         let ret = &self.buf[self.offs..];
         self.offs = self.buf.len();
         ret
     }
 
-    pub fn take(&mut self, len: usize) -> Option<&[u8]> {
+    pub fn take(&mut self, len: usize) -> Option<&'a [u8]> {
         if self.left() < len {
             return None;
         }
@@ -43,7 +43,7 @@ impl<'a> Reader<'a> {
         self.offs
     }
 
-    pub fn sub(&mut self, len: usize) -> Option<Reader> {
+    pub fn sub(&mut self, len: usize) -> Option<Reader<'a>> {
         self.take(len).map(Reader::init)
     }
 }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -97,27 +97,22 @@ impl MessageDeframer {
     /// Does our `buf` contain a full message?  It does if it is big enough to
     /// contain a header, and that header has a length which falls within `buf`.
     /// If so, deframe it and place the message onto the frames output queue.
+    #[allow(clippy::comparison_chain)]
     fn try_deframe_one(&mut self) -> BufferContents {
         // Try to decode a message off the front of buf.
         let mut rd = codec::Reader::init(&self.buf[..self.used]);
 
-        match OpaqueMessage::read(&mut rd) {
-            Ok(m) => {
-                let used = rd.used();
-                self.frames.push_back(m);
-                self.buf_consume(used);
-                BufferContents::Valid
-            }
+        let m = match OpaqueMessage::read(&mut rd) {
+            Ok(m) => m,
             Err(MessageError::TooShortForHeader) | Err(MessageError::TooShortForLength) => {
-                BufferContents::Partial
+                return BufferContents::Partial;
             }
-            Err(_) => BufferContents::Invalid,
-        }
-    }
+            Err(_) => return BufferContents::Invalid,
+        };
 
-    #[allow(clippy::comparison_chain)]
-    fn buf_consume(&mut self, taken: usize) {
-        if taken < self.used {
+        let used = rd.used();
+        self.frames.push_back(m);
+        if used < self.used {
             /* Before:
              * +----------+----------+----------+
              * | taken    | pending  |xxxxxxxxxx|
@@ -131,12 +126,13 @@ impl MessageDeframer {
              * 0          ^ self.used
              */
 
-            self.buf
-                .copy_within(taken..self.used, 0);
-            self.used -= taken;
-        } else if taken == self.used {
+            self.buf.copy_within(used..self.used, 0);
+            self.used -= used;
+        } else if used == self.used {
             self.used = 0;
         }
+
+        BufferContents::Valid
     }
 }
 

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -25,18 +25,6 @@ pub struct MessageDeframer {
     used: usize,
 }
 
-enum BufferContents {
-    /// Contains an invalid message as a header.
-    Invalid,
-
-    /// Might contain a valid message if we receive more.
-    /// Perhaps totally empty!
-    Partial,
-
-    /// Contains a valid frame as a prefix.
-    Valid,
-}
-
 impl Default for MessageDeframer {
     fn default() -> Self {
         Self::new()
@@ -63,6 +51,7 @@ impl MessageDeframer {
     /// Read some bytes from `rd`, and add them to our internal
     /// buffer.  If this means our internal buffer contains
     /// full messages, decode them all.
+    #[allow(clippy::comparison_chain)]
     pub fn read(&mut self, rd: &mut dyn io::Read) -> io::Result<usize> {
         // Try to do the largest reads possible.  Note that if
         // we get a message with a length field out of range here,
@@ -74,13 +63,42 @@ impl MessageDeframer {
         self.used += new_bytes;
 
         loop {
-            match self.try_deframe_one() {
-                BufferContents::Invalid => {
-                    self.desynced = true;
+            // Does our `buf` contain a full message?  It does if it is big enough to
+            // contain a header, and that header has a length which falls within `buf`.
+            // If so, deframe it and place the message onto the frames output queue.
+            let mut rd = codec::Reader::init(&self.buf[..self.used]);
+
+            let m = match OpaqueMessage::read(&mut rd) {
+                Ok(m) => m,
+                Err(e) => {
+                    use MessageError::*;
+                    if !matches!(e, TooShortForHeader | TooShortForLength) {
+                        self.desynced = true;
+                    }
                     break;
                 }
-                BufferContents::Valid => continue,
-                BufferContents::Partial => break,
+            };
+
+            let used = rd.used();
+            self.frames.push_back(m);
+            if used < self.used {
+                /* Before:
+                 * +----------+----------+----------+
+                 * | taken    | pending  |xxxxxxxxxx|
+                 * +----------+----------+----------+
+                 * 0          ^ taken    ^ self.used
+                 *
+                 * After:
+                 * +----------+----------+----------+
+                 * | pending  |xxxxxxxxxxxxxxxxxxxxx|
+                 * +----------+----------+----------+
+                 * 0          ^ self.used
+                 */
+
+                self.buf.copy_within(used..self.used, 0);
+                self.used -= used;
+            } else if used == self.used {
+                self.used = 0;
             }
         }
 
@@ -92,47 +110,6 @@ impl MessageDeframer {
     /// queue or partial messages in our buffer.
     pub fn has_pending(&self) -> bool {
         !self.frames.is_empty() || self.used > 0
-    }
-
-    /// Does our `buf` contain a full message?  It does if it is big enough to
-    /// contain a header, and that header has a length which falls within `buf`.
-    /// If so, deframe it and place the message onto the frames output queue.
-    #[allow(clippy::comparison_chain)]
-    fn try_deframe_one(&mut self) -> BufferContents {
-        // Try to decode a message off the front of buf.
-        let mut rd = codec::Reader::init(&self.buf[..self.used]);
-
-        let m = match OpaqueMessage::read(&mut rd) {
-            Ok(m) => m,
-            Err(MessageError::TooShortForHeader) | Err(MessageError::TooShortForLength) => {
-                return BufferContents::Partial;
-            }
-            Err(_) => return BufferContents::Invalid,
-        };
-
-        let used = rd.used();
-        self.frames.push_back(m);
-        if used < self.used {
-            /* Before:
-             * +----------+----------+----------+
-             * | taken    | pending  |xxxxxxxxxx|
-             * +----------+----------+----------+
-             * 0          ^ taken    ^ self.used
-             *
-             * After:
-             * +----------+----------+----------+
-             * | pending  |xxxxxxxxxxxxxxxxxxxxx|
-             * +----------+----------+----------+
-             * 0          ^ self.used
-             */
-
-            self.buf.copy_within(used..self.used, 0);
-            self.used -= used;
-        } else if used == self.used {
-            self.used = 0;
-        }
-
-        BufferContents::Valid
     }
 }
 

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -220,13 +220,13 @@ mod tests {
     fn pop_first(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Handshake);
-        Message::try_from(&m).unwrap();
+        Message::try_from(&m.into_plain_message()).unwrap();
     }
 
     fn pop_second(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Alert);
-        Message::try_from(&m).unwrap();
+        Message::try_from(&m.into_plain_message()).unwrap();
     }
 
     #[test]

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::io;
 
 use crate::error::Error;
-use crate::msgs::codec;
 use crate::msgs::message::{MessageError, OpaqueMessage};
 
 /// This deframer works to reconstruct TLS messages
@@ -66,9 +65,7 @@ impl MessageDeframer {
             // Does our `buf` contain a full message?  It does if it is big enough to
             // contain a header, and that header has a length which falls within `buf`.
             // If so, deframe it and place the message onto the frames output queue.
-            let mut rd = codec::Reader::init(&self.buf[..self.used]);
-
-            let m = match OpaqueMessage::read(&mut rd) {
+            let (m, used) = match OpaqueMessage::read(&mut self.buf[..self.used]) {
                 Ok(m) => m,
                 Err(e) => {
                     use MessageError::*;
@@ -79,7 +76,6 @@ impl MessageDeframer {
                 }
             };
 
-            let used = rd.used();
             self.frames.push_back(m);
             if used < self.used {
                 /* Before:

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -243,13 +243,13 @@ mod tests {
     fn pop_first(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Handshake);
-        Message::try_from(m).unwrap();
+        Message::try_from(&m).unwrap();
     }
 
     fn pop_second(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Alert);
-        Message::try_from(m).unwrap();
+        Message::try_from(&m).unwrap();
     }
 
     #[test]

--- a/rustls/src/msgs/enums_test.rs
+++ b/rustls/src/msgs/enums_test.rs
@@ -3,19 +3,28 @@
 use super::codec::Codec;
 use super::enums::*;
 
-fn get8<T: Codec>(enum_value: &T) -> u8 {
+fn get8<T>(enum_value: &T) -> u8
+where
+    for<'a> T: Codec<'a>,
+{
     let enc = enum_value.get_encoding();
     assert_eq!(enc.len(), 1);
     enc[0]
 }
 
-fn get16<T: Codec>(enum_value: &T) -> u16 {
+fn get16<T>(enum_value: &T) -> u16
+where
+    for<'a> T: Codec<'a>,
+{
     let enc = enum_value.get_encoding();
     assert_eq!(enc.len(), 2);
     (enc[0] as u16 >> 8) | (enc[1] as u16)
 }
 
-fn test_enum16<T: Codec>(first: T, last: T) {
+fn test_enum16<T>(first: T, last: T)
+where
+    for<'a> T: Codec<'a>,
+{
     let first_v = get16(&first);
     let last_v = get16(&last);
 
@@ -29,7 +38,10 @@ fn test_enum16<T: Codec>(first: T, last: T) {
     }
 }
 
-fn test_enum8<T: Codec>(first: T, last: T) {
+fn test_enum8<T>(first: T, last: T)
+where
+    for<'a> T: Codec<'a>,
+{
     let first_v = get8(&first);
     let last_v = get8(&last);
 

--- a/rustls/src/msgs/fragmenter.rs
+++ b/rustls/src/msgs/fragmenter.rs
@@ -84,7 +84,7 @@ mod tests {
         bytes: &[u8],
     ) {
         let m = mm.unwrap();
-        let buf = m.clone().encode();
+        let buf = m.to_owned().encode();
 
         assert_eq!(&m.typ, typ);
         assert_eq!(&m.version, version);

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -182,19 +182,10 @@ impl SessionID {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UnknownExtension<'a> {
     pub typ: ExtensionType,
     pub payload: Payload<'a>,
-}
-
-impl<'a> UnknownExtension<'a> {
-    fn to_owned(&self) -> UnknownExtension<'static> {
-        UnknownExtension {
-            typ: self.typ,
-            payload: self.payload.to_owned(),
-        }
-    }
 }
 
 impl<'a> UnknownExtension<'a> {
@@ -263,7 +254,7 @@ impl DecomposedSignatureScheme for SignatureScheme {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ServerNamePayload<'a> {
     // Stored twice, bytes so we can round-trip, and DnsName for use
     HostName((PayloadU16<'a>, webpki::DnsName)),
@@ -310,7 +301,7 @@ impl<'a> ServerNamePayload<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServerName<'a> {
     pub typ: ServerNameType,
     pub payload: ServerNamePayload<'a>,
@@ -414,7 +405,7 @@ impl<'a> ConvertProtocolNameList for ProtocolNameList<'a> {
 }
 
 // --- TLS 1.3 Key shares ---
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct KeyShareEntry<'a> {
     pub group: NamedGroup,
     pub payload: PayloadU16<'a>,
@@ -425,15 +416,6 @@ impl KeyShareEntry<'static> {
         KeyShareEntry {
             group,
             payload: PayloadU16::new(payload.to_vec()),
-        }
-    }
-}
-
-impl<'a> KeyShareEntry<'a> {
-    fn to_owned(&self) -> KeyShareEntry<'static> {
-        KeyShareEntry {
-            group: self.group,
-            payload: self.payload.to_owned(),
         }
     }
 }
@@ -453,7 +435,7 @@ impl<'a> Codec<'a> for KeyShareEntry<'a> {
 }
 
 // --- TLS 1.3 PresharedKey offers ---
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PresharedKeyIdentity<'a> {
     pub identity: PayloadU16<'a>,
     pub obfuscated_ticket_age: u32,
@@ -464,15 +446,6 @@ impl PresharedKeyIdentity<'static> {
         PresharedKeyIdentity {
             identity: PayloadU16::new(id),
             obfuscated_ticket_age: age,
-        }
-    }
-}
-
-impl<'a> PresharedKeyIdentity<'a> {
-    fn to_owned(&self) -> PresharedKeyIdentity<'static> {
-        PresharedKeyIdentity {
-            identity: self.identity.to_owned(),
-            obfuscated_ticket_age: self.obfuscated_ticket_age,
         }
     }
 }
@@ -496,7 +469,7 @@ declare_u16_vec_lifetime!(PresharedKeyIdentities, PresharedKeyIdentity);
 pub type PresharedKeyBinder<'a> = PayloadU8<'a>;
 pub type PresharedKeyBinders<'a> = VecU16OfPayloadU8<'a>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PresharedKeyOffer<'a> {
     pub identities: PresharedKeyIdentities<'a>,
     pub binders: PresharedKeyBinders<'a>,
@@ -508,23 +481,6 @@ impl PresharedKeyOffer<'static> {
         PresharedKeyOffer {
             identities: vec![id],
             binders: vec![PresharedKeyBinder::new(binder)],
-        }
-    }
-}
-
-impl<'a> PresharedKeyOffer<'a> {
-    fn to_owned(&self) -> PresharedKeyOffer<'static> {
-        PresharedKeyOffer {
-            identities: self
-                .identities
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-            binders: self
-                .binders
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
         }
     }
 }
@@ -546,23 +502,10 @@ impl<'a> Codec<'a> for PresharedKeyOffer<'a> {
 // --- RFC6066 certificate status request ---
 type ResponderIDs<'a> = VecU16OfPayloadU16<'a>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct OCSPCertificateStatusRequest<'a> {
     pub responder_ids: ResponderIDs<'a>,
     pub extensions: PayloadU16<'a>,
-}
-
-impl<'a> OCSPCertificateStatusRequest<'a> {
-    fn to_owned(&self) -> OCSPCertificateStatusRequest<'static> {
-        OCSPCertificateStatusRequest {
-            responder_ids: self
-                .responder_ids
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-            extensions: self.extensions.to_owned(),
-        }
-    }
 }
 
 impl<'a> Codec<'a> for OCSPCertificateStatusRequest<'a> {
@@ -580,20 +523,10 @@ impl<'a> Codec<'a> for OCSPCertificateStatusRequest<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum CertificateStatusRequest<'a> {
     OCSP(OCSPCertificateStatusRequest<'a>),
     Unknown((CertificateStatusType, Payload<'a>)),
-}
-
-impl<'a> CertificateStatusRequest<'a> {
-    fn to_owned(&self) -> CertificateStatusRequest<'static> {
-        use CertificateStatusRequest::*;
-        match self {
-            OCSP(x) => OCSP(x.to_owned()),
-            Unknown((ty, payload)) => Unknown((*ty, payload.to_owned())),
-        }
-    }
 }
 
 impl<'a> Codec<'a> for CertificateStatusRequest<'a> {
@@ -644,7 +577,7 @@ declare_u8_vec!(PSKKeyExchangeModes, PSKKeyExchangeMode);
 declare_u16_vec_lifetime!(KeyShareEntries, KeyShareEntry);
 declare_u8_vec!(ProtocolVersions, ProtocolVersion);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ClientExtension<'a> {
     ECPointFormats(ECPointFormatList),
     NamedGroups(NamedGroups),
@@ -690,31 +623,6 @@ impl<'a> ClientExtension<'a> {
             ClientExtension::TransportParametersDraft(_) => ExtensionType::TransportParametersDraft,
             ClientExtension::EarlyData => ExtensionType::EarlyData,
             ClientExtension::Unknown(ref r) => r.typ,
-        }
-    }
-
-    pub fn to_owned(&self) -> ClientExtension<'static> {
-        use ClientExtension::*;
-        match self {
-            ECPointFormats(x) => ECPointFormats(x.clone()),
-            NamedGroups(x) => NamedGroups(x.clone()),
-            SignatureAlgorithms(x) => SignatureAlgorithms(x.clone()),
-            ServerName(x) => ServerName(x.iter().map(|y| y.to_owned()).collect()),
-            SessionTicketRequest => SessionTicketRequest,
-            SessionTicketOffer(x) => SessionTicketOffer(x.to_owned()),
-            Protocols(x) => Protocols(x.iter().map(|y| y.to_owned()).collect()),
-            SupportedVersions(x) => SupportedVersions(x.clone()),
-            KeyShare(x) => KeyShare(x.iter().map(|y| y.to_owned()).collect()),
-            PresharedKeyModes(x) => PresharedKeyModes(x.clone()),
-            PresharedKey(x) => PresharedKey(x.to_owned()),
-            Cookie(x) => Cookie(x.to_owned()),
-            ExtendedMasterSecretRequest => ExtendedMasterSecretRequest,
-            CertificateStatusRequest(x) => CertificateStatusRequest(x.to_owned()),
-            SignedCertificateTimestampRequest => SignedCertificateTimestampRequest,
-            TransportParameters(x) => TransportParameters(x.to_vec().into()),
-            TransportParametersDraft(x) => TransportParametersDraft(x.to_vec().into()),
-            EarlyData => EarlyData,
-            Unknown(r) => Unknown(r.to_owned()),
         }
     }
 }
@@ -842,7 +750,7 @@ impl ClientExtension<'static> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ServerExtension<'a> {
     ECPointFormats(ECPointFormatList),
     ServerNameAck,
@@ -879,29 +787,6 @@ impl<'a> ServerExtension<'a> {
             ServerExtension::TransportParametersDraft(_) => ExtensionType::TransportParametersDraft,
             ServerExtension::EarlyData => ExtensionType::EarlyData,
             ServerExtension::Unknown(ref r) => r.typ,
-        }
-    }
-
-    pub fn to_owned(&self) -> ServerExtension<'static> {
-        use ServerExtension::*;
-        match self {
-            ECPointFormats(x) => ECPointFormats(x.clone()),
-            ServerNameAck => ServerNameAck,
-            SessionTicketAck => SessionTicketAck,
-            RenegotiationInfo(x) => RenegotiationInfo(x.to_owned()),
-            Protocols(x) => Protocols(x.iter().map(|x| x.to_owned()).collect()),
-            KeyShare(x) => KeyShare(x.to_owned()),
-            PresharedKey(x) => PresharedKey(*x),
-            ExtendedMasterSecretAck => ExtendedMasterSecretAck,
-            CertificateStatusAck => CertificateStatusAck,
-            SignedCertificateTimestamp(x) => {
-                SignedCertificateTimestamp(x.iter().map(|x| x.to_owned()).collect())
-            }
-            SupportedVersions(x) => SupportedVersions(*x),
-            TransportParameters(x) => TransportParameters(x.to_vec().into()),
-            TransportParametersDraft(x) => TransportParametersDraft(x.to_vec().into()),
-            EarlyData => EarlyData,
-            Unknown(r) => Unknown(r.to_owned()),
         }
     }
 }
@@ -985,9 +870,13 @@ impl<'a> ServerExtension<'a> {
         ServerExtension::RenegotiationInfo(PayloadU8::new(empty))
     }
 
-    pub fn make_sct(sctl: &'a [u8]) -> ServerExtension<'a> {
+    pub fn make_sct(sctl: &[u8]) -> ServerExtension<'static> {
         let scts = SCTList::read_bytes(&sctl).expect("invalid SCT list");
-        ServerExtension::SignedCertificateTimestamp(scts)
+        ServerExtension::SignedCertificateTimestamp(
+            scts.into_iter()
+                .map(|x| x.to_owned())
+                .collect(),
+        )
     }
 }
 
@@ -1192,21 +1081,6 @@ impl<'a> ClientHelloPayload<'a> {
         self.find_extension(ExtensionType::EarlyData)
             .is_some()
     }
-
-    fn to_owned(&self) -> ClientHelloPayload<'static> {
-        ClientHelloPayload {
-            client_version: self.client_version,
-            random: self.random.clone(),
-            session_id: self.session_id,
-            cipher_suites: self.cipher_suites.clone(),
-            compression_methods: self.compression_methods.clone(),
-            extensions: self
-                .extensions
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -1224,16 +1098,6 @@ impl<'a> HelloRetryExtension<'a> {
             HelloRetryExtension::Cookie(_) => ExtensionType::Cookie,
             HelloRetryExtension::SupportedVersions(_) => ExtensionType::SupportedVersions,
             HelloRetryExtension::Unknown(ref r) => r.typ,
-        }
-    }
-
-    fn to_owned(&self) -> HelloRetryExtension<'static> {
-        use HelloRetryExtension::*;
-        match self {
-            KeyShare(x) => KeyShare(x.to_owned()),
-            Cookie(x) => Cookie(x.to_owned()),
-            SupportedVersions(x) => SupportedVersions(x.to_owned()),
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -1363,19 +1227,6 @@ impl<'a> HelloRetryRequest<'a> {
             _ => None,
         }
     }
-
-    fn to_owned(&self) -> HelloRetryRequest<'static> {
-        HelloRetryRequest {
-            legacy_version: self.legacy_version,
-            session_id: self.session_id,
-            cipher_suite: self.cipher_suite,
-            extensions: self
-                .extensions
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -1470,21 +1321,6 @@ impl<'a> ServerHelloPayload<'a> {
             _ => None,
         }
     }
-
-    fn to_owned(&self) -> ServerHelloPayload<'static> {
-        ServerHelloPayload {
-            legacy_version: self.legacy_version,
-            random: self.random.clone(),
-            session_id: self.session_id,
-            cipher_suite: self.cipher_suite,
-            compression_method: self.compression_method,
-            extensions: self
-                .extensions
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 pub type CertificatePayload<'a> = Vec<key::Certificate<'a>>;
@@ -1536,17 +1372,6 @@ impl<'a> CertificateExtension<'a> {
         match *self {
             CertificateExtension::SignedCertificateTimestamp(ref sctl) => Some(sctl),
             _ => None,
-        }
-    }
-
-    fn to_owned(&self) -> CertificateExtension<'static> {
-        use CertificateExtension::*;
-        match self {
-            CertificateStatus(x) => CertificateStatus(x.to_owned()),
-            SignedCertificateTimestamp(x) => {
-                SignedCertificateTimestamp(x.iter().map(|y| y.to_owned()).collect())
-            }
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -1651,17 +1476,6 @@ impl<'a> CertificateEntry<'a> {
             .find(|ext| ext.get_type() == ExtensionType::SCT)
             .and_then(CertificateExtension::get_sct_list)
     }
-
-    fn to_owned(&self) -> CertificateEntry<'static> {
-        CertificateEntry {
-            cert: self.cert.to_owned(),
-            exts: self
-                .exts
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -1747,17 +1561,6 @@ impl<'a> CertificatePayloadTLS13<'a> {
             ret.push(entry.cert.to_owned());
         }
         ret
-    }
-
-    fn to_owned(&self) -> CertificatePayloadTLS13<'static> {
-        CertificatePayloadTLS13 {
-            context: self.context.to_owned(),
-            entries: self
-                .entries
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
     }
 }
 
@@ -1870,13 +1673,6 @@ impl<'a> ServerECDHParams<'a> {
             public: PayloadU8::new(pubkey.to_vec()),
         }
     }
-
-    fn to_owned(&self) -> ServerECDHParams<'static> {
-        ServerECDHParams {
-            curve_params: self.curve_params,
-            public: self.public.to_owned(),
-        }
-    }
 }
 
 impl<'a> Codec<'a> for ServerECDHParams<'a> {
@@ -1900,15 +1696,6 @@ impl<'a> Codec<'a> for ServerECDHParams<'a> {
 pub struct ECDHEServerKeyExchange<'a> {
     pub params: ServerECDHParams<'a>,
     pub dss: DigitallySignedStruct<'a>,
-}
-
-impl<'a> ECDHEServerKeyExchange<'a> {
-    fn to_owned(&self) -> ECDHEServerKeyExchange<'static> {
-        ECDHEServerKeyExchange {
-            params: self.params.to_owned(),
-            dss: self.dss.to_owned(),
-        }
-    }
 }
 
 impl<'a> Codec<'a> for ECDHEServerKeyExchange<'a> {
@@ -1978,14 +1765,6 @@ impl<'a> ServerKeyExchangePayload<'a> {
         match *self {
             ServerKeyExchangePayload::ECDHE(ref x) => Some(&x.dss),
             _ => None,
-        }
-    }
-
-    fn to_owned(&self) -> ServerKeyExchangePayload<'static> {
-        use ServerKeyExchangePayload::*;
-        match self {
-            ECDHE(x) => ECDHE(x.to_owned()),
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -2062,20 +1841,6 @@ pub struct CertificateRequestPayload<'a> {
     pub canames: DistinguishedNames<'a>,
 }
 
-impl<'a> CertificateRequestPayload<'a> {
-    fn to_owned(&self) -> CertificateRequestPayload<'static> {
-        CertificateRequestPayload {
-            certtypes: self.certtypes.clone(),
-            sigschemes: self.sigschemes.clone(),
-            canames: self
-                .canames
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
-}
-
 impl<'a> Codec<'a> for CertificateRequestPayload<'a> {
     fn encode(&self, bytes: &mut Vec<u8>) {
         self.certtypes.encode(bytes);
@@ -2114,15 +1879,6 @@ impl<'a> CertReqExtension<'a> {
             CertReqExtension::SignatureAlgorithms(_) => ExtensionType::SignatureAlgorithms,
             CertReqExtension::AuthorityNames(_) => ExtensionType::CertificateAuthorities,
             CertReqExtension::Unknown(ref r) => r.typ,
-        }
-    }
-
-    fn to_owned(&self) -> CertReqExtension<'static> {
-        use CertReqExtension::*;
-        match self {
-            SignatureAlgorithms(x) => SignatureAlgorithms(x.clone()),
-            AuthorityNames(x) => AuthorityNames(x.iter().map(|y| y.to_owned()).collect()),
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -2213,17 +1969,6 @@ impl<'a> CertificateRequestPayloadTLS13<'a> {
             _ => None,
         }
     }
-
-    fn to_owned(&self) -> CertificateRequestPayloadTLS13<'static> {
-        CertificateRequestPayloadTLS13 {
-            context: self.context.to_owned(),
-            extensions: self
-                .extensions
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 // -- NewSessionTicket --
@@ -2238,13 +1983,6 @@ impl<'a> NewSessionTicketPayload<'a> {
         NewSessionTicketPayload {
             lifetime_hint,
             ticket: PayloadU16::new(ticket),
-        }
-    }
-
-    fn to_owned(&self) -> NewSessionTicketPayload<'static> {
-        NewSessionTicketPayload {
-            lifetime_hint: self.lifetime_hint,
-            ticket: self.ticket.to_owned(),
         }
     }
 }
@@ -2278,14 +2016,6 @@ impl<'a> NewSessionTicketExtension<'a> {
         match *self {
             NewSessionTicketExtension::EarlyData(_) => ExtensionType::EarlyData,
             NewSessionTicketExtension::Unknown(ref r) => r.typ,
-        }
-    }
-
-    fn to_owned(&self) -> NewSessionTicketExtension<'static> {
-        use NewSessionTicketExtension::*;
-        match self {
-            EarlyData(x) => EarlyData(*x),
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -2358,20 +2088,6 @@ impl<'a> NewSessionTicketPayloadTLS13<'a> {
             _ => None,
         }
     }
-
-    fn to_owned(&self) -> NewSessionTicketPayloadTLS13<'static> {
-        NewSessionTicketPayloadTLS13 {
-            lifetime: self.lifetime,
-            age_add: self.age_add,
-            nonce: self.nonce.to_owned(),
-            ticket: self.ticket.to_owned(),
-            exts: self
-                .exts
-                .iter()
-                .map(|x| x.to_owned())
-                .collect(),
-        }
-    }
 }
 
 impl<'a> Codec<'a> for NewSessionTicketPayloadTLS13<'a> {
@@ -2436,12 +2152,6 @@ impl<'a> CertificateStatus<'a> {
     pub fn into_inner(self) -> Vec<u8> {
         self.ocsp_response.0.into_owned()
     }
-
-    fn to_owned(&self) -> CertificateStatus<'static> {
-        CertificateStatus {
-            ocsp_response: self.ocsp_response.to_owned(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -2495,34 +2205,6 @@ impl<'a> HandshakePayload<'a> {
             HandshakePayload::CertificateStatus(ref x) => x.encode(bytes),
             HandshakePayload::MessageHash(ref x) => x.encode(bytes),
             HandshakePayload::Unknown(ref x) => x.encode(bytes),
-        }
-    }
-
-    fn to_owned(&self) -> HandshakePayload<'static> {
-        use HandshakePayload::*;
-        match self {
-            HelloRequest => HelloRequest,
-            ServerHelloDone => ServerHelloDone,
-            EarlyData => EarlyData,
-            EndOfEarlyData => EndOfEarlyData,
-            ClientHello(x) => ClientHello(x.to_owned()),
-            ServerHello(x) => ServerHello(x.to_owned()),
-            HelloRetryRequest(x) => HelloRetryRequest(x.to_owned()),
-            Certificate(x) => Certificate(x.iter().map(|y| y.to_owned()).collect()),
-            CertificateTLS13(x) => CertificateTLS13(x.to_owned()),
-            ServerKeyExchange(x) => ServerKeyExchange(x.to_owned()),
-            ClientKeyExchange(x) => ClientKeyExchange(x.to_owned()),
-            CertificateRequest(x) => CertificateRequest(x.to_owned()),
-            CertificateRequestTLS13(x) => CertificateRequestTLS13(x.to_owned()),
-            CertificateVerify(x) => CertificateVerify(x.to_owned()),
-            NewSessionTicket(x) => NewSessionTicket(x.to_owned()),
-            NewSessionTicketTLS13(x) => NewSessionTicketTLS13(x.to_owned()),
-            EncryptedExtensions(x) => EncryptedExtensions(x.iter().map(|y| y.to_owned()).collect()),
-            KeyUpdate(x) => KeyUpdate(x.to_owned()),
-            Finished(x) => Finished(x.to_owned()),
-            CertificateStatus(x) => CertificateStatus(x.to_owned()),
-            MessageHash(x) => MessageHash(x.to_owned()),
-            Unknown(x) => Unknown(x.to_owned()),
         }
     }
 }
@@ -2684,13 +2366,6 @@ impl<'a> HandshakeMessagePayload<'a> {
         HandshakeMessagePayload {
             typ: HandshakeType::MessageHash,
             payload: HandshakePayload::MessageHash(Payload::new(hash.to_vec())),
-        }
-    }
-
-    pub fn to_owned(&self) -> HandshakeMessagePayload<'static> {
-        HandshakeMessagePayload {
-            typ: self.typ,
-            payload: self.payload.to_owned(),
         }
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -1322,7 +1322,7 @@ impl CertificateExtension {
         CertificateExtension::SignedCertificateTimestamp(sctl)
     }
 
-    pub fn get_cert_status(&self) -> Option<&Vec<u8>> {
+    pub fn get_cert_status(&self) -> Option<&[u8]> {
         match *self {
             CertificateExtension::CertificateStatus(ref cs) => Some(&cs.ocsp_response.0),
             _ => None,
@@ -1424,7 +1424,7 @@ impl CertificateEntry {
         })
     }
 
-    pub fn get_ocsp_response(&self) -> Option<&Vec<u8>> {
+    pub fn get_ocsp_response(&self) -> Option<&[u8]> {
         self.exts
             .iter()
             .find(|ext| ext.get_type() == ExtensionType::StatusRequest)
@@ -1501,7 +1501,7 @@ impl CertificatePayloadTLS13 {
         self.entries
             .first()
             .and_then(CertificateEntry::get_ocsp_response)
-            .cloned()
+            .map(|bytes| bytes.to_vec())
             .unwrap_or_else(Vec::new)
     }
 
@@ -2100,7 +2100,7 @@ impl CertificateStatus {
     }
 
     pub fn into_inner(self) -> Vec<u8> {
-        self.ocsp_response.0
+        self.ocsp_response.0.into_owned()
     }
 }
 

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -370,8 +370,8 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             ClientExtension::make_sni(DnsNameRef::try_from_ascii_str("hello").unwrap()),
             ClientExtension::SessionTicketRequest,
-            ClientExtension::SessionTicketOffer(Payload(vec![])),
-            ClientExtension::Protocols(vec![PayloadU8(vec![0])]),
+            ClientExtension::SessionTicketOffer(Payload(vec![].into())),
+            ClientExtension::Protocols(vec![PayloadU8(vec![0].into())]),
             ClientExtension::SupportedVersions(vec![ProtocolVersion::TLSv1_3]),
             ClientExtension::KeyShare(vec![KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])]),
             ClientExtension::PresharedKeyModes(vec![PSKKeyExchangeMode::PSK_DHE_KE]),
@@ -392,7 +392,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload {
             ClientExtension::TransportParameters(vec![1, 2, 3]),
             ClientExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -500,7 +500,7 @@ fn test_client_extension_getter(typ: ExtensionType, getter: fn(&ClientHelloPaylo
 
     chp.extensions = vec![ClientExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&chp));
 }
@@ -619,7 +619,7 @@ fn test_helloretry_extension_getter(typ: ExtensionType, getter: fn(&HelloRetryRe
 
     hrr.extensions = vec![HelloRetryExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&hrr));
 }
@@ -688,7 +688,7 @@ fn test_server_extension_getter(typ: ExtensionType, getter: fn(&ServerHelloPaylo
 
     shp.extensions = vec![ServerExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&shp));
 }
@@ -738,7 +738,7 @@ fn test_cert_extension_getter(typ: ExtensionType, getter: fn(&CertificateEntry) 
 
     ce.exts = vec![CertificateExtension::Unknown(UnknownExtension {
         typ,
-        payload: Payload(vec![]),
+        payload: Payload(vec![].into()),
     })];
     assert!(!getter(&ce));
 }
@@ -766,8 +766,8 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::ECPointFormats(ECPointFormatList::supported()),
             ServerExtension::ServerNameAck,
             ServerExtension::SessionTicketAck,
-            ServerExtension::RenegotiationInfo(PayloadU8(vec![0])),
-            ServerExtension::Protocols(vec![PayloadU8(vec![0])]),
+            ServerExtension::RenegotiationInfo(PayloadU8(vec![0].into())),
+            ServerExtension::Protocols(vec![PayloadU8(vec![0].into())]),
             ServerExtension::KeyShare(KeyShareEntry::new(NamedGroup::X25519, &[1, 2, 3])),
             ServerExtension::PresharedKey(3),
             ServerExtension::ExtendedMasterSecretAck,
@@ -777,7 +777,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload {
             ServerExtension::TransportParameters(vec![1, 2, 3]),
             ServerExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -806,7 +806,7 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
             HelloRetryExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
             HelloRetryExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -814,17 +814,17 @@ fn get_sample_helloretryrequest() -> HelloRetryRequest {
 
 fn get_sample_certificatepayloadtls13() -> CertificatePayloadTLS13 {
     CertificatePayloadTLS13 {
-        context: PayloadU8(vec![1, 2, 3]),
+        context: PayloadU8(vec![1, 2, 3].into()),
         entries: vec![CertificateEntry {
             cert: Certificate(vec![3, 4, 5]),
             exts: vec![
                 CertificateExtension::CertificateStatus(CertificateStatus {
-                    ocsp_response: PayloadU24(vec![1, 2, 3]),
+                    ocsp_response: PayloadU24(vec![1, 2, 3].into()),
                 }),
                 CertificateExtension::SignedCertificateTimestamp(vec![PayloadU16(vec![0])]),
                 CertificateExtension::Unknown(UnknownExtension {
                     typ: ExtensionType::Unknown(12345),
-                    payload: Payload(vec![1, 2, 3]),
+                    payload: Payload(vec![1, 2, 3].into()),
                 }),
             ],
         }],
@@ -838,7 +838,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
                 curve_type: ECCurveType::NamedCurve,
                 named_group: NamedGroup::X25519,
             },
-            public: PayloadU8(vec![1, 2, 3]),
+            public: PayloadU8(vec![1, 2, 3].into()),
         },
         dss: DigitallySignedStruct {
             scheme: SignatureScheme::RSA_PSS_SHA256,
@@ -848,7 +848,7 @@ fn get_sample_serverkeyexchangepayload_ecdhe() -> ServerKeyExchangePayload {
 }
 
 fn get_sample_serverkeyexchangepayload_unknown() -> ServerKeyExchangePayload {
-    ServerKeyExchangePayload::Unknown(Payload(vec![1, 2, 3]))
+    ServerKeyExchangePayload::Unknown(Payload(vec![1, 2, 3].into()))
 }
 
 fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
@@ -861,13 +861,13 @@ fn get_sample_certificaterequestpayload() -> CertificateRequestPayload {
 
 fn get_sample_certificaterequestpayloadtls13() -> CertificateRequestPayloadTLS13 {
     CertificateRequestPayloadTLS13 {
-        context: PayloadU8(vec![1, 2, 3]),
+        context: PayloadU8(vec![1, 2, 3].into()),
         extensions: vec![
             CertReqExtension::SignatureAlgorithms(vec![SignatureScheme::ECDSA_NISTP256_SHA256]),
             CertReqExtension::AuthorityNames(vec![PayloadU16(vec![1, 2, 3])]),
             CertReqExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
-                payload: Payload(vec![1, 2, 3]),
+                payload: Payload(vec![1, 2, 3].into()),
             }),
         ],
     }
@@ -884,11 +884,11 @@ fn get_sample_newsessionticketpayloadtls13() -> NewSessionTicketPayloadTLS13 {
     NewSessionTicketPayloadTLS13 {
         lifetime: 123,
         age_add: 1234,
-        nonce: PayloadU8(vec![1, 2, 3]),
+        nonce: PayloadU8(vec![1, 2, 3].into()),
         ticket: PayloadU16(vec![4, 5, 6]),
         exts: vec![NewSessionTicketExtension::Unknown(UnknownExtension {
             typ: ExtensionType::Unknown(12345),
-            payload: Payload(vec![1, 2, 3]),
+            payload: Payload(vec![1, 2, 3].into()),
         })],
     }
 }
@@ -899,7 +899,7 @@ fn get_sample_encryptedextensions() -> EncryptedExtensions {
 
 fn get_sample_certificatestatus() -> CertificateStatus {
     CertificateStatus {
-        ocsp_response: PayloadU24(vec![1, 2, 3]),
+        ocsp_response: PayloadU24(vec![1, 2, 3].into()),
     }
 }
 
@@ -947,7 +947,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -967,7 +967,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -975,7 +975,7 @@ fn get_all_tls12_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3].into())),
         },
     ]
 }
@@ -1086,7 +1086,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::ClientKeyExchange,
-            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::ClientKeyExchange(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::NewSessionTicket,
@@ -1108,7 +1108,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Finished,
-            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Finished(Payload(vec![1, 2, 3].into())),
         },
         HandshakeMessagePayload {
             typ: HandshakeType::CertificateStatus,
@@ -1116,7 +1116,7 @@ fn get_all_tls13_handshake_payloads() -> Vec<HandshakeMessagePayload> {
         },
         HandshakeMessagePayload {
             typ: HandshakeType::Unknown(99),
-            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3])),
+            payload: HandshakePayload::Unknown(Payload(vec![1, 2, 3].into())),
         },
     ]
 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -389,7 +389,7 @@ fn get_sample_clienthellopayload() -> ClientHelloPayload<'static> {
             ClientExtension::ExtendedMasterSecretRequest,
             ClientExtension::CertificateStatusRequest(CertificateStatusRequest::build_ocsp()),
             ClientExtension::SignedCertificateTimestampRequest,
-            ClientExtension::TransportParameters(vec![1, 2, 3]),
+            ClientExtension::TransportParameters(vec![1, 2, 3].into()),
             ClientExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
                 payload: Payload(vec![1, 2, 3].into()),
@@ -773,7 +773,7 @@ fn get_sample_serverhellopayload() -> ServerHelloPayload<'static> {
             ServerExtension::CertificateStatusAck,
             ServerExtension::SignedCertificateTimestamp(vec![PayloadU16(vec![0].into())]),
             ServerExtension::SupportedVersions(ProtocolVersion::TLSv1_2),
-            ServerExtension::TransportParameters(vec![1, 2, 3]),
+            ServerExtension::TransportParameters(vec![1, 2, 3].into()),
             ServerExtension::Unknown(UnknownExtension {
                 typ: ExtensionType::Unknown(12345),
                 payload: Payload(vec![1, 2, 3].into()),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -808,7 +808,7 @@ fn get_sample_certificatepayloadtls13() -> CertificatePayloadTLS13<'static> {
     CertificatePayloadTLS13 {
         context: PayloadU8(vec![1, 2, 3].into()),
         entries: vec![CertificateEntry {
-            cert: Certificate(vec![3, 4, 5]),
+            cert: Certificate(vec![3, 4, 5].into()),
             exts: vec![
                 CertificateExtension::CertificateStatus(CertificateStatus {
                     ocsp_response: PayloadU24(vec![1, 2, 3].into()),

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -482,23 +482,29 @@ fn test_truncated_client_extension_is_detected() {
 }
 
 fn test_client_extension_getter(typ: ExtensionType, getter: fn(&ClientHelloPayload) -> bool) {
-    let mut chp = get_sample_clienthellopayload();
-    let ext = chp
-        .find_extension(typ)
-        .unwrap()
-        .to_owned();
+    let chp = get_sample_clienthellopayload();
+    let ext = chp.find_extension(typ).unwrap().clone();
 
-    chp.extensions = vec![];
-    assert!(!getter(&chp));
+    let mut borrowed_chp = ClientHelloPayload {
+        client_version: chp.client_version,
+        random: chp.random.clone(),
+        session_id: chp.session_id,
+        cipher_suites: chp.cipher_suites.clone(),
+        compression_methods: chp.compression_methods.clone(),
+        extensions: vec![],
+    };
 
-    chp.extensions = vec![ext];
-    assert!(getter(&chp));
+    borrowed_chp.extensions = vec![];
+    assert!(!getter(&borrowed_chp));
 
-    chp.extensions = vec![ClientExtension::Unknown(UnknownExtension {
+    borrowed_chp.extensions = vec![ext];
+    assert!(getter(&borrowed_chp));
+
+    borrowed_chp.extensions = vec![ClientExtension::Unknown(UnknownExtension {
         typ,
         payload: Payload(vec![].into()),
     })];
-    assert!(!getter(&chp));
+    assert!(!getter(&borrowed_chp));
 }
 
 #[test]
@@ -673,23 +679,29 @@ fn test_truncated_server_extension_is_detected() {
 }
 
 fn test_server_extension_getter(typ: ExtensionType, getter: fn(&ServerHelloPayload) -> bool) {
-    let mut shp = get_sample_serverhellopayload();
-    let ext = shp
-        .find_extension(typ)
-        .unwrap()
-        .to_owned();
+    let shp = get_sample_serverhellopayload();
+    let ext = shp.find_extension(typ).unwrap().clone();
 
-    shp.extensions = vec![];
-    assert!(!getter(&shp));
+    let mut borrowed_shp = ServerHelloPayload {
+        legacy_version: shp.legacy_version,
+        random: shp.random.clone(),
+        session_id: shp.session_id,
+        cipher_suite: shp.cipher_suite,
+        compression_method: shp.compression_method,
+        extensions: vec![],
+    };
 
-    shp.extensions = vec![ext];
-    assert!(getter(&shp));
+    borrowed_shp.extensions = vec![];
+    assert!(!getter(&borrowed_shp));
 
-    shp.extensions = vec![ServerExtension::Unknown(UnknownExtension {
+    borrowed_shp.extensions = vec![ext];
+    assert!(getter(&borrowed_shp));
+
+    borrowed_shp.extensions = vec![ServerExtension::Unknown(UnknownExtension {
         typ,
         payload: Payload(vec![].into()),
     })];
-    assert!(!getter(&shp));
+    assert!(!getter(&borrowed_shp));
 }
 
 #[test]

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -13,7 +13,7 @@ const HEADER_SIZE: usize = 1 + 3;
 /// one handshake payload.
 pub struct HandshakeJoiner {
     /// Completed handshake frames for output.
-    pub frames: VecDeque<Message>,
+    pub frames: VecDeque<Message<'static>>,
 
     /// The message payload we're currently accumulating.
     buf: Vec<u8>,
@@ -103,7 +103,7 @@ impl HandshakeJoiner {
 
             let m = Message {
                 version,
-                payload: MessagePayload::Handshake(payload),
+                payload: MessagePayload::Handshake(payload.to_owned()),
             };
 
             self.frames.push_back(m);

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -56,10 +56,10 @@ impl HandshakeJoiner {
         // handshake messages arrive in a single fragment. Avoid allocating and
         // copying in that common case.
         if self.buf.is_empty() {
-            self.buf = msg.payload.0;
+            self.buf = msg.payload;
         } else {
             self.buf
-                .extend_from_slice(&msg.payload.0[..]);
+                .extend_from_slice(&msg.payload[..]);
         }
 
         let mut count = 0;
@@ -118,7 +118,6 @@ impl HandshakeJoiner {
 mod tests {
     use super::HandshakeJoiner;
     use crate::msgs::base::Payload;
-    use crate::msgs::codec::Codec;
     use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
     use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
     use crate::msgs::message::{Message, MessagePayload, OpaqueMessage};
@@ -131,13 +130,13 @@ mod tests {
         let wanted = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"hello world".to_vec()),
+            payload: b"hello world".to_vec(),
         };
 
         let unwanted = OpaqueMessage {
             typ: ContentType::Alert,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"ponytown".to_vec()),
+            payload: b"ponytown".to_vec(),
         };
 
         assert_eq!(hj.want_message(&wanted), true);
@@ -151,7 +150,7 @@ mod tests {
 
         let (mut left, mut right) = (Vec::new(), Vec::new());
         got.payload.encode(&mut left);
-        expect.payload.encode(&mut right);
+        right.extend(&expect.payload);
 
         assert_eq!(left, right);
     }
@@ -165,7 +164,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec()),
+            payload: b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -194,7 +193,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x01\x00\x00\x02\xff\xff".to_vec()),
+            payload: b"\x01\x00\x00\x02\xff\xff".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -211,7 +210,7 @@ mod tests {
         let mut msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec()),
+            payload: b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -222,7 +221,7 @@ mod tests {
         msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec()),
+            payload: b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -233,7 +232,7 @@ mod tests {
         msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x0f".to_vec()),
+            payload: b"\x0f".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -259,7 +258,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x0b\x01\x00\x04\x01\x00\x01\x00\xff\xfe".to_vec()),
+            payload: b"\x0b\x01\x00\x04\x01\x00\x01\x00\xff\xfe".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);
@@ -270,7 +269,7 @@ mod tests {
             let msg = OpaqueMessage {
                 typ: ContentType::Handshake,
                 version: ProtocolVersion::TLSv1_2,
-                payload: Payload::new(b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec()),
+                payload: b"\x01\x02\x03\x04\x05\x06\x07\x08".to_vec(),
             };
 
             assert_eq!(hj.want_message(&msg), true);
@@ -282,7 +281,7 @@ mod tests {
         let msg = OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
-            payload: Payload::new(b"\x01\x02\x03\x04\x05\x06".to_vec()),
+            payload: b"\x01\x02\x03\x04\x05\x06".to_vec(),
         };
 
         assert_eq!(hj.want_message(&msg), true);

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -28,11 +28,6 @@ impl HandshakeJoiner {
         msg.typ == ContentType::Handshake
     }
 
-    /// Do we have any buffered data?
-    pub fn is_empty(&self) -> bool {
-        self.buf.is_empty()
-    }
-
     /// Take the message, and join/split it as needed
     pub fn take_message(&mut self, msg: OpaqueMessage) {
         // The vast majority of the time `self.buf` will be empty since most
@@ -136,7 +131,7 @@ mod tests {
     #[test]
     fn want() {
         let hj = HandshakeJoiner::new();
-        assert_eq!(hj.is_empty(), true);
+        assert_eq!(hj.buf.is_empty(), true);
 
         let wanted = OpaqueMessage {
             typ: ContentType::Handshake,
@@ -186,7 +181,7 @@ mod tests {
 
         assert_eq!(hj.want_message(&msg), true);
         hj.take_message(msg);
-        assert_eq!(hj.is_empty(), false);
+        assert_eq!(hj.buf.is_empty(), false);
 
         let expect = Message {
             version: ProtocolVersion::TLSv1_2,
@@ -222,7 +217,7 @@ mod tests {
     fn join() {
         // Check we join one handshake message split over two PDUs.
         let mut hj = HandshakeJoiner::new();
-        assert_eq!(hj.is_empty(), true);
+        assert_eq!(hj.buf.is_empty(), true);
 
         // Introduce Finished of 16 bytes, providing 4.
         let mut msg = OpaqueMessage {
@@ -233,7 +228,7 @@ mod tests {
 
         assert_eq!(hj.want_message(&msg), true);
         hj.take_message(msg);
-        assert_eq!(hj.is_empty(), false);
+        assert_eq!(hj.buf.is_empty(), false);
 
         // 11 more bytes.
         msg = OpaqueMessage {
@@ -244,7 +239,7 @@ mod tests {
 
         assert_eq!(hj.want_message(&msg), true);
         hj.take_message(msg);
-        assert_eq!(hj.is_empty(), false);
+        assert_eq!(hj.buf.is_empty(), false);
 
         // Final 1 byte.
         msg = OpaqueMessage {
@@ -255,7 +250,7 @@ mod tests {
 
         assert_eq!(hj.want_message(&msg), true);
         hj.take_message(msg);
-        assert_eq!(hj.is_empty(), false);
+        assert_eq!(hj.buf.is_empty(), false);
 
         let payload = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f".to_vec();
         let expect = Message {
@@ -281,7 +276,7 @@ mod tests {
 
         assert_eq!(hj.want_message(&msg), true);
         hj.take_message(msg);
-        assert_eq!(hj.is_empty(), false);
+        assert_eq!(hj.buf.is_empty(), false);
 
         for _i in 0..8191 {
             let msg = OpaqueMessage {
@@ -292,7 +287,7 @@ mod tests {
 
             assert_eq!(hj.want_message(&msg), true);
             hj.take_message(msg);
-            assert_eq!(hj.is_empty(), false);
+            assert_eq!(hj.buf.is_empty(), false);
         }
 
         // final 6 bytes

--- a/rustls/src/msgs/macros.rs
+++ b/rustls/src/msgs/macros.rs
@@ -21,12 +21,12 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl<'a> Codec<'a> for $enum_name {
             fn encode(&self, bytes: &mut Vec<u8>) {
                 self.get_u8().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
+            fn read(r: &mut Reader<'a>) -> Option<Self> {
                 u8::read(r).map($enum_name::from)
             }
         }
@@ -60,12 +60,12 @@ macro_rules! enum_builder {
                 }
             }
         }
-        impl Codec for $enum_name {
+        impl<'a> Codec<'a> for $enum_name {
             fn encode(&self, bytes: &mut Vec<u8>) {
                 self.get_u16().encode(bytes);
             }
 
-            fn read(r: &mut Reader) -> Option<Self> {
+            fn read(r: &mut Reader<'a>) -> Option<Self> {
                 u16::read(r).map($enum_name::from)
             }
         }

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -109,7 +109,7 @@ impl OpaqueMessage {
         Ok(OpaqueMessage {
             typ,
             version,
-            payload: payload.0,
+            payload: payload.0.into_owned(),
         })
     }
 
@@ -146,7 +146,7 @@ impl From<Message> for OpaqueMessage {
     fn from(msg: Message) -> OpaqueMessage {
         let typ = msg.payload.content_type();
         let payload = match msg.payload {
-            MessagePayload::ApplicationData(payload) => payload.0,
+            MessagePayload::ApplicationData(payload) => payload.0.into_owned(),
             _ => {
                 let mut buf = Vec::new();
                 msg.payload.encode(&mut buf);

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -1,4 +1,3 @@
-use super::codec::Reader;
 use super::enums::{AlertDescription, AlertLevel, HandshakeType};
 use super::message::{Message, OpaqueMessage};
 
@@ -25,8 +24,7 @@ fn test_read_fuzz_corpus() {
         let mut bytes = Vec::new();
         f.read_to_end(&mut bytes).unwrap();
 
-        let mut rd = Reader::init(&bytes);
-        let msg = OpaqueMessage::read(&mut rd).unwrap();
+        let (msg, used) = OpaqueMessage::read(&mut bytes).unwrap();
         println!("{:?}", msg);
 
         let msg = match Message::try_from(&msg) {
@@ -36,7 +34,7 @@ fn test_read_fuzz_corpus() {
 
         let enc = OpaqueMessage::from(msg).encode();
         assert_eq!(bytes.to_vec(), enc);
-        assert_eq!(bytes[..rd.used()].to_vec(), enc);
+        assert_eq!(bytes.len(), used);
     }
 }
 
@@ -46,7 +44,7 @@ fn can_read_safari_client_hello() {
         .filter(None, log::LevelFilter::Trace)
         .try_init();
 
-    let bytes = b"\
+    let mut bytes = b"\
         \x16\x03\x01\x00\xeb\x01\x00\x00\xe7\x03\x03\xb6\x1f\xe4\x3a\x55\
         \x90\x3e\xc0\x28\x9c\x12\xe0\x5c\x84\xea\x90\x1b\xfb\x11\xfc\xbd\
         \x25\x55\xda\x9f\x51\x93\x1b\x8d\x92\x66\xfd\x00\x00\x2e\xc0\x2c\
@@ -61,9 +59,9 @@ fn can_read_safari_client_hello() {
         \x32\x05\x68\x32\x2d\x31\x36\x05\x68\x32\x2d\x31\x35\x05\x68\x32\
         \x2d\x31\x34\x08\x73\x70\x64\x79\x2f\x33\x2e\x31\x06\x73\x70\x64\
         \x79\x2f\x33\x08\x68\x74\x74\x70\x2f\x31\x2e\x31\x00\x0b\x00\x02\
-        \x01\x00\x00\x0a\x00\x0a\x00\x08\x00\x1d\x00\x17\x00\x18\x00\x19";
-    let mut rd = Reader::init(bytes);
-    let m = OpaqueMessage::read(&mut rd).unwrap();
+        \x01\x00\x00\x0a\x00\x0a\x00\x08\x00\x1d\x00\x17\x00\x18\x00\x19"
+        .to_vec();
+    let (m, _) = OpaqueMessage::read(&mut bytes[..]).unwrap();
     println!("m = {:?}", m);
     assert!(Message::try_from(&m).is_err());
 }
@@ -82,15 +80,15 @@ fn alert_is_not_opaque() {
 
 #[test]
 fn construct_all_types() {
-    let samples = [
-        &b"\x14\x03\x04\x00\x01\x01"[..],
-        &b"\x15\x03\x04\x00\x02\x01\x16"[..],
-        &b"\x16\x03\x04\x00\x05\x18\x00\x00\x01\x00"[..],
-        &b"\x17\x03\x04\x00\x04\x11\x22\x33\x44"[..],
-        &b"\x18\x03\x04\x00\x04\x11\x22\x33\x44"[..],
+    let mut samples = [
+        b"\x14\x03\x04\x00\x01\x01"[..].to_vec(),
+        b"\x15\x03\x04\x00\x02\x01\x16"[..].to_vec(),
+        b"\x16\x03\x04\x00\x05\x18\x00\x00\x01\x00"[..].to_vec(),
+        b"\x17\x03\x04\x00\x04\x11\x22\x33\x44"[..].to_vec(),
+        b"\x18\x03\x04\x00\x04\x11\x22\x33\x44"[..].to_vec(),
     ];
-    for &bytes in samples.iter() {
-        let m = OpaqueMessage::read(&mut Reader::init(bytes)).unwrap();
+    for bytes in samples.iter_mut() {
+        let (m, _) = OpaqueMessage::read(bytes).unwrap();
         println!("m = {:?}", m);
         let m = Message::try_from(&m);
         println!("m' = {:?}", m);

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -27,7 +27,7 @@ fn test_read_fuzz_corpus() {
         let (msg, used) = OpaqueMessage::read(&mut bytes).unwrap();
         println!("{:?}", msg);
 
-        let plain = msg.into_plain_message();
+        let plain = msg.to_plain_message();
         let msg = match Message::try_from(&plain) {
             Ok(msg) => msg,
             Err(_) => continue,
@@ -66,7 +66,7 @@ fn can_read_safari_client_hello() {
         .to_vec();
     let (m, _) = OpaqueMessage::read(&mut bytes[..]).unwrap();
     println!("m = {:?}", m);
-    assert!(Message::try_from(&m.into_plain_message()).is_err());
+    assert!(Message::try_from(&m.to_plain_message()).is_err());
 }
 
 #[test]
@@ -93,7 +93,7 @@ fn construct_all_types() {
     for bytes in samples.iter_mut() {
         let (m, _) = OpaqueMessage::read(bytes).unwrap();
         println!("m = {:?}", m);
-        let plain = m.into_plain_message();
+        let plain = m.to_plain_message();
         let m = Message::try_from(&plain);
         println!("m' = {:?}", m);
     }

--- a/rustls/src/msgs/message_test.rs
+++ b/rustls/src/msgs/message_test.rs
@@ -29,7 +29,7 @@ fn test_read_fuzz_corpus() {
         let msg = OpaqueMessage::read(&mut rd).unwrap();
         println!("{:?}", msg);
 
-        let msg = match Message::try_from(msg) {
+        let msg = match Message::try_from(&msg) {
             Ok(msg) => msg,
             Err(_) => continue,
         };
@@ -65,7 +65,7 @@ fn can_read_safari_client_hello() {
     let mut rd = Reader::init(bytes);
     let m = OpaqueMessage::read(&mut rd).unwrap();
     println!("m = {:?}", m);
-    assert!(Message::try_from(m).is_err());
+    assert!(Message::try_from(&m).is_err());
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn construct_all_types() {
     for &bytes in samples.iter() {
         let m = OpaqueMessage::read(&mut Reader::init(bytes)).unwrap();
         println!("m = {:?}", m);
-        let m = Message::try_from(m);
+        let m = Message::try_from(&m);
         println!("m' = {:?}", m);
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -35,13 +35,13 @@ mod test {
 
     #[test]
     fn smoketest() {
-        use super::codec::Reader;
         use super::message::{Message, OpaqueMessage};
-        let bytes = include_bytes!("handshake-test.1.bin");
-        let mut r = Reader::init(bytes);
+        let mut bytes = include_bytes!("handshake-test.1.bin").to_vec();
+        let mut offset = 0;
 
-        while r.any_left() {
-            let m = OpaqueMessage::read(&mut r).unwrap();
+        while offset < bytes.len() {
+            let (m, used) = OpaqueMessage::read(&mut bytes[offset..]).unwrap();
+            offset += used;
 
             let out = m.to_owned().encode();
             assert!(out.len() > 0);

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -46,7 +46,7 @@ mod test {
             let out = m.to_owned().encode();
             assert!(out.len() > 0);
 
-            Message::try_from(&m.into_plain_message()).unwrap();
+            Message::try_from(&m.to_plain_message()).unwrap();
         }
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -43,10 +43,10 @@ mod test {
         while r.any_left() {
             let m = OpaqueMessage::read(&mut r).unwrap();
 
-            let out = m.clone().encode();
+            let out = m.to_owned().encode();
             assert!(out.len() > 0);
 
-            Message::try_from(m).unwrap();
+            Message::try_from(&m).unwrap();
         }
     }
 }

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -46,7 +46,7 @@ mod test {
             let out = m.to_owned().encode();
             assert!(out.len() > 0);
 
-            Message::try_from(&m).unwrap();
+            Message::try_from(&m.into_plain_message()).unwrap();
         }
     }
 }

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -29,7 +29,10 @@ fn clientsessionvalue_is_debug() {
         &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],
-        &vec![Certificate(b"abc".to_vec()), Certificate(b"def".to_vec())],
+        &vec![
+            Certificate(b"abc".to_vec().into()),
+            Certificate(b"def".to_vec().into()),
+        ],
         TimeBase::now().unwrap(),
     );
     println!("{:?}", csv);

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -3,7 +3,6 @@ pub use crate::client::ClientQuicExt;
 use crate::conn::ConnectionCommon;
 use crate::error::Error;
 use crate::key_schedule::hkdf_expand;
-use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
 use crate::msgs::message::OpaqueMessage;
 pub use crate::server::ServerQuicExt;
@@ -190,7 +189,7 @@ pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(
         .take_message(OpaqueMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
-            payload: Payload::new(plaintext.to_vec()),
+            payload: plaintext.to_vec(),
         })
         .is_none()
     {

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,6 +1,6 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
-use crate::msgs::message::{BorrowedOpaqueMessage, OpaqueMessage};
+use crate::msgs::message::{OpaqueMessage, PlainMessage};
 
 static SEQ_SOFT_LIMIT: u64 = 0xffff_ffff_ffff_0000u64;
 static SEQ_HARD_LIMIT: u64 = 0xffff_ffff_ffff_fffeu64;
@@ -119,7 +119,10 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<OpaqueMessage, Error> {
+    pub fn decrypt_incoming(
+        &mut self,
+        encr: OpaqueMessage,
+    ) -> Result<PlainMessage<'static>, Error> {
         debug_assert!(self.decrypt_state == DirectionState::Active);
         let seq = self.read_seq;
         self.read_seq += 1;
@@ -131,7 +134,7 @@ impl RecordLayer {
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub fn encrypt_outgoing(&mut self, plain: BorrowedOpaqueMessage) -> OpaqueMessage {
+    pub fn encrypt_outgoing(&mut self, plain: PlainMessage<'_>) -> OpaqueMessage {
         debug_assert!(self.encrypt_state == DirectionState::Active);
         assert!(!self.encrypt_exhausted());
         let seq = self.write_seq;

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -119,10 +119,10 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub fn decrypt_incoming(
+    pub fn decrypt_incoming<'a>(
         &mut self,
-        encr: OpaqueMessage,
-    ) -> Result<PlainMessage<'static>, Error> {
+        encr: &'a mut OpaqueMessage<'a>,
+    ) -> Result<PlainMessage<'a>, Error> {
         debug_assert!(self.decrypt_state == DirectionState::Active);
         let seq = self.read_seq;
         self.read_seq += 1;
@@ -134,7 +134,7 @@ impl RecordLayer {
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub fn encrypt_outgoing(&mut self, plain: PlainMessage<'_>) -> OpaqueMessage {
+    pub fn encrypt_outgoing(&mut self, plain: PlainMessage<'_>) -> OpaqueMessage<'static> {
         debug_assert!(self.encrypt_state == DirectionState::Active);
         assert!(!self.encrypt_exhausted());
         let seq = self.write_seq;

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -102,7 +102,7 @@ impl ServerConfigBuilderWithClientAuth {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
     ) -> Result<ServerConfig, Error> {
         let resolver = handy::AlwaysResolvesChain::new(cert_chain, &key_der)?;
@@ -122,7 +122,7 @@ impl ServerConfigBuilderWithClientAuth {
     /// This function fails if `key_der` is invalid.
     pub fn with_single_cert_with_ocsp_and_sct(
         self,
-        cert_chain: Vec<key::Certificate>,
+        cert_chain: Vec<key::Certificate<'static>>,
         key_der: key::PrivateKey,
         ocsp: Vec<u8>,
         scts: Vec<u8>,

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -88,7 +88,7 @@ impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private
     /// key type and encoding.
     pub fn new(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesChain, Error> {
         let key = sign::any_supported_type(priv_key)
@@ -103,7 +103,7 @@ impl AlwaysResolvesChain {
     ///
     /// If non-empty, the given OCSP response and SCTs are attached.
     pub fn new_with_extras(
-        chain: Vec<key::Certificate>,
+        chain: Vec<key::Certificate<'static>>,
         priv_key: &key::PrivateKey,
         ocsp: Vec<u8>,
         scts: Vec<u8>,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -172,7 +172,11 @@ impl ExtensionProcessing {
                         && hello.early_data_extension_offered()
                         && resume.version == cx.common.negotiated_version.unwrap()
                         && resume.cipher_suite == suite.suite
-                        && resume.alpn.as_ref().map(|x| &x.0) == cx.common.alpn_protocol.as_ref()
+                        && resume
+                            .alpn
+                            .as_ref()
+                            .map(|x| x.0.as_ref())
+                            == cx.common.alpn_protocol.as_deref()
                         && !cx.data.reject_early_data
                     {
                         self.exts

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -191,7 +191,7 @@ impl ExtensionProcessing {
                 // and put it in the legacy extension.
                 if let Some(sct_list) = sct_list.take() {
                     self.exts
-                        .push(ServerExtension::make_sct(sct_list).to_owned());
+                        .push(ServerExtension::make_sct(sct_list));
                 }
             }
         } else {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "quic")]
 use crate::conn::Protocol;
-use crate::conn::{ConnectionCommon, ConnectionRandoms, Context, State};
+use crate::conn::{CommonApi, ConnectionRandoms, Context, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 #[cfg(feature = "logging")]
@@ -28,17 +28,17 @@ pub(super) type NextState = Box<dyn State<ServerConnectionData>>;
 pub(super) type NextStateOrError = Result<NextState, Error>;
 pub(super) type ServerContext<'a> = Context<'a, ServerConnectionData>;
 
-pub fn incompatible(common: &mut ConnectionCommon, why: &str) -> Error {
+pub(super) fn incompatible(common: &mut CommonApi, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::HandshakeFailure);
     Error::PeerIncompatibleError(why.to_string())
 }
 
-fn bad_version(common: &mut ConnectionCommon, why: &str) -> Error {
+fn bad_version(common: &mut CommonApi, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::ProtocolVersion);
     Error::PeerIncompatibleError(why.to_string())
 }
 
-pub fn decode_error(common: &mut ConnectionCommon, why: &str) -> Error {
+pub(super) fn decode_error(common: &mut CommonApi, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::DecodeError);
     Error::PeerMisbehavedError(why.to_string())
 }

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -497,8 +497,8 @@ pub trait ServerQuicExt {
         }
 
         let ext = match quic_version {
-            quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params),
-            quic::Version::V1 => ServerExtension::TransportParameters(params),
+            quic::Version::V1Draft => ServerExtension::TransportParametersDraft(params.into()),
+            quic::Version::V1 => ServerExtension::TransportParameters(params.into()),
         };
         let mut new = ServerConnection::from_config(config, vec![ext])?;
         new.common.protocol = Protocol::Quic;

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -377,10 +377,8 @@ impl Connection for ServerConnection {
         label: &[u8],
         context: Option<&[u8]>,
     ) -> Result<(), Error> {
-        self.state
-            .as_ref()
-            .ok_or(Error::HandshakeNotComplete)
-            .and_then(|st| st.export_keying_material(output, label, context))
+        self.common
+            .export_keying_material(output, label, context, &self.state)
     }
 
     fn negotiated_cipher_suite(&self) -> Option<&'static SupportedCipherSuite> {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -359,7 +359,7 @@ impl Connection for ServerConnection {
         self.common.send_close_notify()
     }
 
-    fn peer_certificates(&self) -> Option<&[key::Certificate]> {
+    fn peer_certificates(&self) -> Option<&[key::Certificate<'static>]> {
         self.data.client_cert_chain.as_deref()
     }
 
@@ -426,7 +426,7 @@ struct ServerConnectionData {
     sni: Option<webpki::DnsName>,
     received_resumption_data: Option<Vec<u8>>,
     resumption_data: Vec<u8>,
-    client_cert_chain: Option<Vec<key::Certificate>>,
+    client_cert_chain: Option<Vec<key::Certificate<'static>>>,
     /// Whether to reject early data even if it would otherwise be accepted
     reject_early_data: bool,
 }

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -455,13 +455,13 @@ impl quic::QuicExt for ServerConnection {
     }
 
     fn read_hs(&mut self, plaintext: &[u8]) -> Result<(), Error> {
-        quic::read_hs(&mut self.common, plaintext)?;
+        self.common.read_hs(plaintext)?;
         self.common
             .process_new_handshake_messages(&mut self.state, &mut self.data)
     }
 
     fn write_hs(&mut self, buf: &mut Vec<u8>) -> Option<quic::Keys> {
-        quic::write_hs(&mut self.common, buf)
+        self.common.write_hs(buf)
     }
 
     fn alert(&self) -> Option<AlertDescription> {
@@ -469,7 +469,7 @@ impl quic::QuicExt for ServerConnection {
     }
 
     fn next_1rtt_keys(&mut self) -> Option<quic::PacketKeySet> {
-        quic::next_1rtt_keys(&mut self.common)
+        self.common.next_1rtt_keys()
     }
 }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -226,7 +226,7 @@ impl ServerConfig {
 /// Read data from the peer using the `io::Read` trait implementation.
 pub struct ServerConnection {
     common: ConnectionCommon,
-    state: Option<Box<dyn hs::State>>,
+    state: Option<hs::NextState>,
     data: ServerConnectionData,
 }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -239,7 +239,7 @@ impl ServerConnection {
 
     fn from_config(
         config: Arc<ServerConfig>,
-        extra_exts: Vec<ServerExtension>,
+        extra_exts: Vec<ServerExtension<'static>>,
     ) -> Result<Self, Error> {
         Ok(ServerConnection {
             common: ConnectionCommon::new(config.max_fragment_size, false)?,

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -307,15 +307,6 @@ impl ServerConnection {
         );
         self.data.reject_early_data = true;
     }
-
-    fn send_some_plaintext(&mut self, buf: &[u8]) -> usize {
-        let mut st = self.state.take();
-        if let Some(st) = st.as_mut() {
-            st.perhaps_write_key_update(&mut self.common);
-        }
-        self.state = st;
-        self.common.send_some_plaintext(buf)
-    }
 }
 
 impl Connection for ServerConnection {
@@ -396,13 +387,17 @@ impl Connection for ServerConnection {
 
 impl PlaintextSink for ServerConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Ok(self.send_some_plaintext(buf))
+        Ok(self
+            .common
+            .send_some_plaintext(buf, &mut self.state))
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let mut sz = 0;
         for buf in bufs {
-            sz += self.send_some_plaintext(buf);
+            sz += self
+                .common
+                .send_some_plaintext(buf, &mut self.state);
         }
         Ok(sz)
     }

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -51,7 +51,7 @@ mod client_hello {
         pub(in crate::server) using_ems: bool,
         pub(in crate::server) randoms: ConnectionRandoms,
         pub(in crate::server) send_ticket: bool,
-        pub(in crate::server) extra_exts: Vec<ServerExtension>,
+        pub(in crate::server) extra_exts: Vec<ServerExtension<'static>>,
     }
 
     impl CompleteClientHelloHandling {
@@ -326,7 +326,7 @@ mod client_hello {
         hello: &ClientHelloPayload,
         resumedata: Option<&persist::ServerSessionValue>,
         randoms: &ConnectionRandoms,
-        extra_exts: Vec<ServerExtension>,
+        extra_exts: Vec<ServerExtension<'static>>,
     ) -> Result<bool, Error> {
         let mut ep = hs::ExtensionProcessing::new();
         ep.process_common(
@@ -510,7 +510,11 @@ struct ExpectCertificate {
 }
 
 impl hs::State for ExpectCertificate {
-    fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(
+        mut self: Box<Self>,
+        cx: &mut ServerContext<'_>,
+        m: Message<'_>,
+    ) -> hs::NextStateOrError {
         self.transcript.add_message(&m);
         let cert_chain = require_handshake_msg_move!(
             m,
@@ -891,7 +895,7 @@ struct ExpectTraffic {
 impl ExpectTraffic {}
 
 impl hs::State for ExpectTraffic {
-    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
+    fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx
                 .common

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets, State};
+use crate::conn::{CommonApi, ConnectionRandoms, ConnectionSecrets, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -364,7 +364,7 @@ mod client_hello {
 
     fn emit_certificate(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         cert_chain: &[Certificate],
     ) {
         let c = Message {
@@ -384,11 +384,7 @@ mod client_hello {
         common.send_msg(c, false);
     }
 
-    fn emit_cert_status(
-        transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
-        ocsp: &[u8],
-    ) {
+    fn emit_cert_status(transcript: &mut HandshakeHash, common: &mut CommonApi, ocsp: &[u8]) {
         let st = CertificateStatus::new(ocsp.to_owned());
 
         let c = Message {
@@ -405,7 +401,7 @@ mod client_hello {
 
     fn emit_server_kx(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         sigschemes: Vec<SignatureScheme>,
         skxg: &'static kx::SupportedKxGroup,
         signing_key: &dyn sign::SigningKey,
@@ -488,7 +484,7 @@ mod client_hello {
         Ok(true)
     }
 
-    fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut ConnectionCommon) {
+    fn emit_server_hello_done(transcript: &mut HandshakeHash, common: &mut CommonApi) {
         let m = Message {
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
@@ -790,7 +786,7 @@ fn emit_ticket(
     cx.common.send_msg(m, false);
 }
 
-fn emit_ccs(common: &mut ConnectionCommon) {
+fn emit_ccs(common: &mut CommonApi) {
     let m = Message {
         version: ProtocolVersion::TLSv1_2,
         payload: MessagePayload::ChangeCipherSpec(ChangeCipherSpecPayload {}),
@@ -802,7 +798,7 @@ fn emit_ccs(common: &mut ConnectionCommon) {
 fn emit_finished(
     secrets: &ConnectionSecrets,
     transcript: &mut HandshakeHash,
-    common: &mut ConnectionCommon,
+    common: &mut CommonApi,
 ) {
     let vh = transcript.get_current_hash();
     let verify_data = secrets.server_verify_data(&vh);

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -1,5 +1,5 @@
 use crate::check::{check_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets};
+use crate::conn::{ConnectionCommon, ConnectionRandoms, ConnectionSecrets, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -19,7 +19,7 @@ use crate::{kx, tls12};
 
 use super::common::ActiveCertifiedKey;
 use super::hs::{self, ServerContext};
-use super::{ProducesTickets, ServerConfig};
+use super::{ProducesTickets, ServerConfig, ServerConnectionData};
 
 use ring::constant_time;
 
@@ -514,7 +514,7 @@ struct ExpectCertificate {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCertificate {
+impl State<ServerConnectionData> for ExpectCertificate {
     fn handle(
         mut self: Box<Self>,
         cx: &mut ServerContext<'_>,
@@ -593,7 +593,7 @@ struct ExpectClientKx {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectClientKx {
+impl State<ServerConnectionData> for ExpectClientKx {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let client_kx = require_handshake_msg!(
             m,
@@ -662,7 +662,7 @@ struct ExpectCertificateVerify {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCertificateVerify {
+impl State<ServerConnectionData> for ExpectCertificateVerify {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let rc = {
             let sig = require_handshake_msg!(
@@ -711,7 +711,7 @@ struct ExpectCcs {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectCcs {
+impl State<ServerConnectionData> for ExpectCcs {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         check_message(&m, &[ContentType::ChangeCipherSpec], &[])?;
 
@@ -830,7 +830,7 @@ struct ExpectFinished {
     send_ticket: bool,
 }
 
-impl hs::State for ExpectFinished {
+impl State<ServerConnectionData> for ExpectFinished {
     fn handle(mut self: Box<Self>, cx: &mut ServerContext<'_>, m: Message) -> hs::NextStateOrError {
         let finished =
             require_handshake_msg!(m, HandshakeType::Finished, HandshakePayload::Finished)?;
@@ -899,7 +899,7 @@ struct ExpectTraffic {
 
 impl ExpectTraffic {}
 
-impl hs::State for ExpectTraffic {
+impl State<ServerConnectionData> for ExpectTraffic {
     fn handle(self: Box<Self>, cx: &mut ServerContext<'_>, m: Message<'_>) -> hs::NextStateOrError {
         match m.payload {
             MessagePayload::ApplicationData(payload) => cx

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -371,7 +371,12 @@ mod client_hello {
             version: ProtocolVersion::TLSv1_2,
             payload: MessagePayload::Handshake(HandshakeMessagePayload {
                 typ: HandshakeType::Certificate,
-                payload: HandshakePayload::Certificate(cert_chain.to_owned()),
+                payload: HandshakePayload::Certificate(
+                    cert_chain
+                        .iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
             }),
         };
 
@@ -569,7 +574,7 @@ impl hs::State for ExpectCertificate {
             suite: self.suite,
             using_ems: self.using_ems,
             server_kx: self.server_kx,
-            client_cert,
+            client_cert: client_cert.map(|x| x.iter().map(|y| y.to_owned()).collect()),
             send_ticket: self.send_ticket,
         }))
     }
@@ -584,7 +589,7 @@ struct ExpectClientKx {
     suite: Tls12CipherSuite,
     using_ems: bool,
     server_kx: kx::KeyExchange,
-    client_cert: Option<Vec<Certificate>>,
+    client_cert: Option<Vec<Certificate<'static>>>,
     send_ticket: bool,
 }
 
@@ -653,7 +658,7 @@ struct ExpectCertificateVerify {
     transcript: HandshakeHash,
     session_id: SessionID,
     using_ems: bool,
-    client_cert: Vec<Certificate>,
+    client_cert: Vec<Certificate<'static>>,
     send_ticket: bool,
 }
 

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -275,7 +275,10 @@ mod client_hello {
 
             if let Some(ref resume) = resumedata {
                 cx.data.received_resumption_data = Some(resume.application_data.0.to_vec());
-                cx.data.client_cert_chain = resume.client_cert_chain.clone();
+                cx.data.client_cert_chain = resume
+                    .client_cert_chain
+                    .as_ref()
+                    .map(|x| x.iter().map(|y| y.to_owned()).collect());
             }
 
             let full_handshake = resumedata.is_none();
@@ -835,7 +838,7 @@ struct ExpectCertificateVerify {
     suite: &'static SupportedCipherSuite,
     randoms: ConnectionRandoms,
     key_schedule: KeyScheduleTrafficWithClientFinishedPending,
-    client_cert: Vec<Certificate>,
+    client_cert: Vec<Certificate<'static>>,
     send_ticket: bool,
     hash_at_server_fin: Digest,
 }

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "quic")]
 use crate::check::check_message;
 use crate::check::{inappropriate_handshake_message, inappropriate_message};
-use crate::conn::{ConnectionCommon, ConnectionRandoms, State};
+use crate::conn::{CommonApi, ConnectionRandoms, State};
 use crate::error::Error;
 use crate::hash_hs::HandshakeHash;
 use crate::key::Certificate;
@@ -475,7 +475,7 @@ mod client_hello {
         Ok(key_schedule)
     }
 
-    fn emit_fake_ccs(common: &mut ConnectionCommon) {
+    fn emit_fake_ccs(common: &mut CommonApi) {
         if common.is_quic() {
             return;
         }
@@ -489,7 +489,7 @@ mod client_hello {
     fn emit_hello_retry_request(
         transcript: &mut HandshakeHash,
         suite: &'static SupportedCipherSuite,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         group: NamedGroup,
     ) {
         let mut req = HelloRetryRequest {
@@ -608,7 +608,7 @@ mod client_hello {
 
     fn emit_certificate_tls13(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         cert_chain: &[Certificate],
         ocsp_response: Option<&[u8]>,
         sct_list: Option<&[u8]>,
@@ -657,7 +657,7 @@ mod client_hello {
 
     fn emit_certificate_verify_tls13(
         transcript: &mut HandshakeHash,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         signing_key: &dyn sign::SigningKey,
         schemes: &[SignatureScheme],
     ) -> Result<(), Error> {
@@ -1059,7 +1059,7 @@ struct ExpectTraffic {
 impl ExpectTraffic {
     fn handle_key_update(
         &mut self,
-        common: &mut ConnectionCommon,
+        common: &mut CommonApi,
         kur: &KeyUpdateRequest,
     ) -> Result<(), Error> {
         #[cfg(feature = "quic")]
@@ -1135,7 +1135,7 @@ impl State<ServerConnectionData> for ExpectTraffic {
             .export_keying_material(output, label, context)
     }
 
-    fn perhaps_write_key_update(&mut self, common: &mut ConnectionCommon) {
+    fn perhaps_write_key_update(&mut self, common: &mut CommonApi) {
         if self.want_write_key_update {
             self.want_write_key_update = false;
             common.send_msg_encrypt(Message::build_key_update_notify().into());

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -30,10 +30,9 @@ pub trait Signer: Send + Sync {
 
 /// A packaged-together certificate chain, matching `SigningKey` and
 /// optional stapled OCSP response and/or SCT list.
-#[derive(Clone)]
 pub struct CertifiedKey {
     /// The certificate chain.
-    pub cert: Vec<key::Certificate>,
+    pub cert: Vec<key::Certificate<'static>>,
 
     /// The certified key.
     pub key: Arc<dyn SigningKey>,
@@ -53,7 +52,7 @@ impl CertifiedKey {
     ///
     /// The cert chain must not be empty. The first certificate in the chain
     /// must be the end-entity certificate.
-    pub fn new(cert: Vec<key::Certificate>, key: Arc<dyn SigningKey>) -> CertifiedKey {
+    pub fn new(cert: Vec<key::Certificate<'static>>, key: Arc<dyn SigningKey>) -> CertifiedKey {
         CertifiedKey {
             cert,
             key,
@@ -115,6 +114,21 @@ impl CertifiedKey {
         }
 
         Ok(())
+    }
+}
+
+impl Clone for CertifiedKey {
+    fn clone(&self) -> Self {
+        CertifiedKey {
+            cert: self
+                .cert
+                .iter()
+                .map(|x| x.to_owned())
+                .collect(),
+            key: Arc::clone(&self.key),
+            ocsp: self.ocsp.clone(),
+            sct_list: self.sct_list.clone(),
+        }
     }
 }
 

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -4,9 +4,9 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, ContentType};
 use crate::Error;
 
-pub fn decode_ecdh_params<T: Codec>(
+pub fn decode_ecdh_params<'a, T: Codec<'a>>(
     conn: &mut ConnectionCommon,
-    kx_params: &[u8],
+    kx_params: &'a [u8],
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {
         conn.send_fatal_alert(AlertDescription::DecodeError);
@@ -14,7 +14,7 @@ pub fn decode_ecdh_params<T: Codec>(
     })
 }
 
-fn decode_ecdh_params_<T: Codec>(kx_params: &[u8]) -> Option<T> {
+fn decode_ecdh_params_<'a, T: Codec<'a>>(kx_params: &'a [u8]) -> Option<T> {
     let mut rd = Reader::init(kx_params);
     let ecdh_params = T::read(&mut rd)?;
     match rd.any_left() {

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -1,11 +1,11 @@
-use crate::conn::ConnectionCommon;
+use crate::conn::CommonApi;
 use crate::kx;
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, ContentType};
 use crate::Error;
 
-pub fn decode_ecdh_params<'a, T: Codec<'a>>(
-    conn: &mut ConnectionCommon,
+pub(crate) fn decode_ecdh_params<'a, T: Codec<'a>>(
+    conn: &mut CommonApi,
     kx_params: &'a [u8],
 ) -> Result<T, Error> {
     decode_ecdh_params_::<T>(kx_params).ok_or_else(|| {

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -182,7 +182,7 @@ struct Context {
     name: &'static str,
     domain: &'static str,
     roots: anchors::RootCertStore,
-    chain: Vec<key::Certificate>,
+    chain: Vec<key::Certificate<'static>>,
     now: SystemTime,
 }
 
@@ -197,7 +197,7 @@ impl Context {
             chain: certs
                 .iter()
                 .copied()
-                .map(|bytes| key::Certificate(bytes.to_vec()))
+                .map(|bytes| key::Certificate(bytes.to_vec().into()))
                 .collect(),
             now: SystemTime::UNIX_EPOCH + Duration::from_secs(1617300000),
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3444,7 +3444,7 @@ fn test_client_does_not_offer_sha1() {
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
             let (msg, _) = OpaqueMessage::read(&mut buf[..sz]).unwrap();
-            let plain = msg.into_plain_message();
+            let plain = msg.to_plain_message();
             let msg = Message::try_from(&plain).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3426,7 +3426,7 @@ mod test_quic {
 #[test]
 fn test_client_does_not_offer_sha1() {
     use rustls::internal::msgs::{
-        codec::Reader, enums::HandshakeType, handshake::HandshakePayload, message::MessagePayload,
+        enums::HandshakeType, handshake::HandshakePayload, message::MessagePayload,
         message::OpaqueMessage,
     };
 
@@ -3439,7 +3439,7 @@ fn test_client_does_not_offer_sha1() {
             let sz = client
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
-            let msg = OpaqueMessage::read(&mut Reader::init(&buf[..sz])).unwrap();
+            let (msg, _) = OpaqueMessage::read(&mut buf[..sz]).unwrap();
             let msg = Message::try_from(&msg).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2126,7 +2126,7 @@ fn sni_resolver_rejects_bad_certs() {
         )
     );
 
-    let bad_chain = vec![rustls::Certificate(vec![0xa0])];
+    let bad_chain = vec![rustls::Certificate(vec![0xa0].into())];
     assert_eq!(
         Err(Error::General(
             "End-entity certificate in certificate chain is syntactically invalid".into()

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3289,7 +3289,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
-        use rustls::internal::msgs::message::OpaqueMessage;
+        use rustls::internal::msgs::message::PlainMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3324,7 +3324,9 @@ mod test_quic {
             }),
         };
 
-        let buf = OpaqueMessage::from(client_hello).encode();
+        let buf = PlainMessage::from(client_hello)
+            .into_unencrypted_opaque()
+            .encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3353,7 +3355,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
-        use rustls::internal::msgs::message::OpaqueMessage;
+        use rustls::internal::msgs::message::PlainMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3391,7 +3393,9 @@ mod test_quic {
             }),
         };
 
-        let buf = OpaqueMessage::from(client_hello).encode();
+        let buf = PlainMessage::from(client_hello)
+            .into_unencrypted_opaque()
+            .encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3440,7 +3444,8 @@ fn test_client_does_not_offer_sha1() {
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
             let (msg, _) = OpaqueMessage::read(&mut buf[..sz]).unwrap();
-            let msg = Message::try_from(&msg).unwrap();
+            let plain = msg.into_plain_message();
+            let msg = Message::try_from(&plain).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 
             let client_hello = match msg.payload {

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -806,7 +806,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -830,7 +836,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: Some(vec![]),
             };
@@ -927,7 +939,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_unreachable,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -961,7 +979,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_err,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: Some(true),
                 offered_schemes: None,
             };
@@ -989,7 +1013,13 @@ mod test_clientverifier {
         for kt in ALL_KEY_TYPES.iter() {
             let client_verifier = MockClientVerifier {
                 verified: ver_ok,
-                subjects: Some(get_client_root_store(*kt).subjects()),
+                subjects: Some(
+                    get_client_root_store(*kt)
+                        .subjects()
+                        .into_iter()
+                        .map(|x| x.to_owned())
+                        .collect(),
+                ),
                 mandatory: None,
                 offered_schemes: None,
             };
@@ -3410,7 +3440,7 @@ fn test_client_does_not_offer_sha1() {
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
             let msg = OpaqueMessage::read(&mut Reader::init(&buf[..sz])).unwrap();
-            let msg = Message::try_from(msg).unwrap();
+            let msg = Message::try_from(&msg).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 
             let client_hello = match msg.payload {
@@ -3678,7 +3708,7 @@ fn test_server_rejects_duplicate_sni_names() {
             if let HandshakePayload::ClientHello(ch) = &mut hs.payload {
                 for mut ext in ch.extensions.iter_mut() {
                     if let ClientExtension::ServerName(snr) = &mut ext {
-                        snr.push(snr[0].clone());
+                        snr.push(snr[0].to_owned());
                     }
                 }
             }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -155,7 +155,7 @@ where
         while offset < bytes.len() {
             let (message, used) = OpaqueMessage::read(&mut bytes[offset..]).unwrap();
             offset += used;
-            let plain = message.into_plain_message();
+            let plain = message.to_plain_message();
             let mut message = Message::try_from(&plain).unwrap();
             filter(&mut message);
             let message_enc = PlainMessage::from(message)

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -186,11 +186,11 @@ impl KeyType {
         }
     }
 
-    pub fn get_chain(&self) -> Vec<Certificate> {
+    pub fn get_chain(&self) -> Vec<Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(self.bytes_for("end.fullchain")))
             .unwrap()
             .iter()
-            .map(|v| Certificate(v.clone()))
+            .map(|v| Certificate(v.clone().into()))
             .collect()
     }
 
@@ -202,11 +202,11 @@ impl KeyType {
         )
     }
 
-    pub fn get_client_chain(&self) -> Vec<Certificate> {
+    pub fn get_client_chain(&self) -> Vec<Certificate<'static>> {
         rustls_pemfile::certs(&mut io::BufReader::new(self.bytes_for("client.fullchain")))
             .unwrap()
             .iter()
-            .map(|v| Certificate(v.clone()))
+            .map(|v| Certificate(v.clone().into()))
             .collect()
     }
 

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use rustls;
 use rustls_pemfile;
 
-use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage};
 use rustls::ConfigBuilder;
 use rustls::Connection;
@@ -151,9 +150,11 @@ where
             return total;
         }
 
-        let mut reader = Reader::init(&buf[..sz]);
-        while reader.any_left() {
-            let message = OpaqueMessage::read(&mut reader).unwrap();
+        let bytes = &mut buf[..sz];
+        let mut offset = 0;
+        while offset < bytes.len() {
+            let (message, used) = OpaqueMessage::read(&mut bytes[offset..]).unwrap();
+            offset += used;
             let mut message = Message::try_from(&message).unwrap();
             filter(&mut message);
             let message_enc = OpaqueMessage::from(message).encode();


### PR DESCRIPTION
Combines #685 and #691 and builds on top of that to continue borrowing more. Notably this gets rid of all the `to_owned()` methods in handshake payloads added in #685 after these are made unnecessary due to borrowing from the joiner. It also splits the semantic notion of a `PlainMessage` (after decryption) from the `OpaqueMessage`, as previously discussed. It also prepares to flatten the handshake joiner into the deframer as discussed in #668, and I'll continue work towards that.