### PR TITLE
Represent server names with a dedicated type

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
     type.
   - *Breaking API change*: `peer_certificates` returns a borrow rather than a copy on the
     internally stored certificate chain.
+  - *Breaking API change*: `ClientConnection`'s DNS name parameter is now a new enum, `ServerName`, to allow future support for ECH and servers named by IP address.
 * 0.19.1 (2021-04-17):
   - Backport: fix security issue: there was a reachable panic in servers if a client
     sent an invalid `ClientECDiffieHellmanPublic` encoding, due to an errant `unwrap()`

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -6,6 +6,7 @@ extern crate webpki;
 use rustls::{ConfigBuilder, ClientConnection, Connection, RootCertStore};
 use std::io;
 use std::sync::Arc;
+use std::convert::TryInto;
 
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
@@ -14,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
         .unwrap()
         .with_root_certificates(root_store, &[])
         .with_no_client_auth());
-    let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
+    let example_com = "example.com".try_into().unwrap();
     let mut client = ClientConnection::new(config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -3,6 +3,7 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
+use std::convert::TryInto;
 use std::env;
 use std::fs;
 use std::io::{self, Read, Write};
@@ -22,7 +23,6 @@ use rustls::{ClientConfig, ClientConnection};
 use rustls::{ServerConfig, ServerConnection};
 
 use rustls_pemfile;
-use webpki;
 
 fn duration_nanos(d: Duration) -> f64 {
     (d.as_secs() as f64) + f64::from(d.subsec_nanos()) / 1e9
@@ -370,8 +370,8 @@ fn bench_handshake(params: &BenchmarkParam, clientauth: ClientAuth, resume: Resu
     let mut server_time = 0f64;
 
     for _ in 0..rounds {
-        let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        let mut client = ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap();
+        let server_name = "localhost".try_into().unwrap();
+        let mut client = ClientConnection::new(Arc::clone(&client_config), server_name).unwrap();
         let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
 
         server_time += time(|| {
@@ -445,8 +445,8 @@ fn bench_bulk(params: &BenchmarkParam, plaintext_size: u64, max_fragment_size: O
         max_fragment_size,
     ));
 
-    let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-    let mut client = ClientConnection::new(client_config, dns_name).unwrap();
+    let server_name = "localhost".try_into().unwrap();
+    let mut client = ClientConnection::new(client_config, server_name).unwrap();
     client.set_buffer_limit(0);
     let mut server = ServerConnection::new(Arc::clone(&server_config)).unwrap();
     server.set_buffer_limit(0);
@@ -519,8 +519,8 @@ fn bench_memory(params: &BenchmarkParam, conn_count: u64) {
 
     for _i in 0..conn_count {
         servers.push(ServerConnection::new(Arc::clone(&server_config)).unwrap());
-        let dns_name = webpki::DnsNameRef::try_from_ascii_str("localhost").unwrap();
-        clients.push(ClientConnection::new(Arc::clone(&client_config), dns_name).unwrap());
+        let server_name = "localhost".try_into().unwrap();
+        clients.push(ClientConnection::new(Arc::clone(&client_config), server_name).unwrap());
     }
 
     for _step in 0..5 {

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -4,10 +4,10 @@
 // See: https://github.com/HowNetWorks/trytls-rustls-stub
 //
 
-use webpki;
 use webpki_roots;
 
 use rustls::{ClientConfig, ClientConnection, ConfigBuilder, Connection, Error, RootCertStore};
+use std::convert::TryInto;
 use std::env;
 use std::error::Error as StdError;
 use std::fs::File;
@@ -51,9 +51,9 @@ fn communicate(
     port: u16,
     config: ClientConfig,
 ) -> Result<Verdict, Box<dyn StdError>> {
-    let dns_name = webpki::DnsNameRef::try_from_ascii_str(&host).unwrap();
+    let server_name = host.as_str().try_into().unwrap();
     let rc_config = Arc::new(config);
-    let mut client = ClientConnection::new(rc_config, dns_name).unwrap();
+    let mut client = ClientConnection::new(rc_config, server_name).unwrap();
     let mut stream = TcpStream::connect((&*host, port))?;
 
     client

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -3,11 +3,11 @@
 /// observe using `nm` that the binary of this program does not contain any AES code.
 use std::sync::Arc;
 
+use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 
 use rustls;
-use webpki;
 use webpki_roots;
 
 use rustls::Connection;
@@ -25,8 +25,8 @@ fn main() {
     .with_root_certificates(root_store, &[])
     .with_no_client_auth();
 
-    let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
+    let server_name = "google.com".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -1,17 +1,19 @@
 use std::sync::Arc;
 
+use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 
 use env_logger;
 use rustls;
 use rustls::RootCertStore;
-use webpki;
 use webpki_roots;
 
 fn start_connection(config: &Arc<rustls::ClientConfig>, domain_name: &str) {
-    let dns_name = webpki::DnsNameRef::try_from_ascii_str(domain_name).unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::clone(&config), dns_name).unwrap();
+    let server_name = domain_name
+        .try_into()
+        .expect("invalid DNS name");
+    let mut conn = rustls::ClientConnection::new(Arc::clone(&config), server_name).unwrap();
     let mut sock = TcpStream::connect(format!("{}:443", domain_name)).unwrap();
     sock.set_nodelay(true).unwrap();
     let request = format!(

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -9,11 +9,11 @@
 /// that is sensible outside of example code.
 use std::sync::Arc;
 
+use std::convert::TryInto;
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
 
 use rustls;
-use webpki;
 use webpki_roots;
 
 use rustls::{Connection, RootCertStore};
@@ -27,8 +27,8 @@ fn main() {
         .with_root_certificates(root_store, &[])
         .with_no_client_auth();
 
-    let dns_name = webpki::DnsNameRef::try_from_ascii_str("google.com").unwrap();
-    let mut conn = rustls::ClientConnection::new(Arc::new(config), dns_name).unwrap();
+    let server_name = "google.com".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("google.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
     tls.write(

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -179,6 +179,22 @@ impl ClientConfig {
 /// will be extended in the future to knowing the IP address of the
 /// server, as well as supporting privacy-preserving names for the
 /// server ("ECH").  For this reason this enum is `non_exhaustive`.
+///
+/// # Making one
+///
+/// If you have a DNS name as a `&str`, this type implements `TryFrom<&str>`,
+/// so you can do:
+///
+/// ```
+/// # use std::convert::{TryInto, TryFrom};
+/// # use rustls::ServerName;
+/// ServerName::try_from("example.com").expect("invalid DNS name");
+///
+/// // or, alternatively...
+///
+/// let x = "example.com".try_into().expect("invalid DNS name");
+/// # let _: ServerName = x;
+/// ```
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Clone)]
 pub enum ServerName {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -123,6 +123,7 @@
 //! # use rustls;
 //! # use webpki;
 //! # use std::sync::Arc;
+//! # use std::convert::TryInto;
 //! # let mut root_store = rustls::RootCertStore::empty();
 //! # root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
 //! # let trusted_ct_logs = &[];
@@ -132,7 +133,7 @@
 //! #     .with_root_certificates(root_store, trusted_ct_logs)
 //! #     .with_no_client_auth();
 //! let rc_config = Arc::new(config);
-//! let example_com = webpki::DnsNameRef::try_from_ascii_str("example.com").unwrap();
+//! let example_com = "example.com".try_into().unwrap();
 //! let mut client = rustls::ClientConnection::new(rc_config, example_com);
 //! ```
 //!
@@ -299,6 +300,7 @@ pub use crate::builder::{
 };
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
+pub use crate::client::ServerName;
 pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientConnection, WriteEarlyData};
 pub use crate::conn::{Connection, Reader, Writer};

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -1,3 +1,4 @@
+use crate::client::ServerName;
 use crate::msgs::base::{PayloadU8, PayloadU16};
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{CipherSuite, ProtocolVersion};
@@ -17,13 +18,13 @@ use std::mem;
 #[derive(Debug)]
 pub struct ClientSessionKey {
     kind: &'static [u8],
-    dns_name: PayloadU8,
+    name: Vec<u8>,
 }
 
 impl Codec for ClientSessionKey {
     fn encode(&self, bytes: &mut Vec<u8>) {
         bytes.extend_from_slice(self.kind);
-        self.dns_name.encode(bytes);
+        bytes.extend_from_slice(&self.name);
     }
 
     // Don't need to read these.
@@ -33,19 +34,17 @@ impl Codec for ClientSessionKey {
 }
 
 impl ClientSessionKey {
-    pub fn session_for_dns_name(dns_name: webpki::DnsNameRef) -> ClientSessionKey {
-        let dns_name_str: &str = dns_name.into();
+    pub fn session_for_server_name(server_name: &ServerName) -> ClientSessionKey {
         ClientSessionKey {
             kind: b"session",
-            dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),
+            name: server_name.encode(),
         }
     }
 
-    pub fn hint_for_dns_name(dns_name: webpki::DnsNameRef) -> ClientSessionKey {
-        let dns_name_str: &str = dns_name.into();
+    pub fn hint_for_server_name(server_name: &ServerName) -> ClientSessionKey {
         ClientSessionKey {
             kind: b"kx-hint",
-            dns_name: PayloadU8::new(dns_name_str.as_bytes().to_vec()),
+            name: server_name.encode(),
         }
     }
 }

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -5,12 +5,12 @@ use super::persist::*;
 use crate::key::Certificate;
 use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
 use crate::ticketer::TimeBase;
-use webpki::DnsNameRef;
+use std::convert::TryInto;
 
 #[test]
 fn clientsessionkey_is_debug() {
-    let name = DnsNameRef::try_from_ascii_str("hello").unwrap();
-    let csk = ClientSessionKey::session_for_dns_name(name);
+    let name = "hello".try_into().unwrap();
+    let csk = ClientSessionKey::session_for_server_name(&name);
     println!("{:?}", csk);
 }
 

--- a/rustls/src/verifybench.rs
+++ b/rustls/src/verifybench.rs
@@ -4,13 +4,13 @@
 // Note: we don't use any of the standard 'cargo bench', 'test::Bencher',
 // etc. because it's unstable at the time of writing.
 
+use std::convert::TryInto;
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::anchors;
 use crate::key;
 use crate::verify;
 use crate::verify::ServerCertVerifier;
-use webpki;
 
 use webpki_roots;
 
@@ -212,12 +212,12 @@ impl Context {
         let (end_entity, intermediates) = self.chain.split_first().unwrap();
         for _ in 0..count {
             let start = Instant::now();
-            let dns_name = webpki::DnsNameRef::try_from_ascii_str(self.domain).unwrap();
+            let server_name = self.domain.try_into().unwrap();
             verifier
                 .verify_server_cert(
                     end_entity,
                     intermediates,
-                    dns_name,
+                    &server_name,
                     &mut SCTS.iter().copied(),
                     OCSP_RESPONSE,
                     self.now,


### PR DESCRIPTION
Heavily inspired by the ECH API in #663. The meat here is in client/mod.rs, the rest naturally flows from that.