### PR TITLE
Use type state to avoid unwrapping in key schedules

### DIFF
--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2439,8 +2439,8 @@ fn key_log_for_tls13() {
     assert_eq!("EXPORTER_SECRET", client_full_log[3].label);
     assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_full_log[4].label);
 
-    assert_eq!(client_full_log[0], server_full_log[1]);
-    assert_eq!(client_full_log[1], server_full_log[0]);
+    assert_eq!(client_full_log[0], server_full_log[0]);
+    assert_eq!(client_full_log[1], server_full_log[1]);
     assert_eq!(client_full_log[2], server_full_log[2]);
     assert_eq!(client_full_log[3], server_full_log[3]);
     assert_eq!(client_full_log[4], server_full_log[4]);
@@ -2465,8 +2465,8 @@ fn key_log_for_tls13() {
     assert_eq!("EXPORTER_SECRET", client_resume_log[3].label);
     assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_resume_log[4].label);
 
-    assert_eq!(client_resume_log[0], server_resume_log[1]);
-    assert_eq!(client_resume_log[1], server_resume_log[0]);
+    assert_eq!(client_resume_log[0], server_resume_log[0]);
+    assert_eq!(client_resume_log[1], server_resume_log[1]);
     assert_eq!(client_resume_log[2], server_resume_log[2]);
     assert_eq!(client_resume_log[3], server_resume_log[3]);
     assert_eq!(client_resume_log[4], server_resume_log[4]);

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -2435,9 +2435,9 @@ fn key_log_for_tls13() {
     assert_eq!(5, client_full_log.len());
     assert_eq!("CLIENT_HANDSHAKE_TRAFFIC_SECRET", client_full_log[0].label);
     assert_eq!("SERVER_HANDSHAKE_TRAFFIC_SECRET", client_full_log[1].label);
-    assert_eq!("SERVER_TRAFFIC_SECRET_0", client_full_log[2].label);
-    assert_eq!("EXPORTER_SECRET", client_full_log[3].label);
-    assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_full_log[4].label);
+    assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_full_log[2].label);
+    assert_eq!("SERVER_TRAFFIC_SECRET_0", client_full_log[3].label);
+    assert_eq!("EXPORTER_SECRET", client_full_log[4].label);
 
     assert_eq!(client_full_log[0], server_full_log[0]);
     assert_eq!(client_full_log[1], server_full_log[1]);
@@ -2461,9 +2461,9 @@ fn key_log_for_tls13() {
         "SERVER_HANDSHAKE_TRAFFIC_SECRET",
         client_resume_log[1].label
     );
-    assert_eq!("SERVER_TRAFFIC_SECRET_0", client_resume_log[2].label);
-    assert_eq!("EXPORTER_SECRET", client_resume_log[3].label);
-    assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_resume_log[4].label);
+    assert_eq!("CLIENT_TRAFFIC_SECRET_0", client_resume_log[2].label);
+    assert_eq!("SERVER_TRAFFIC_SECRET_0", client_resume_log[3].label);
+    assert_eq!("EXPORTER_SECRET", client_resume_log[4].label);
 
     assert_eq!(client_resume_log[0], server_resume_log[0]);
     assert_eq!(client_resume_log[1], server_resume_log[1]);


### PR DESCRIPTION
Removes 5 unwrap() calls and 100 lines of code.