### PR TITLE
Make Message cloneable

### DIFF
--- a/rustls/src/msgs/alert.rs
+++ b/rustls/src/msgs/alert.rs
@@ -1,7 +1,7 @@
 use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, AlertLevel};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AlertMessagePayload {
     pub level: AlertLevel,
     pub description: AlertDescription,

--- a/rustls/src/msgs/ccs.rs
+++ b/rustls/src/msgs/ccs.rs
@@ -1,6 +1,6 @@
 use crate::msgs::codec::{Codec, Reader};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChangeCipherSpecPayload;
 
 impl Codec for ChangeCipherSpecPayload {

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -841,7 +841,7 @@ impl ServerExtension {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ClientHelloPayload {
     pub client_version: ProtocolVersion,
     pub random: Random,
@@ -1044,7 +1044,7 @@ impl ClientHelloPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HelloRetryExtension {
     KeyShare(NamedGroup),
     Cookie(PayloadU16),
@@ -1097,7 +1097,7 @@ impl Codec for HelloRetryExtension {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HelloRetryRequest {
     pub legacy_version: ProtocolVersion,
     pub session_id: SessionID,
@@ -1190,7 +1190,7 @@ impl HelloRetryRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerHelloPayload {
     pub legacy_version: ProtocolVersion,
     pub random: Random,
@@ -1301,7 +1301,7 @@ impl Codec for CertificatePayload {
 // That's annoying. It means the parsing is not
 // context-free any more.
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CertificateExtension {
     CertificateStatus(CertificateStatus),
     SignedCertificateTimestamp(SCTList),
@@ -1375,7 +1375,7 @@ impl Codec for CertificateExtension {
 
 declare_u16_vec!(CertificateExtensions, CertificateExtension);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateEntry {
     pub cert: key::Certificate,
     pub exts: CertificateExtensions,
@@ -1439,7 +1439,7 @@ impl CertificateEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificatePayloadTLS13 {
     pub context: PayloadU8,
     pub entries: Vec<CertificateEntry>,
@@ -1534,7 +1534,7 @@ pub enum KeyExchangeAlgorithm {
 // We don't support arbitrary curves.  It's a terrible
 // idea and unnecessary attack surface.  Please,
 // get a grip.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ECParameters {
     pub curve_type: ECCurveType,
     pub named_group: NamedGroup,
@@ -1607,7 +1607,7 @@ impl Codec for ClientECDHParams {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ServerECDHParams {
     pub curve_params: ECParameters,
     pub public: PayloadU8,
@@ -1642,7 +1642,7 @@ impl Codec for ServerECDHParams {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ECDHEServerKeyExchange {
     pub params: ServerECDHParams,
     pub dss: DigitallySignedStruct,
@@ -1662,7 +1662,7 @@ impl Codec for ECDHEServerKeyExchange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ServerKeyExchangePayload {
     ECDHE(ECDHEServerKeyExchange),
     Unknown(Payload),
@@ -1784,7 +1784,7 @@ declare_u8_vec!(ClientCertificateTypes, ClientCertificateType);
 pub type DistinguishedName = PayloadU16;
 pub type DistinguishedNames = VecU16OfPayloadU16;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateRequestPayload {
     pub certtypes: ClientCertificateTypes,
     pub sigschemes: SupportedSignatureSchemes,
@@ -1816,7 +1816,7 @@ impl Codec for CertificateRequestPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CertReqExtension {
     SignatureAlgorithms(SupportedSignatureSchemes),
     AuthorityNames(DistinguishedNames),
@@ -1874,7 +1874,7 @@ impl Codec for CertReqExtension {
 
 declare_u16_vec!(CertReqExtensions, CertReqExtension);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateRequestPayloadTLS13 {
     pub context: PayloadU8,
     pub extensions: CertReqExtensions,
@@ -1922,7 +1922,7 @@ impl CertificateRequestPayloadTLS13 {
 }
 
 // -- NewSessionTicket --
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NewSessionTicketPayload {
     pub lifetime_hint: u32,
     pub ticket: PayloadU16,
@@ -1955,7 +1955,7 @@ impl Codec for NewSessionTicketPayload {
 }
 
 // -- NewSessionTicket electric boogaloo --
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum NewSessionTicketExtension {
     EarlyData(u32),
     Unknown(UnknownExtension),
@@ -2000,7 +2000,7 @@ impl Codec for NewSessionTicketExtension {
 
 declare_u16_vec!(NewSessionTicketExtensions, NewSessionTicketExtension);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NewSessionTicketPayloadTLS13 {
     pub lifetime: u32,
     pub age_add: u32,
@@ -2069,7 +2069,7 @@ impl Codec for NewSessionTicketPayloadTLS13 {
 // -- RFC6066 certificate status types
 
 /// Only supports OCSP
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CertificateStatus {
     pub ocsp_response: PayloadU24,
 }
@@ -2104,7 +2104,7 @@ impl CertificateStatus {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HandshakePayload {
     HelloRequest,
     ClientHello(ClientHelloPayload),
@@ -2159,7 +2159,7 @@ impl HandshakePayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HandshakeMessagePayload {
     pub typ: HandshakeType,
     pub payload: HandshakePayload,

--- a/rustls/src/msgs/message.rs
+++ b/rustls/src/msgs/message.rs
@@ -10,7 +10,7 @@ use crate::msgs::handshake::HandshakeMessagePayload;
 
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MessagePayload {
     Alert(AlertMessagePayload),
     Handshake(HandshakeMessagePayload),
@@ -161,7 +161,7 @@ impl From<Message> for OpaqueMessage {
 }
 
 /// A message with decoded payload
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Message {
     pub version: ProtocolVersion,
     pub payload: MessagePayload,


### PR DESCRIPTION
Hello!

first thanks for the possibility to use rustls and the message definitions as a library. I have the need to clone a Message.
Sadly because Rust does not yet implement negative trait bounds it is not possible to do the following:

```rust

impl<T: 'static> SomeTrait for T
where
    T: Clone,
{
    fn ...
}

impl SomeTrait for Message {
    fn ...
}
```

This is because of `where T: Clone`. This causes an issue because rustls can always implement `Clone` and break the above code. Rust does not allow that to happen.

I think there is no problem with implementing Clone for more types.