### PR TITLE
Fix a typo in comment

### DIFF
--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -1024,7 +1024,7 @@ impl hs::State for ExpectFinished {
 }
 
 // -- Traffic transit state (TLS1.3) --
-// In this state we can be sent tickets, keyupdates,
+// In this state we can be sent tickets, key updates,
 // and application data.
 struct ExpectTraffic {
     config: Arc<ClientConfig>,


### PR DESCRIPTION
Fix a typo in comment: keyupdates -> key updates