### PR TITLE
Use different types for TLS 1.2/1.3 cipher suites

### DIFF
--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -361,12 +361,12 @@ fn lookup_ipv4(host: &str, port: u16) -> SocketAddr {
 }
 
 /// Find a ciphersuite with the given name
-fn find_suite(name: &str) -> Option<&'static rustls::SupportedCipherSuite> {
+fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
     for suite in rustls::ALL_CIPHERSUITES {
-        let sname = format!("{:?}", suite.suite).to_lowercase();
+        let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {
-            return Some(suite);
+            return Some(*suite);
         }
     }
 
@@ -374,7 +374,7 @@ fn find_suite(name: &str) -> Option<&'static rustls::SupportedCipherSuite> {
 }
 
 /// Make a vector of ciphersuites named in `suites`
-fn lookup_suites(suites: &[String]) -> Vec<&'static rustls::SupportedCipherSuite> {
+fn lookup_suites(suites: &[String]) -> Vec<rustls::SupportedCipherSuite> {
     let mut out = Vec::new();
 
     for csname in suites {

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -471,19 +471,19 @@ struct Args {
     arg_fport: Option<u16>,
 }
 
-fn find_suite(name: &str) -> Option<&'static rustls::SupportedCipherSuite> {
+fn find_suite(name: &str) -> Option<rustls::SupportedCipherSuite> {
     for suite in rustls::ALL_CIPHERSUITES {
-        let sname = format!("{:?}", suite.suite).to_lowercase();
+        let sname = format!("{:?}", suite.suite()).to_lowercase();
 
         if sname == name.to_string().to_lowercase() {
-            return Some(suite);
+            return Some(*suite);
         }
     }
 
     None
 }
 
-fn lookup_suites(suites: &[String]) -> Vec<&'static rustls::SupportedCipherSuite> {
+fn lookup_suites(suites: &[String]) -> Vec<rustls::SupportedCipherSuite> {
     let mut out = Vec::new();
 
     for csname in suites {

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -16,7 +16,7 @@ fn main() {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
     let config = rustls::ConfigBuilder::with_cipher_suites(&[
-        &rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256.into(),
     ])
     .with_kx_groups(&[&rustls::kx_group::X25519])
     .with_protocol_versions(&[&rustls::version::TLS13])
@@ -47,7 +47,7 @@ fn main() {
     writeln!(
         &mut std::io::stderr(),
         "Current ciphersuite: {:?}",
-        ciphersuite.suite
+        ciphersuite.suite()
     )
     .unwrap();
     let mut plaintext = Vec::new();

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -49,7 +49,7 @@ fn main() {
     writeln!(
         &mut std::io::stderr(),
         "Current ciphersuite: {:?}",
-        ciphersuite.suite
+        ciphersuite.suite()
     )
     .unwrap();
     let mut plaintext = Vec::new();

--- a/rustls/src/cipher.rs
+++ b/rustls/src/cipher.rs
@@ -127,12 +127,11 @@ pub fn new_tls12(secrets: &ConnectionSecrets) -> MessageCipherPair {
 
     let suite = secrets.suite();
     let scs = &suite.common;
-    let params = &suite.params;
 
     let (client_write_key, key_block) = split_key(&key_block, scs.aead_algorithm);
     let (server_write_key, key_block) = split_key(&key_block, scs.aead_algorithm);
-    let (client_write_iv, key_block) = key_block.split_at(params.fixed_iv_len);
-    let (server_write_iv, extra) = key_block.split_at(params.fixed_iv_len);
+    let (client_write_iv, key_block) = key_block.split_at(suite.fixed_iv_len);
+    let (server_write_iv, extra) = key_block.split_at(suite.fixed_iv_len);
 
     let (write_key, write_iv, read_key, read_iv) = if secrets.randoms.we_are_client {
         (
@@ -151,10 +150,10 @@ pub fn new_tls12(secrets: &ConnectionSecrets) -> MessageCipherPair {
     };
 
     (
-        params
+        suite
             .aead_alg
             .decrypter(read_key, read_iv),
-        params
+        suite
             .aead_alg
             .encrypter(write_key, write_iv, extra),
     )

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -54,7 +54,7 @@ use std::sync::Arc;
 /// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ClientConfig::key_log`]: key material is not logged.
 pub struct ClientConfigBuilder {
-    pub(crate) cipher_suites: Vec<&'static SupportedCipherSuite>,
+    pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,
     pub(crate) versions: versions::EnabledVersions,
 }
@@ -93,7 +93,7 @@ impl ClientConfigBuilder {
 /// A [`ClientConfigBuilder`] where we know the cipher suites, key exchange
 /// groups, enabled versions, and server certificate auth policy.
 pub struct ClientConfigBuilderWithCertVerifier {
-    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ServerCertVerifier>,

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -393,7 +393,7 @@ impl hs::State for ExpectServerKx {
         self.transcript.add_message(&m);
 
         let decoded_kx = opaque_kx
-            .unwrap_given_kxa(&self.suite.params.kx)
+            .unwrap_given_kxa(&self.suite.kx)
             .ok_or_else(|| {
                 cx.common
                     .send_fatal_alert(AlertDescription::DecodeError);
@@ -747,7 +747,7 @@ impl hs::State for ExpectServerDone {
                 let error_message = format!(
                     "peer signed kx with wrong algorithm (got {:?} expect {:?})",
                     sig.scheme.sign(),
-                    suite.params.sign
+                    suite.sign
                 );
                 return Err(Error::PeerMisbehavedError(error_message));
             }

--- a/rustls/src/conn.rs
+++ b/rustls/src/conn.rs
@@ -481,11 +481,11 @@ impl ConnectionSecrets {
     }
 
     pub fn make_key_block(&self) -> Vec<u8> {
+        let suite = &self.suite;
         let common = &self.suite.common;
-        let params = &self.suite.params;
 
         let len =
-            (common.aead_algorithm.key_len() + params.fixed_iv_len) * 2 + params.explicit_nonce_len;
+            (common.aead_algorithm.key_len() + suite.fixed_iv_len) * 2 + suite.explicit_nonce_len;
 
         let mut out = Vec::new();
         out.resize(len, 0u8);

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -320,7 +320,8 @@ pub use crate::server::{ClientHello, ProducesTickets, ResolvesServerCert};
 pub use crate::server::{ServerConfig, ServerConnection};
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
-    BulkAlgorithm, SupportedCipherSuite, ALL_CIPHERSUITES, DEFAULT_CIPHERSUITES,
+    BulkAlgorithm, SupportedCipherSuite, Tls12CipherSuite, Tls13CipherSuite, ALL_CIPHERSUITES,
+    DEFAULT_CIPHERSUITES,
 };
 pub use crate::ticketer::Ticketer;
 pub use crate::verify::{

--- a/rustls/src/msgs/persist.rs
+++ b/rustls/src/msgs/persist.rs
@@ -67,12 +67,13 @@ pub struct ClientSessionValue {
 impl ClientSessionValue {
     pub fn resolve_cipher_suite(
         self,
-        enabled_cipher_suites: &[&'static SupportedCipherSuite],
+        enabled_cipher_suites: &[SupportedCipherSuite],
         time: TimeBase,
     ) -> Option<ClientSessionValueWithResolvedCipherSuite> {
         let supported_cipher_suite = enabled_cipher_suites
             .iter()
-            .find(|scs| scs.suite == self.cipher_suite)?;
+            .copied()
+            .find(|scs| scs.suite() == self.cipher_suite)?;
         Some(ClientSessionValueWithResolvedCipherSuite {
             value: self,
             supported_cipher_suite,
@@ -128,7 +129,7 @@ impl Codec for ClientSessionValue {
 #[derive(Debug)]
 pub struct ClientSessionValueWithResolvedCipherSuite {
     value: ClientSessionValue,
-    supported_cipher_suite: &'static SupportedCipherSuite,
+    supported_cipher_suite: SupportedCipherSuite,
     time_retrieved: TimeBase,
 }
 
@@ -144,7 +145,7 @@ static MAX_TICKET_LIFETIME: u32 = 7 * 24 * 60 * 60;
 impl ClientSessionValueWithResolvedCipherSuite {
     pub fn new(
         v: ProtocolVersion,
-        cipher_suite: &'static SupportedCipherSuite,
+        cipher_suite: SupportedCipherSuite,
         sessid: &SessionID,
         ticket: Vec<u8>,
         ms: Vec<u8>,
@@ -154,7 +155,7 @@ impl ClientSessionValueWithResolvedCipherSuite {
         ClientSessionValueWithResolvedCipherSuite {
             value: ClientSessionValue {
                 version: v,
-                cipher_suite: cipher_suite.suite,
+                cipher_suite: cipher_suite.suite(),
                 session_id: *sessid,
                 ticket: PayloadU16::new(ticket),
                 master_secret: PayloadU8::new(ms),
@@ -170,7 +171,7 @@ impl ClientSessionValueWithResolvedCipherSuite {
         }
     }
 
-    pub fn supported_cipher_suite(&self) -> &'static SupportedCipherSuite {
+    pub fn supported_cipher_suite(&self) -> SupportedCipherSuite {
         self.supported_cipher_suite
     }
 

--- a/rustls/src/msgs/persist_test.rs
+++ b/rustls/src/msgs/persist_test.rs
@@ -2,9 +2,11 @@ use super::codec::{Codec, Reader};
 use super::enums::*;
 use super::handshake::*;
 use super::persist::*;
+
 use crate::key::Certificate;
 use crate::suites::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;
 use crate::ticketer::TimeBase;
+
 use std::convert::TryInto;
 
 #[test]
@@ -25,7 +27,7 @@ fn clientsessionkey_cannot_be_read() {
 fn clientsessionvalue_is_debug() {
     let csv = ClientSessionValueWithResolvedCipherSuite::new(
         ProtocolVersion::TLSv1_2,
-        &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         &SessionID::random().unwrap(),
         vec![],
         vec![1, 2, 3],

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -52,7 +52,7 @@ use std::sync::Arc;
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
 pub struct ServerConfigBuilder {
-    pub(crate) cipher_suites: Vec<&'static SupportedCipherSuite>,
+    pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,
     pub(crate) versions: versions::EnabledVersions,
 }
@@ -80,7 +80,7 @@ impl ServerConfigBuilder {
 /// A [`ServerConfigBuilder`] where we know the cipher suites, key exchange
 /// groups, enabled versions, and client auth policy.
 pub struct ServerConfigBuilderWithClientAuth {
-    cipher_suites: Vec<&'static SupportedCipherSuite>,
+    cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ClientCertVerifier>,

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -154,7 +154,7 @@ impl<'a> ClientHello<'a> {
 #[derive(Clone)]
 pub struct ServerConfig {
     /// List of ciphersuites, in preference order.
-    pub cipher_suites: Vec<&'static SupportedCipherSuite>,
+    pub cipher_suites: Vec<SupportedCipherSuite>,
 
     /// List of supported key exchange groups.
     ///
@@ -216,7 +216,7 @@ impl ServerConfig {
             && self
                 .cipher_suites
                 .iter()
-                .any(|cs| cs.usable_for_version(v))
+                .any(|cs| cs.version().version == v)
     }
 }
 
@@ -383,7 +383,7 @@ impl Connection for ServerConnection {
             .and_then(|st| st.export_keying_material(output, label, context))
     }
 
-    fn negotiated_cipher_suite(&self) -> Option<&'static SupportedCipherSuite> {
+    fn negotiated_cipher_suite(&self) -> Option<SupportedCipherSuite> {
         self.common.get_suite()
     }
 
@@ -449,7 +449,9 @@ impl quic::QuicExt for ServerConnection {
 
     fn zero_rtt_keys(&self) -> Option<quic::DirectionalKeys> {
         Some(quic::DirectionalKeys::new(
-            self.common.get_suite()?,
+            self.common
+                .get_suite()
+                .and_then(|suite| suite.tls13())?,
             self.common.quic.early_secret.as_ref()?,
         ))
     }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -1,4 +1,4 @@
-use crate::cipher;
+use crate::cipher::{self, Tls12AeadAlgorithm};
 use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::{CipherSuite, SignatureAlgorithm, SignatureScheme};
 use crate::msgs::handshake::DecomposedSignatureScheme;
@@ -110,8 +110,7 @@ pub(crate) struct Tls12Parameters {
     /// chacha20poly1305 works this way by design.
     pub explicit_nonce_len: usize,
 
-    pub build_tls12_encrypter: cipher::BuildTls12Encrypter,
-    pub build_tls12_decrypter: cipher::BuildTls12Decrypter,
+    pub aead_alg: &'static dyn Tls12AeadAlgorithm,
 }
 
 /// A TLS 1.2 cipher suite supported by rustls.
@@ -241,8 +240,7 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             sign: TLS12_ECDSA_SCHEMES,
             fixed_iv_len: 12,
             explicit_nonce_len: 0,
-            build_tls12_encrypter: cipher::build_tls12_chacha_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_chacha_decrypter,
+            aead_alg: &cipher::ChaCha20Poly1305,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
@@ -260,8 +258,7 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             sign: TLS12_RSA_SCHEMES,
             fixed_iv_len: 12,
             explicit_nonce_len: 0,
-            build_tls12_encrypter: cipher::build_tls12_chacha_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_chacha_decrypter,
+            aead_alg: &cipher::ChaCha20Poly1305,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
@@ -279,8 +276,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             sign: TLS12_RSA_SCHEMES,
             fixed_iv_len: 4,
             explicit_nonce_len: 8,
-            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+            aead_alg: &cipher::AesGcm,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
@@ -298,8 +294,7 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             sign: TLS12_RSA_SCHEMES,
             fixed_iv_len: 4,
             explicit_nonce_len: 8,
-            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+            aead_alg: &cipher::AesGcm,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA384,
     });
@@ -317,8 +312,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             sign: TLS12_ECDSA_SCHEMES,
             fixed_iv_len: 4,
             explicit_nonce_len: 8,
-            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+            aead_alg: &cipher::AesGcm,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
@@ -336,8 +330,7 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             sign: TLS12_ECDSA_SCHEMES,
             fixed_iv_len: 4,
             explicit_nonce_len: 8,
-            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+            aead_alg: &cipher::AesGcm,
         },
         hmac_algorithm: ring::hmac::HMAC_SHA384,
     });

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -3,8 +3,8 @@ use crate::msgs::enums::ProtocolVersion;
 use crate::msgs::enums::{CipherSuite, SignatureAlgorithm, SignatureScheme};
 use crate::msgs::handshake::DecomposedSignatureScheme;
 use crate::msgs::handshake::KeyExchangeAlgorithm;
+use crate::versions::{SupportedProtocolVersion, TLS12, TLS13};
 
-use std::convert::TryFrom;
 use std::fmt;
 
 /// Bulk symmetric encryption scheme used by a cipher suite.
@@ -21,21 +21,74 @@ pub enum BulkAlgorithm {
     Chacha20Poly1305,
 }
 
-/// A cipher suite supported by rustls.
-///
-/// All possible instances of this class are provided by the library in
-/// the `ALL_CIPHERSUITES` array.
-pub struct SupportedCipherSuite {
+/// Common state for cipher suites (both for TLS 1.2 and TLS 1.3)
+pub struct CipherSuiteCommon {
     /// The TLS enumeration naming this cipher suite.
     pub suite: CipherSuite,
 
     /// How to do bulk encryption.
     pub bulk: BulkAlgorithm,
 
-    pub(crate) hkdf_algorithm: ring::hkdf::Algorithm,
     pub(crate) aead_algorithm: &'static ring::aead::Algorithm,
+}
 
-    tls12: Option<Tls12Parameters>,
+/// A cipher suite supported by rustls.
+///
+/// All possible instances of this type are provided by the library in
+/// the `ALL_CIPHERSUITES` array.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SupportedCipherSuite {
+    /// A TLS 1.2 cipher suite
+    Tls12(&'static Tls12CipherSuite),
+    /// A TLS 1.3 cipher suite
+    Tls13(&'static Tls13CipherSuite),
+}
+
+/// A TLS 1.3 cipher suite supported by rustls.
+pub struct Tls13CipherSuite {
+    /// Common cipher suite fields.
+    pub common: CipherSuiteCommon,
+    pub(crate) hkdf_algorithm: ring::hkdf::Algorithm,
+}
+
+impl Tls13CipherSuite {
+    /// Which hash function to use with this suite.
+    pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
+        self.hkdf_algorithm
+            .hmac_algorithm()
+            .digest_algorithm()
+    }
+
+    /// Can a session using suite self resume from suite prev?
+    pub fn can_resume_from(&self, prev: SupportedCipherSuite) -> Option<&'static Tls13CipherSuite> {
+        match prev {
+            SupportedCipherSuite::Tls13(inner) if inner.get_hash() == self.get_hash() => {
+                Some(inner)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<&'static Tls13CipherSuite> for SupportedCipherSuite {
+    fn from(s: &'static Tls13CipherSuite) -> Self {
+        SupportedCipherSuite::Tls13(s)
+    }
+}
+
+impl PartialEq for Tls13CipherSuite {
+    fn eq(&self, other: &Self) -> bool {
+        self.common.suite == other.common.suite
+    }
+}
+
+impl fmt::Debug for Tls13CipherSuite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tls13CipherSuite")
+            .field("suite", &self.common.suite)
+            .field("bulk", &self.common.bulk)
+            .finish()
+    }
 }
 
 pub(crate) struct Tls12Parameters {
@@ -61,61 +114,50 @@ pub(crate) struct Tls12Parameters {
     pub build_tls12_decrypter: cipher::BuildTls12Decrypter,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct Tls12CipherSuite {
-    scs: &'static SupportedCipherSuite,
-    tls12: &'static Tls12Parameters,
-}
-
-impl TryFrom<&'static SupportedCipherSuite> for Tls12CipherSuite {
-    type Error = VersionNotCompatibleError;
-
-    fn try_from(scs: &'static SupportedCipherSuite) -> Result<Self, Self::Error> {
-        scs.tls12
-            .as_ref()
-            .map(|tls12| Self { scs, tls12 })
-            .ok_or(VersionNotCompatibleError(()))
-    }
+/// A TLS 1.2 cipher suite supported by rustls.
+pub struct Tls12CipherSuite {
+    /// Common cipher suite fields.
+    pub common: CipherSuiteCommon,
+    pub(crate) params: Tls12Parameters,
+    pub(crate) hmac_algorithm: ring::hmac::Algorithm,
 }
 
 impl Tls12CipherSuite {
-    #[inline]
-    pub fn supported_suite(&self) -> &'static SupportedCipherSuite {
-        self.scs
-    }
-
-    #[inline]
-    pub fn tls12(&self) -> &'static Tls12Parameters {
-        self.tls12
-    }
-
     /// Resolve the set of supported `SignatureScheme`s from the
     /// offered `SupportedSignatureSchemes`.  If we return an empty
     /// set, the handshake terminates.
     pub fn resolve_sig_schemes(&self, offered: &[SignatureScheme]) -> Vec<SignatureScheme> {
-        self.tls12
+        self.params
             .sign
             .iter()
             .filter(|pref| offered.contains(pref))
             .cloned()
             .collect()
     }
-}
 
-#[derive(Clone, Copy, Debug)]
-pub struct VersionNotCompatibleError(());
-
-impl PartialEq for SupportedCipherSuite {
-    fn eq(&self, other: &SupportedCipherSuite) -> bool {
-        self.suite == other.suite
+    /// Which hash function to use with this suite.
+    pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
+        self.hmac_algorithm.digest_algorithm()
     }
 }
 
-impl fmt::Debug for SupportedCipherSuite {
+impl From<&'static Tls12CipherSuite> for SupportedCipherSuite {
+    fn from(s: &'static Tls12CipherSuite) -> Self {
+        SupportedCipherSuite::Tls12(s)
+    }
+}
+
+impl PartialEq for Tls12CipherSuite {
+    fn eq(&self, other: &Self) -> bool {
+        self.common.suite == other.common.suite
+    }
+}
+
+impl fmt::Debug for Tls12CipherSuite {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SupportedCipherSuite")
-            .field("suite", &self.suite)
-            .field("bulk", &self.bulk)
+        f.debug_struct("Tls12CipherSuite")
+            .field("suite", &self.common.suite)
+            .field("bulk", &self.common.bulk)
             .finish()
     }
 }
@@ -123,52 +165,49 @@ impl fmt::Debug for SupportedCipherSuite {
 impl SupportedCipherSuite {
     /// Which hash function to use with this suite.
     pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
-        self.hmac_algorithm().digest_algorithm()
+        match self {
+            SupportedCipherSuite::Tls12(inner) => inner.get_hash(),
+            SupportedCipherSuite::Tls13(inner) => inner.get_hash(),
+        }
     }
 
-    pub(crate) fn hmac_algorithm(&self) -> ring::hmac::Algorithm {
-        self.hkdf_algorithm.hmac_algorithm()
+    /// The cipher suite's identifier
+    pub fn suite(&self) -> CipherSuite {
+        self.common().suite
     }
 
+    pub(crate) fn common(&self) -> &CipherSuiteCommon {
+        match self {
+            SupportedCipherSuite::Tls12(inner) => &inner.common,
+            SupportedCipherSuite::Tls13(inner) => &inner.common,
+        }
+    }
 
-    /// Return true if this suite is usable for TLS `version`.
-    pub fn usable_for_version(&self, version: ProtocolVersion) -> bool {
-        match version {
-            ProtocolVersion::TLSv1_3 => self.tls12.is_none(),
-            ProtocolVersion::TLSv1_2 => self.tls12.is_some(),
-            _ => false,
+    pub(crate) fn tls13(&self) -> Option<&'static Tls13CipherSuite> {
+        match self {
+            SupportedCipherSuite::Tls12(_) => None,
+            SupportedCipherSuite::Tls13(inner) => Some(inner),
+        }
+    }
+
+    /// Return supported protocol version for the cipher suite.
+    pub fn version(&self) -> &'static SupportedProtocolVersion {
+        match self {
+            SupportedCipherSuite::Tls12(_) => &TLS12,
+            SupportedCipherSuite::Tls13(_) => &TLS13,
         }
     }
 
     /// Return true if this suite is usable for a key only offering `sigalg`
     /// signatures.  This resolves to true for all TLS1.3 suites.
     pub fn usable_for_sigalg(&self, sigalg: SignatureAlgorithm) -> bool {
-        match &self.tls12 {
-            None => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
-            Some(tls12) => tls12
+        match self {
+            SupportedCipherSuite::Tls13(_) => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
+            SupportedCipherSuite::Tls12(inner) => inner
+                .params
                 .sign
                 .iter()
                 .any(|scheme| scheme.sign() == sigalg),
-        }
-    }
-
-    /// Can a session using suite self resume using suite new_suite?
-    pub fn can_resume_to(&self, new_suite: &SupportedCipherSuite) -> bool {
-        if self.usable_for_version(ProtocolVersion::TLSv1_3)
-            && new_suite.usable_for_version(ProtocolVersion::TLSv1_3)
-        {
-            // TLS1.3 actually specifies requirements here: suites are compatible
-            // for resumption if they have the same KDF hash
-            self.get_hash() == new_suite.get_hash()
-        } else if self.usable_for_version(ProtocolVersion::TLSv1_2)
-            && new_suite.usable_for_version(ProtocolVersion::TLSv1_2)
-        {
-            // Previous versions don't specify any constraint, so we don't
-            // resume between suites to avoid bad interactions.
-            self.suite == new_suite.suite
-        } else {
-            // Suites for different versions definitely can't resume!
-            false
         }
     }
 }
@@ -191,159 +230,183 @@ static TLS12_RSA_SCHEMES: &[SignatureScheme] = &[
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.
 pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite {
-        suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-        bulk: BulkAlgorithm::Chacha20Poly1305,
-        hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-        aead_algorithm: &ring::aead::CHACHA20_POLY1305,
-        tls12: Some(Tls12Parameters {
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+            bulk: BulkAlgorithm::Chacha20Poly1305,
+            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+        },
+        params: Tls12Parameters {
             kx: KeyExchangeAlgorithm::ECDHE,
             sign: TLS12_ECDSA_SCHEMES,
             fixed_iv_len: 12,
             explicit_nonce_len: 0,
             build_tls12_encrypter: cipher::build_tls12_chacha_encrypter,
             build_tls12_decrypter: cipher::build_tls12_chacha_decrypter,
-        }),
-    };
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA256,
+    });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
-    SupportedCipherSuite {
-        suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-        bulk: BulkAlgorithm::Chacha20Poly1305,
-        hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-        aead_algorithm: &ring::aead::CHACHA20_POLY1305,
-        tls12: Some(Tls12Parameters {
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            bulk: BulkAlgorithm::Chacha20Poly1305,
+            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+        },
+        params: Tls12Parameters {
             kx: KeyExchangeAlgorithm::ECDHE,
             sign: TLS12_RSA_SCHEMES,
             fixed_iv_len: 12,
             explicit_nonce_len: 0,
             build_tls12_encrypter: cipher::build_tls12_chacha_encrypter,
             build_tls12_decrypter: cipher::build_tls12_chacha_decrypter,
-        }),
-    };
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA256,
+    });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    bulk: BulkAlgorithm::Aes128Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-    aead_algorithm: &ring::aead::AES_128_GCM,
-    tls12: Some(Tls12Parameters {
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        fixed_iv_len: 4,
-        explicit_nonce_len: 8,
-        build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-        build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
-    }),
-};
+pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            bulk: BulkAlgorithm::Aes128Gcm,
+            aead_algorithm: &ring::aead::AES_128_GCM,
+        },
+        params: Tls12Parameters {
+            kx: KeyExchangeAlgorithm::ECDHE,
+            sign: TLS12_RSA_SCHEMES,
+            fixed_iv_len: 4,
+            explicit_nonce_len: 8,
+            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
+            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA256,
+    });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-    bulk: BulkAlgorithm::Aes256Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
-    aead_algorithm: &ring::aead::AES_256_GCM,
-    tls12: Some(Tls12Parameters {
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_RSA_SCHEMES,
-        fixed_iv_len: 4,
-        explicit_nonce_len: 8,
-        build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-        build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
-    }),
-};
+pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            bulk: BulkAlgorithm::Aes256Gcm,
+            aead_algorithm: &ring::aead::AES_256_GCM,
+        },
+        params: Tls12Parameters {
+            kx: KeyExchangeAlgorithm::ECDHE,
+            sign: TLS12_RSA_SCHEMES,
+            fixed_iv_len: 4,
+            explicit_nonce_len: 8,
+            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
+            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA384,
+    });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    bulk: BulkAlgorithm::Aes128Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-    aead_algorithm: &ring::aead::AES_128_GCM,
-    tls12: Some(Tls12Parameters {
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        fixed_iv_len: 4,
-        explicit_nonce_len: 8,
-        build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-        build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
-    }),
-};
+pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            bulk: BulkAlgorithm::Aes128Gcm,
+            aead_algorithm: &ring::aead::AES_128_GCM,
+        },
+        params: Tls12Parameters {
+            kx: KeyExchangeAlgorithm::ECDHE,
+            sign: TLS12_ECDSA_SCHEMES,
+            fixed_iv_len: 4,
+            explicit_nonce_len: 8,
+            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
+            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA256,
+    });
 
 /// The TLS1.2 ciphersuite TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-    bulk: BulkAlgorithm::Aes256Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
-    aead_algorithm: &ring::aead::AES_256_GCM,
-    tls12: Some(Tls12Parameters {
-        kx: KeyExchangeAlgorithm::ECDHE,
-        sign: TLS12_ECDSA_SCHEMES,
-        fixed_iv_len: 4,
-        explicit_nonce_len: 8,
-        build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
-        build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
-    }),
-};
+pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
+    SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            bulk: BulkAlgorithm::Aes256Gcm,
+            aead_algorithm: &ring::aead::AES_256_GCM,
+        },
+        params: Tls12Parameters {
+            kx: KeyExchangeAlgorithm::ECDHE,
+            sign: TLS12_ECDSA_SCHEMES,
+            fixed_iv_len: 4,
+            explicit_nonce_len: 8,
+            build_tls12_encrypter: cipher::build_tls12_gcm_encrypter,
+            build_tls12_decrypter: cipher::build_tls12_gcm_decrypter,
+        },
+        hmac_algorithm: ring::hmac::HMAC_SHA384,
+    });
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256
-pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
-    bulk: BulkAlgorithm::Chacha20Poly1305,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-    aead_algorithm: &ring::aead::CHACHA20_POLY1305,
-    tls12: None,
-};
+pub static TLS13_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
+    SupportedCipherSuite::Tls13(&Tls13CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,
+            bulk: BulkAlgorithm::Chacha20Poly1305,
+            aead_algorithm: &ring::aead::CHACHA20_POLY1305,
+        },
+        hkdf_algorithm: ring::hkdf::HKDF_SHA256,
+    });
 
 /// The TLS1.3 ciphersuite TLS_AES_256_GCM_SHA384
-pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
-    bulk: BulkAlgorithm::Aes256Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA384,
-    aead_algorithm: &ring::aead::AES_256_GCM,
-    tls12: None,
+pub static TLS13_AES_256_GCM_SHA384: SupportedCipherSuite =
+    SupportedCipherSuite::Tls13(&Tls13CipherSuite {
+        common: CipherSuiteCommon {
+            suite: CipherSuite::TLS13_AES_256_GCM_SHA384,
+            bulk: BulkAlgorithm::Aes256Gcm,
+            aead_algorithm: &ring::aead::AES_256_GCM,
+        },
+        hkdf_algorithm: ring::hkdf::HKDF_SHA384,
+    });
+
+pub(crate) static TLS13_AES_128_GCM_SHA256_INTERNAL: &Tls13CipherSuite = &Tls13CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
+        bulk: BulkAlgorithm::Aes128Gcm,
+        aead_algorithm: &ring::aead::AES_128_GCM,
+    },
+    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
 };
 
 /// The TLS1.3 ciphersuite TLS_AES_128_GCM_SHA256
-pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite {
-    suite: CipherSuite::TLS13_AES_128_GCM_SHA256,
-    bulk: BulkAlgorithm::Aes128Gcm,
-    hkdf_algorithm: ring::hkdf::HKDF_SHA256,
-    aead_algorithm: &ring::aead::AES_128_GCM,
-    tls12: None,
-};
+pub static TLS13_AES_128_GCM_SHA256: SupportedCipherSuite =
+    SupportedCipherSuite::Tls13(TLS13_AES_128_GCM_SHA256_INTERNAL);
 
 /// A list of all the cipher suites supported by rustls.
-pub static ALL_CIPHERSUITES: &[&SupportedCipherSuite] = &[
+pub static ALL_CIPHERSUITES: &[SupportedCipherSuite] = &[
     // TLS1.3 suites
-    &TLS13_AES_256_GCM_SHA384,
-    &TLS13_AES_128_GCM_SHA256,
-    &TLS13_CHACHA20_POLY1305_SHA256,
+    TLS13_AES_256_GCM_SHA384,
+    TLS13_AES_128_GCM_SHA256,
+    TLS13_CHACHA20_POLY1305_SHA256,
     // TLS1.2 suites
-    &TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-    &TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    &TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-    &TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-    &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    &TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
 /// The cipher suite configuration that an application should use by default.
 ///
 /// This will be `ALL_CIPHERSUITES` sans any supported cipher suites that
 /// shouldn't be enabled by most applications.
-pub static DEFAULT_CIPHERSUITES: &[&SupportedCipherSuite] = ALL_CIPHERSUITES;
+pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = ALL_CIPHERSUITES;
 
 // These both O(N^2)!
 pub fn choose_ciphersuite_preferring_client(
     client_suites: &[CipherSuite],
-    server_suites: &[&'static SupportedCipherSuite],
-) -> Option<&'static SupportedCipherSuite> {
+    server_suites: &[SupportedCipherSuite],
+) -> Option<SupportedCipherSuite> {
     for client_suite in client_suites {
         if let Some(selected) = server_suites
             .iter()
-            .find(|x| *client_suite == x.suite)
+            .find(|x| *client_suite == x.suite())
         {
             return Some(*selected);
         }
@@ -354,11 +417,11 @@ pub fn choose_ciphersuite_preferring_client(
 
 pub fn choose_ciphersuite_preferring_server(
     client_suites: &[CipherSuite],
-    server_suites: &[&'static SupportedCipherSuite],
-) -> Option<&'static SupportedCipherSuite> {
+    server_suites: &[SupportedCipherSuite],
+) -> Option<SupportedCipherSuite> {
     if let Some(selected) = server_suites
         .iter()
-        .find(|x| client_suites.contains(&x.suite))
+        .find(|x| client_suites.contains(&x.suite()))
     {
         return Some(*selected);
     }
@@ -369,31 +432,31 @@ pub fn choose_ciphersuite_preferring_server(
 /// Return a list of the ciphersuites in `all` with the suites
 /// incompatible with `SignatureAlgorithm` `sigalg` removed.
 pub fn reduce_given_sigalg(
-    all: &[&'static SupportedCipherSuite],
+    all: &[SupportedCipherSuite],
     sigalg: SignatureAlgorithm,
-) -> Vec<&'static SupportedCipherSuite> {
+) -> Vec<SupportedCipherSuite> {
     all.iter()
         .filter(|&&suite| suite.usable_for_sigalg(sigalg))
-        .cloned()
+        .copied()
         .collect()
 }
 
 /// Return a list of the ciphersuites in `all` with the suites
 /// incompatible with the chosen `version` removed.
 pub fn reduce_given_version(
-    all: &[&'static SupportedCipherSuite],
+    all: &[SupportedCipherSuite],
     version: ProtocolVersion,
-) -> Vec<&'static SupportedCipherSuite> {
+) -> Vec<SupportedCipherSuite> {
     all.iter()
-        .filter(|&&suite| suite.usable_for_version(version))
-        .cloned()
+        .filter(|&&suite| suite.version().version == version)
+        .copied()
         .collect()
 }
 
 /// Return true if `sigscheme` is usable by any of the given suites.
 pub fn compatible_sigscheme_for_suites(
     sigscheme: SignatureScheme,
-    common_suites: &[&'static SupportedCipherSuite],
+    common_suites: &[SupportedCipherSuite],
 ) -> bool {
     let sigalg = sigscheme.sign();
     common_suites
@@ -413,12 +476,12 @@ mod test {
             CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
         ];
         let server = vec![
-            &TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         ];
         let chosen = choose_ciphersuite_preferring_client(&client, &server);
         assert!(chosen.is_some());
-        assert_eq!(chosen.unwrap(), &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
+        assert_eq!(chosen.unwrap(), TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256);
     }
 
     #[test]
@@ -428,12 +491,12 @@ mod test {
             CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
         ];
         let server = vec![
-            &TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            &TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         ];
         let chosen = choose_ciphersuite_preferring_server(&client, &server);
         assert!(chosen.is_some());
-        assert_eq!(chosen.unwrap(), &TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384);
+        assert_eq!(chosen.unwrap(), TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384);
     }
 
     #[test]
@@ -460,45 +523,20 @@ mod test {
     }
 
     #[test]
-    fn test_usable_for_version() {
-        fn ok_tls13(scs: &SupportedCipherSuite) {
-            assert!(!scs.usable_for_version(ProtocolVersion::TLSv1_0));
-            assert!(!scs.usable_for_version(ProtocolVersion::TLSv1_2));
-            assert!(scs.usable_for_version(ProtocolVersion::TLSv1_3));
-        }
-
-        fn ok_tls12(scs: &SupportedCipherSuite) {
-            assert!(!scs.usable_for_version(ProtocolVersion::TLSv1_0));
-            assert!(scs.usable_for_version(ProtocolVersion::TLSv1_2));
-            assert!(!scs.usable_for_version(ProtocolVersion::TLSv1_3));
-        }
-
-        ok_tls13(&TLS13_CHACHA20_POLY1305_SHA256);
-        ok_tls13(&TLS13_AES_256_GCM_SHA384);
-        ok_tls13(&TLS13_AES_128_GCM_SHA256);
-
-        ok_tls12(&TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256);
-        ok_tls12(&TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256);
-        ok_tls12(&TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
-        ok_tls12(&TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256);
-        ok_tls12(&TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384);
-    }
-
-    #[test]
     fn test_can_resume_to() {
-        assert!(TLS13_CHACHA20_POLY1305_SHA256.can_resume_to(&TLS13_AES_128_GCM_SHA256));
-        assert!(!TLS13_CHACHA20_POLY1305_SHA256.can_resume_to(&TLS13_AES_256_GCM_SHA384));
         assert!(
-            !TLS13_CHACHA20_POLY1305_SHA256
-                .can_resume_to(&TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256)
+            TLS13_AES_128_GCM_SHA256
+                .tls13()
+                .unwrap()
+                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
+                .is_some()
         );
         assert!(
-            !TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-                .can_resume_to(&TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256)
-        );
-        assert!(
-            TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-                .can_resume_to(&TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256)
+            TLS13_AES_256_GCM_SHA384
+                .tls13()
+                .unwrap()
+                .can_resume_from(TLS13_CHACHA20_POLY1305_SHA256)
+                .is_none()
         );
     }
 }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -91,7 +91,11 @@ impl fmt::Debug for Tls13CipherSuite {
     }
 }
 
-pub(crate) struct Tls12Parameters {
+/// A TLS 1.2 cipher suite supported by rustls.
+pub struct Tls12CipherSuite {
+    /// Common cipher suite fields.
+    pub common: CipherSuiteCommon,
+    pub(crate) hmac_algorithm: ring::hmac::Algorithm,
     /// How to exchange/agree keys.
     pub kx: KeyExchangeAlgorithm,
 
@@ -110,15 +114,7 @@ pub(crate) struct Tls12Parameters {
     /// chacha20poly1305 works this way by design.
     pub explicit_nonce_len: usize,
 
-    pub aead_alg: &'static dyn Tls12AeadAlgorithm,
-}
-
-/// A TLS 1.2 cipher suite supported by rustls.
-pub struct Tls12CipherSuite {
-    /// Common cipher suite fields.
-    pub common: CipherSuiteCommon,
-    pub(crate) params: Tls12Parameters,
-    pub(crate) hmac_algorithm: ring::hmac::Algorithm,
+    pub(crate) aead_alg: &'static dyn Tls12AeadAlgorithm,
 }
 
 impl Tls12CipherSuite {
@@ -126,8 +122,7 @@ impl Tls12CipherSuite {
     /// offered `SupportedSignatureSchemes`.  If we return an empty
     /// set, the handshake terminates.
     pub fn resolve_sig_schemes(&self, offered: &[SignatureScheme]) -> Vec<SignatureScheme> {
-        self.params
-            .sign
+        self.sign
             .iter()
             .filter(|pref| offered.contains(pref))
             .cloned()
@@ -203,7 +198,6 @@ impl SupportedCipherSuite {
         match self {
             SupportedCipherSuite::Tls13(_) => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
             SupportedCipherSuite::Tls12(inner) => inner
-                .params
                 .sign
                 .iter()
                 .any(|scheme| scheme.sign() == sigalg),
@@ -235,13 +229,11 @@ pub static TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             bulk: BulkAlgorithm::Chacha20Poly1305,
             aead_algorithm: &ring::aead::CHACHA20_POLY1305,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_ECDSA_SCHEMES,
-            fixed_iv_len: 12,
-            explicit_nonce_len: 0,
-            aead_alg: &cipher::ChaCha20Poly1305,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_ECDSA_SCHEMES,
+        fixed_iv_len: 12,
+        explicit_nonce_len: 0,
+        aead_alg: &cipher::ChaCha20Poly1305,
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
 
@@ -253,13 +245,11 @@ pub static TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite =
             bulk: BulkAlgorithm::Chacha20Poly1305,
             aead_algorithm: &ring::aead::CHACHA20_POLY1305,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_RSA_SCHEMES,
-            fixed_iv_len: 12,
-            explicit_nonce_len: 0,
-            aead_alg: &cipher::ChaCha20Poly1305,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_RSA_SCHEMES,
+        fixed_iv_len: 12,
+        explicit_nonce_len: 0,
+        aead_alg: &cipher::ChaCha20Poly1305,
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
 
@@ -271,13 +261,11 @@ pub static TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             bulk: BulkAlgorithm::Aes128Gcm,
             aead_algorithm: &ring::aead::AES_128_GCM,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_RSA_SCHEMES,
-            fixed_iv_len: 4,
-            explicit_nonce_len: 8,
-            aead_alg: &cipher::AesGcm,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_RSA_SCHEMES,
+        fixed_iv_len: 4,
+        explicit_nonce_len: 8,
+        aead_alg: &cipher::AesGcm,
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
 
@@ -289,13 +277,11 @@ pub static TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             bulk: BulkAlgorithm::Aes256Gcm,
             aead_algorithm: &ring::aead::AES_256_GCM,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_RSA_SCHEMES,
-            fixed_iv_len: 4,
-            explicit_nonce_len: 8,
-            aead_alg: &cipher::AesGcm,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_RSA_SCHEMES,
+        fixed_iv_len: 4,
+        explicit_nonce_len: 8,
+        aead_alg: &cipher::AesGcm,
         hmac_algorithm: ring::hmac::HMAC_SHA384,
     });
 
@@ -307,13 +293,11 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite =
             bulk: BulkAlgorithm::Aes128Gcm,
             aead_algorithm: &ring::aead::AES_128_GCM,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_ECDSA_SCHEMES,
-            fixed_iv_len: 4,
-            explicit_nonce_len: 8,
-            aead_alg: &cipher::AesGcm,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_ECDSA_SCHEMES,
+        fixed_iv_len: 4,
+        explicit_nonce_len: 8,
+        aead_alg: &cipher::AesGcm,
         hmac_algorithm: ring::hmac::HMAC_SHA256,
     });
 
@@ -325,13 +309,11 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite =
             bulk: BulkAlgorithm::Aes256Gcm,
             aead_algorithm: &ring::aead::AES_256_GCM,
         },
-        params: Tls12Parameters {
-            kx: KeyExchangeAlgorithm::ECDHE,
-            sign: TLS12_ECDSA_SCHEMES,
-            fixed_iv_len: 4,
-            explicit_nonce_len: 8,
-            aead_alg: &cipher::AesGcm,
-        },
+        kx: KeyExchangeAlgorithm::ECDHE,
+        sign: TLS12_ECDSA_SCHEMES,
+        fixed_iv_len: 4,
+        explicit_nonce_len: 8,
+        aead_alg: &cipher::AesGcm,
         hmac_algorithm: ring::hmac::HMAC_SHA384,
     });
 

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -197,7 +197,7 @@ fn config_builder_for_client_rejects_empty_cipher_suites() {
 #[test]
 fn config_builder_for_client_rejects_incompatible_cipher_suites() {
     assert_eq!(
-        ConfigBuilder::with_cipher_suites(&[&rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+        ConfigBuilder::with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .for_client()
@@ -233,7 +233,7 @@ fn config_builder_for_server_rejects_empty_cipher_suites() {
 #[test]
 fn config_builder_for_server_rejects_incompatible_cipher_suites() {
     assert_eq!(
-        ConfigBuilder::with_cipher_suites(&[&rustls::cipher_suite::TLS13_AES_256_GCM_SHA384])
+        ConfigBuilder::with_cipher_suites(&[rustls::cipher_suite::TLS13_AES_256_GCM_SHA384.into()])
             .with_safe_default_kx_groups()
             .with_protocol_versions(&[&rustls::version::TLS12])
             .for_server()
@@ -2175,12 +2175,13 @@ fn test_tls13_exporter() {
 fn do_suite_test(
     client_config: ClientConfig,
     server_config: ServerConfig,
-    expect_suite: &'static SupportedCipherSuite,
+    expect_suite: SupportedCipherSuite,
     expect_version: ProtocolVersion,
 ) {
     println!(
         "do_suite_test {:?} {:?}",
-        expect_version, expect_suite.suite
+        expect_version,
+        expect_suite.suite()
     );
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
@@ -2220,9 +2221,9 @@ fn do_suite_test(
     assert_eq!(Some(expect_suite), server.negotiated_cipher_suite());
 }
 
-fn find_suite(suite: CipherSuite) -> &'static SupportedCipherSuite {
-    for scs in ALL_CIPHERSUITES.iter() {
-        if scs.suite == suite {
+fn find_suite(suite: CipherSuite) -> SupportedCipherSuite {
+    for scs in ALL_CIPHERSUITES.iter().copied() {
+        if scs.suite() == suite {
             return scs;
         }
     }


### PR DESCRIPTION
Here's an attempt at splitting up the `SupportedCipherSuite` type to make it more obvious which version is being used. This eliminates the need for unwrapping to get at the TLS 1.2-specific type. I also changed the TLS 1.2 encrypter/decrypter setup because I ran into an issue with a bug in rustc (fixed on nightly) to use a trait object instead of function references. I think this maintains link-time dead code elimination, but could use some guidance on how to test for this.

If this is merged, we could consider configuring versions by splitting `cipher_suites` in `tls13_cipher_suites` and `tls12_cipher_suites` (and adding an appropriate builder stage). This seems like an improvement to me since it removes the redundant state between cipher suites and protocol versions.