### PR TITLE
Eliminate unwrap and debug_assert guards from the handshake hash.

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -121,7 +121,7 @@ pub(super) fn start_handshake(
         .client_auth_cert_resolver
         .has_certs()
     {
-        transcript.set_client_auth_enabled();
+        transcript.set_client_auth_enabled()?;
     }
 
     let support_tls13 = config.supports_version(ProtocolVersion::TLSv1_3);
@@ -716,7 +716,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         self.next
             .transcript
             .start_hash(cs.get_hash());
-        self.next.transcript.rollup_for_hrr();
+        self.next.transcript.rollup_for_hrr()?;
         self.next.transcript.add_message(&m);
 
         // Early data is not allowed after HelloRetryrequest

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -109,6 +109,9 @@ pub enum Error {
     /// The `max_fragment_size` value supplied in configuration was too small,
     /// or too large.
     BadMaxFragmentSize,
+
+    /// A transcript invariant was violated
+    InconsistentTranscript,
 }
 
 fn join<T: fmt::Debug>(items: &[T]) -> String {
@@ -161,6 +164,7 @@ impl fmt::Display for Error {
             Error::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
+            Error::InconsistentTranscript => write!(f, "invalid transcript state"),
             Error::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
         }
     }
@@ -219,6 +223,7 @@ mod tests {
             Error::PeerSentOversizedRecord,
             Error::NoApplicationProtocol,
             Error::BadMaxFragmentSize,
+            Error::InconsistentTranscript,
         ];
 
         for err in all {

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -140,7 +140,7 @@ impl HandshakeHash {
         Ok(self
             .ctx
             .as_ref()
-            .ok_or_else(|| Error::InconsistentTranscript)?
+            .ok_or(Error::InconsistentTranscript)?
             .clone()
             .finish())
     }

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -285,7 +285,10 @@ pub struct ExpectClientHello {
 }
 
 impl ExpectClientHello {
-    pub fn new(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> ExpectClientHello {
+    pub fn new(
+        config: Arc<ServerConfig>,
+        extra_exts: Vec<ServerExtension>,
+    ) -> Result<ExpectClientHello, Error> {
         let mut ech = ExpectClientHello {
             config,
             extra_exts,
@@ -297,10 +300,11 @@ impl ExpectClientHello {
         };
 
         if ech.config.verifier.offer_client_auth() {
-            ech.transcript.set_client_auth_enabled();
+            ech.transcript
+                .set_client_auth_enabled()?;
         }
 
-        ech
+        Ok(ech)
     }
 }
 

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -243,7 +243,7 @@ impl ServerConnection {
     ) -> Result<Self, Error> {
         Ok(ServerConnection {
             common: ConnectionCommon::new(config.max_fragment_size, false)?,
-            state: Some(Box::new(hs::ExpectClientHello::new(config, extra_exts))),
+            state: Some(Box::new(hs::ExpectClientHello::new(config, extra_exts)?)),
             data: ServerConnectionData::default(),
         })
     }


### PR DESCRIPTION
These were bugging me as I inspected `hash_hs.rs` during ECH work. They tend to roll up to a `NextStateOrError` result anyway, so the change was mostly mechanical.