### PR TITLE
Conceptually split PlainMessage out of OpaqueMessage

### DIFF
--- a/fuzz/fuzzers/deframer.rs
+++ b/fuzz/fuzzers/deframer.rs
@@ -1,5 +1,6 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
 use rustls::internal::msgs::deframer;
@@ -9,13 +10,16 @@ use std::io;
 
 fuzz_target!(|data: &[u8]| {
     let mut dfm = deframer::MessageDeframer::new();
-    if dfm.read(&mut io::Cursor::new(data)).is_err() {
+    if dfm
+        .read(&mut io::Cursor::new(data))
+        .is_err()
+    {
         return;
     }
     dfm.has_pending();
 
     while !dfm.frames.is_empty() {
         let msg = dfm.frames.pop_front().unwrap();
-        Message::try_from(msg).ok();
+        Message::try_from(msg.into_plain_message()).ok();
     }
 });

--- a/fuzz/fuzzers/fragment.rs
+++ b/fuzz/fuzzers/fragment.rs
@@ -1,5 +1,6 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
 use rustls::internal::msgs::codec::Reader;
@@ -15,14 +16,17 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    let msg = match message::Message::try_from(msg) {
+    let msg = match message::Message::try_from(msg.into_plain_message()) {
         Ok(msg) => msg,
         Err(_) => return,
     };
 
     let frg = fragmenter::MessageFragmenter::new(Some(32)).unwrap();
     let mut out = VecDeque::new();
-    frg.fragment(message::OpaqueMessage::from(msg), &mut out);
+    frg.fragment(
+        message::PlainMessage::from(msg),
+        &mut out,
+    );
 
     for msg in out {
         message::Message::try_from(msg).ok();

--- a/fuzz/fuzzers/hsjoiner.rs
+++ b/fuzz/fuzzers/hsjoiner.rs
@@ -10,7 +10,7 @@ use rustls::internal::msgs::message;
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
     let msg = match message::OpaqueMessage::read(&mut rdr) {
-        Ok(msg) => msg,
+        Ok(msg) => msg.into_plain_message(),
         Err(_) => return,
     };
 

--- a/fuzz/fuzzers/message.rs
+++ b/fuzz/fuzzers/message.rs
@@ -1,20 +1,23 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
 use rustls::internal::msgs::codec::Reader;
-use rustls::internal::msgs::message::{Message, OpaqueMessage};
+use rustls::internal::msgs::message::{Message, PlainMessage, OpaqueMessage};
 use std::convert::TryFrom;
 
 fuzz_target!(|data: &[u8]| {
     let mut rdr = Reader::init(data);
     if let Ok(m) = OpaqueMessage::read(&mut rdr) {
-        let msg = match Message::try_from(m) {
+        let msg = match Message::try_from(m.into_plain_message()) {
             Ok(msg) => msg,
             Err(_) => return,
         };
         //println!("msg = {:#?}", m);
-        let enc = OpaqueMessage::from(msg).encode();
+        let enc = PlainMessage::from(msg)
+            .into_unencrypted_opaque()
+            .encode();
         //println!("data = {:?}", &data[..rdr.used()]);
         assert_eq!(enc, data[..rdr.used()]);
     }

--- a/rustls/src/msgs/deframer.rs
+++ b/rustls/src/msgs/deframer.rs
@@ -243,13 +243,13 @@ mod tests {
     fn pop_first(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Handshake);
-        Message::try_from(m).unwrap();
+        Message::try_from(m.into_plain_message()).unwrap();
     }
 
     fn pop_second(d: &mut MessageDeframer) {
         let m = d.frames.pop_front().unwrap();
         assert_eq!(m.typ, msgs::enums::ContentType::Alert);
-        Message::try_from(m).unwrap();
+        Message::try_from(m.into_plain_message()).unwrap();
     }
 
     #[test]

--- a/rustls/src/msgs/hsjoiner.rs
+++ b/rustls/src/msgs/hsjoiner.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use crate::msgs::codec;
 use crate::msgs::enums::{ContentType, ProtocolVersion};
 use crate::msgs::handshake::HandshakeMessagePayload;
-use crate::msgs::message::{Message, MessagePayload, OpaqueMessage};
+use crate::msgs::message::{Message, MessagePayload, PlainMessage};
 
 const HEADER_SIZE: usize = 1 + 3;
 
@@ -51,7 +51,7 @@ impl HandshakeJoiner {
     }
 
     /// Do we want to process this message?
-    pub fn want_message(&self, msg: &OpaqueMessage) -> bool {
+    pub fn want_message(&self, msg: &PlainMessage) -> bool {
         msg.typ == ContentType::Handshake
     }
 
@@ -67,7 +67,7 @@ impl HandshakeJoiner {
     /// Returns None if msg or a preceding message was corrupt.
     /// You cannot recover from this situation.  Otherwise returns
     /// a count of how many messages we queued.
-    pub fn take_message(&mut self, msg: OpaqueMessage) -> Option<usize> {
+    pub fn take_message(&mut self, msg: PlainMessage) -> Option<usize> {
         // The vast majority of the time `self.buf` will be empty since most
         // handshake messages arrive in a single fragment. Avoid allocating and
         // copying in that common case.
@@ -144,20 +144,20 @@ mod tests {
     use crate::msgs::codec::Codec;
     use crate::msgs::enums::{ContentType, HandshakeType, ProtocolVersion};
     use crate::msgs::handshake::{HandshakeMessagePayload, HandshakePayload};
-    use crate::msgs::message::{Message, MessagePayload, OpaqueMessage};
+    use crate::msgs::message::{Message, MessagePayload, PlainMessage};
 
     #[test]
     fn want() {
         let hj = HandshakeJoiner::new();
         assert_eq!(hj.is_empty(), true);
 
-        let wanted = OpaqueMessage {
+        let wanted = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"hello world".to_vec()),
         };
 
-        let unwanted = OpaqueMessage {
+        let unwanted = PlainMessage {
             typ: ContentType::Alert,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"ponytown".to_vec()),
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(hj.want_message(&unwanted), false);
     }
 
-    fn pop_eq(expect: &OpaqueMessage, hj: &mut HandshakeJoiner) {
+    fn pop_eq(expect: &PlainMessage, hj: &mut HandshakeJoiner) {
         let got = hj.frames.pop_front().unwrap();
         assert_eq!(got.payload.content_type(), expect.typ);
         assert_eq!(got.version, expect.version);
@@ -185,7 +185,7 @@ mod tests {
         let mut hj = HandshakeJoiner::new();
 
         // two HelloRequests
-        let msg = OpaqueMessage {
+        let msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x00\x00\x00\x00\x00\x00\x00\x00".to_vec()),
@@ -214,7 +214,7 @@ mod tests {
         let mut hj = HandshakeJoiner::new();
 
         // short ClientHello
-        let msg = OpaqueMessage {
+        let msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x01\x00\x00\x02\xff\xff".to_vec()),
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(hj.is_empty(), true);
 
         // Introduce Finished of 16 bytes, providing 4.
-        let mut msg = OpaqueMessage {
+        let mut msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x14\x00\x00\x10\x00\x01\x02\x03\x04".to_vec()),
@@ -242,7 +242,7 @@ mod tests {
         assert_eq!(hj.is_empty(), false);
 
         // 11 more bytes.
-        msg = OpaqueMessage {
+        msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e".to_vec()),
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(hj.is_empty(), false);
 
         // Final 1 byte.
-        msg = OpaqueMessage {
+        msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x0f".to_vec()),
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn test_rejects_giant_certs() {
         let mut hj = HandshakeJoiner::new();
-        let msg = OpaqueMessage {
+        let msg = PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_2,
             payload: Payload::new(b"\x0b\x01\x00\x04\x01\x00\x01\x00\xff\xfe".to_vec()),

--- a/rustls/src/msgs/mod.rs
+++ b/rustls/src/msgs/mod.rs
@@ -46,7 +46,7 @@ mod test {
             let out = m.clone().encode();
             assert!(out.len() > 0);
 
-            Message::try_from(m).unwrap();
+            Message::try_from(m.into_plain_message()).unwrap();
         }
     }
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -5,7 +5,7 @@ use crate::error::Error;
 use crate::key_schedule::hkdf_expand;
 use crate::msgs::base::Payload;
 use crate::msgs::enums::{AlertDescription, ContentType, ProtocolVersion};
-use crate::msgs::message::OpaqueMessage;
+use crate::msgs::message::PlainMessage;
 pub use crate::server::ServerQuicExt;
 use crate::suites::{BulkAlgorithm, Tls13CipherSuite, TLS13_AES_128_GCM_SHA256_INTERNAL};
 
@@ -187,7 +187,7 @@ impl Keys {
 pub(crate) fn read_hs(this: &mut ConnectionCommon, plaintext: &[u8]) -> Result<(), Error> {
     if this
         .handshake_joiner
-        .take_message(OpaqueMessage {
+        .take_message(PlainMessage {
             typ: ContentType::Handshake,
             version: ProtocolVersion::TLSv1_3,
             payload: Payload::new(plaintext.to_vec()),

--- a/rustls/src/record_layer.rs
+++ b/rustls/src/record_layer.rs
@@ -1,6 +1,6 @@
 use crate::cipher::{MessageDecrypter, MessageEncrypter};
 use crate::error::Error;
-use crate::msgs::message::{BorrowedOpaqueMessage, OpaqueMessage};
+use crate::msgs::message::{BorrowedPlainMessage, OpaqueMessage, PlainMessage};
 
 static SEQ_SOFT_LIMIT: u64 = 0xffff_ffff_ffff_0000u64;
 static SEQ_HARD_LIMIT: u64 = 0xffff_ffff_ffff_fffeu64;
@@ -119,7 +119,7 @@ impl RecordLayer {
     /// `encr` is a decoded message allegedly received from the peer.
     /// If it can be decrypted, its decryption is returned.  Otherwise,
     /// an error is returned.
-    pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<OpaqueMessage, Error> {
+    pub fn decrypt_incoming(&mut self, encr: OpaqueMessage) -> Result<PlainMessage, Error> {
         debug_assert!(self.decrypt_state == DirectionState::Active);
         let seq = self.read_seq;
         self.read_seq += 1;
@@ -131,7 +131,7 @@ impl RecordLayer {
     ///
     /// `plain` is a TLS message we'd like to send.  This function
     /// panics if the requisite keying material hasn't been established yet.
-    pub fn encrypt_outgoing(&mut self, plain: BorrowedOpaqueMessage) -> OpaqueMessage {
+    pub fn encrypt_outgoing(&mut self, plain: BorrowedPlainMessage) -> OpaqueMessage {
         debug_assert!(self.encrypt_state == DirectionState::Active);
         assert!(!self.encrypt_exhausted());
         let seq = self.write_seq;

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3260,7 +3260,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
-        use rustls::internal::msgs::message::OpaqueMessage;
+        use rustls::internal::msgs::message::PlainMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3295,7 +3295,9 @@ mod test_quic {
             }),
         };
 
-        let buf = OpaqueMessage::from(client_hello).encode();
+        let buf = PlainMessage::from(client_hello)
+            .into_unencrypted_opaque()
+            .encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3324,7 +3326,7 @@ mod test_quic {
         use rustls::internal::msgs::handshake::{
             ClientHelloPayload, HandshakeMessagePayload, KeyShareEntry, Random, SessionID,
         };
-        use rustls::internal::msgs::message::OpaqueMessage;
+        use rustls::internal::msgs::message::PlainMessage;
 
         let rng = ring::rand::SystemRandom::new();
         let mut random = [0; 32];
@@ -3362,7 +3364,9 @@ mod test_quic {
             }),
         };
 
-        let buf = OpaqueMessage::from(client_hello).encode();
+        let buf = PlainMessage::from(client_hello)
+            .into_unencrypted_opaque()
+            .encode();
         server
             .read_tls(&mut buf.as_slice())
             .unwrap();
@@ -3411,7 +3415,7 @@ fn test_client_does_not_offer_sha1() {
                 .write_tls(&mut buf.as_mut())
                 .unwrap();
             let msg = OpaqueMessage::read(&mut Reader::init(&buf[..sz])).unwrap();
-            let msg = Message::try_from(msg).unwrap();
+            let msg = Message::try_from(msg.into_plain_message()).unwrap();
             assert!(msg.is_handshake_type(HandshakeType::ClientHello));
 
             let client_hello = match msg.payload {


### PR DESCRIPTION
Following feedback in #667, further clean up the semantic message
types by distinguishing messages with opaque (potentially encrypted)
payloads and messages with plaintext payloads.

This will also help with borrowing, because OpaqueMessages will
want to mutably borrow their payloads in order to be able to
decrypt them, we can borrow a PlainMessage's payloads immutably.