### PR TITLE
Incrase MSRV to 1.52.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0 # our MSRV
+          - 1.52.1 # MSRV as recommend by https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html
         os: [ubuntu-18.04]
         # but only stable on macos/windows (slower platforms)
         include:


### PR DESCRIPTION
https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html recommends using
1.52.1 or later due to compiler bugs in all earlier versions. Stop
trying to support older versions.