### PR TITLE
Require more precise visibility by denying unreachable_pub

### DIFF
--- a/rustls/src/anchors.rs
+++ b/rustls/src/anchors.rs
@@ -1,7 +1,7 @@
 use crate::key;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace};
-pub use crate::msgs::handshake::{DistinguishedName, DistinguishedNames};
+use crate::msgs::handshake::{DistinguishedName, DistinguishedNames};
 use crate::x509;
 
 /// This is like a `webpki::TrustAnchor`, except it owns

--- a/rustls/src/bs_debug.rs
+++ b/rustls/src/bs_debug.rs
@@ -10,7 +10,7 @@ use std::fmt;
 /// This struct wraps `&[u8]` just to override `fmt::Debug`.
 ///
 /// `BsDebug` is not a part of public API of bytes crate.
-pub struct BsDebug<'a>(pub &'a [u8]);
+pub(crate) struct BsDebug<'a>(pub(crate) &'a [u8]);
 
 impl<'a> fmt::Debug for BsDebug<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/rustls/src/check.rs
+++ b/rustls/src/check.rs
@@ -47,7 +47,7 @@ macro_rules! require_handshake_msg_move(
 /// - the type of m does not appear in `content_types`.
 /// - if m is a handshake message, the handshake message type does
 ///   not appear in `handshake_types`.
-pub fn check_message(
+pub(crate) fn check_message(
     m: &Message,
     content_types: &[ContentType],
     handshake_types: &[HandshakeType],
@@ -65,7 +65,7 @@ pub fn check_message(
     Ok(())
 }
 
-pub fn inappropriate_message(m: &Message, content_types: &[ContentType]) -> Error {
+pub(crate) fn inappropriate_message(m: &Message, content_types: &[ContentType]) -> Error {
     warn!(
         "Received a {:?} message while expecting {:?}",
         m.payload.content_type(),
@@ -77,7 +77,7 @@ pub fn inappropriate_message(m: &Message, content_types: &[ContentType]) -> Erro
     }
 }
 
-pub fn inappropriate_handshake_message(
+pub(crate) fn inappropriate_handshake_message(
     hsp: &HandshakeMessagePayload,
     handshake_types: &[HandshakeType],
 ) -> Error {

--- a/rustls/src/client/common.rs
+++ b/rustls/src/client/common.rs
@@ -9,14 +9,14 @@ use crate::sign;
 
 use std::sync::Arc;
 
-pub struct ServerCertDetails {
-    pub cert_chain: CertificatePayload,
-    pub ocsp_response: Vec<u8>,
-    pub scts: Option<SCTList>,
+pub(super) struct ServerCertDetails {
+    pub(super) cert_chain: CertificatePayload,
+    pub(super) ocsp_response: Vec<u8>,
+    pub(super) scts: Option<SCTList>,
 }
 
 impl ServerCertDetails {
-    pub fn new(
+    pub(super) fn new(
         cert_chain: CertificatePayload,
         ocsp_response: Vec<u8>,
         scts: Option<SCTList>,
@@ -28,7 +28,7 @@ impl ServerCertDetails {
         }
     }
 
-    pub fn scts(&self) -> impl Iterator<Item = &[u8]> {
+    pub(super) fn scts(&self) -> impl Iterator<Item = &[u8]> {
         self.scts
             .as_deref()
             .unwrap_or(&[])
@@ -37,13 +37,13 @@ impl ServerCertDetails {
     }
 }
 
-pub struct ServerKxDetails {
-    pub kx_params: Vec<u8>,
-    pub kx_sig: DigitallySignedStruct,
+pub(super) struct ServerKxDetails {
+    pub(super) kx_params: Vec<u8>,
+    pub(super) kx_sig: DigitallySignedStruct,
 }
 
 impl ServerKxDetails {
-    pub fn new(params: Vec<u8>, sig: DigitallySignedStruct) -> ServerKxDetails {
+    pub(super) fn new(params: Vec<u8>, sig: DigitallySignedStruct) -> ServerKxDetails {
         ServerKxDetails {
             kx_params: params,
             kx_sig: sig,
@@ -51,23 +51,23 @@ impl ServerKxDetails {
     }
 }
 
-pub struct ClientHelloDetails {
-    pub sent_extensions: Vec<ExtensionType>,
+pub(super) struct ClientHelloDetails {
+    pub(super) sent_extensions: Vec<ExtensionType>,
 }
 
 impl ClientHelloDetails {
-    pub fn new() -> ClientHelloDetails {
+    pub(super) fn new() -> ClientHelloDetails {
         ClientHelloDetails {
             sent_extensions: Vec::new(),
         }
     }
 
-    pub fn server_may_send_sct_list(&self) -> bool {
+    pub(super) fn server_may_send_sct_list(&self) -> bool {
         self.sent_extensions
             .contains(&ExtensionType::SCT)
     }
 
-    pub fn server_sent_unsolicited_extensions(
+    pub(super) fn server_sent_unsolicited_extensions(
         &self,
         received_exts: &[ServerExtension],
         allowed_unsolicited: &[ExtensionType],
@@ -85,17 +85,17 @@ impl ClientHelloDetails {
     }
 }
 
-pub struct ReceivedTicketDetails {
-    pub new_ticket: Vec<u8>,
-    pub new_ticket_lifetime: u32,
+pub(super) struct ReceivedTicketDetails {
+    pub(super) new_ticket: Vec<u8>,
+    pub(super) new_ticket_lifetime: u32,
 }
 
 impl ReceivedTicketDetails {
-    pub fn new() -> ReceivedTicketDetails {
+    pub(super) fn new() -> ReceivedTicketDetails {
         ReceivedTicketDetails::from(Vec::new(), 0)
     }
 
-    pub fn from(ticket: Vec<u8>, lifetime: u32) -> ReceivedTicketDetails {
+    pub(super) fn from(ticket: Vec<u8>, lifetime: u32) -> ReceivedTicketDetails {
         ReceivedTicketDetails {
             new_ticket: ticket,
             new_ticket_lifetime: lifetime,
@@ -103,14 +103,14 @@ impl ReceivedTicketDetails {
     }
 }
 
-pub struct ClientAuthDetails {
-    pub certkey: Option<Arc<sign::CertifiedKey>>,
-    pub signer: Option<Box<dyn sign::Signer>>,
-    pub auth_context: Option<Vec<u8>>,
+pub(super) struct ClientAuthDetails {
+    pub(super) certkey: Option<Arc<sign::CertifiedKey>>,
+    pub(super) signer: Option<Box<dyn sign::Signer>>,
+    pub(super) auth_context: Option<Vec<u8>>,
 }
 
 impl ClientAuthDetails {
-    pub fn new() -> ClientAuthDetails {
+    pub(super) fn new() -> ClientAuthDetails {
         ClientAuthDetails {
             certkey: None,
             signer: None,

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -56,7 +56,7 @@ impl client::StoresClientSessions for ClientSessionMemoryCache {
     }
 }
 
-pub struct FailResolveClientCert {}
+pub(super) struct FailResolveClientCert {}
 
 impl client::ResolvesClientCert for FailResolveClientCert {
     fn resolve(
@@ -72,10 +72,10 @@ impl client::ResolvesClientCert for FailResolveClientCert {
     }
 }
 
-pub struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
+pub(super) struct AlwaysResolvesClientCert(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesClientCert {
-    pub fn new(
+    pub(super) fn new(
         chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesClientCert, Error> {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -474,7 +474,7 @@ pub(super) fn process_alpn_protocol(
     Ok(())
 }
 
-pub fn sct_list_is_invalid(scts: &SCTList) -> bool {
+pub(super) fn sct_list_is_invalid(scts: &SCTList) -> bool {
     scts.is_empty() || scts.iter().any(|sct| sct.0.is_empty())
 }
 

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -27,9 +27,9 @@ use std::sync::Arc;
 
 #[macro_use]
 mod hs;
-pub mod builder;
+pub(super) mod builder;
 mod common;
-pub mod handy;
+pub(super) mod handy;
 mod tls12;
 mod tls13;
 
@@ -243,7 +243,7 @@ impl TryFrom<&str> for ServerName {
 
 /// Container for unsafe APIs
 #[cfg(feature = "dangerous_configuration")]
-pub mod danger {
+pub(super) mod danger {
     use std::sync::Arc;
 
     use super::verify::ServerCertVerifier;
@@ -272,7 +272,7 @@ enum EarlyDataState {
     Rejected,
 }
 
-pub struct EarlyData {
+pub(super) struct EarlyData {
     state: EarlyDataState,
     left: usize,
 }

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -40,13 +40,14 @@ mod server_hello {
     use super::*;
 
     pub(in crate::client) struct CompleteServerHelloHandling {
-        pub config: Arc<ClientConfig>,
-        pub resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
-        pub server_name: ServerName,
-        pub randoms: ConnectionRandoms,
-        pub using_ems: bool,
-        pub transcript: HandshakeHash,
-        pub session_id: SessionID,
+        pub(in crate::client) config: Arc<ClientConfig>,
+        pub(in crate::client) resuming_session:
+            Option<persist::ClientSessionValueWithResolvedCipherSuite>,
+        pub(in crate::client) server_name: ServerName,
+        pub(in crate::client) randoms: ConnectionRandoms,
+        pub(in crate::client) using_ems: bool,
+        pub(in crate::client) transcript: HandshakeHash,
+        pub(in crate::client) session_id: SessionID,
     }
 
     impl CompleteServerHelloHandling {
@@ -846,7 +847,7 @@ impl hs::State for ExpectServerDone {
     }
 }
 
-pub struct ExpectNewTicket {
+struct ExpectNewTicket {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,
@@ -890,7 +891,7 @@ impl hs::State for ExpectNewTicket {
 }
 
 // -- Waiting for their CCS --
-pub struct ExpectCcs {
+struct ExpectCcs {
     config: Arc<ClientConfig>,
     secrets: ConnectionSecrets,
     resuming_session: Option<persist::ClientSessionValueWithResolvedCipherSuite>,

--- a/rustls/src/client/tls13.rs
+++ b/rustls/src/client/tls13.rs
@@ -328,7 +328,7 @@ pub(super) fn derive_early_traffic_secret(
     trace!("Starting early data traffic");
 }
 
-pub fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut ConnectionCommon) {
+pub(super) fn emit_fake_ccs(sent_tls13_fake_ccs: &mut bool, common: &mut ConnectionCommon) {
     if common.is_quic() {
         return;
     }
@@ -1134,7 +1134,7 @@ impl hs::State for ExpectTraffic {
 }
 
 #[cfg(feature = "quic")]
-pub struct ExpectQuicTraffic(ExpectTraffic);
+struct ExpectQuicTraffic(ExpectTraffic);
 
 #[cfg(feature = "quic")]
 impl hs::State for ExpectQuicTraffic {

--- a/rustls/src/hash_hs.rs
+++ b/rustls/src/hash_hs.rs
@@ -15,7 +15,7 @@ pub(crate) struct HandshakeHashBuffer {
 }
 
 impl HandshakeHashBuffer {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             buffer: Vec::new(),
             client_auth_enabled: false,
@@ -24,12 +24,12 @@ impl HandshakeHashBuffer {
 
     /// We might be doing client auth, so need to keep a full
     /// log of the handshake.
-    pub fn set_client_auth_enabled(&mut self) {
+    pub(crate) fn set_client_auth_enabled(&mut self) {
         self.client_auth_enabled = true;
     }
 
     /// Hash/buffer a handshake message.
-    pub fn add_message(&mut self, m: &Message) {
+    pub(crate) fn add_message(&mut self, m: &Message) {
         if let MessagePayload::Handshake(hs) = &m.payload {
             self.buffer
                 .extend_from_slice(&hs.get_encoding());
@@ -43,7 +43,11 @@ impl HandshakeHashBuffer {
     }
 
     /// Get the hash value if we were to hash `extra` too.
-    pub fn get_hash_given(&self, hash: &'static digest::Algorithm, extra: &[u8]) -> digest::Digest {
+    pub(crate) fn get_hash_given(
+        &self,
+        hash: &'static digest::Algorithm,
+        extra: &[u8],
+    ) -> digest::Digest {
         let mut ctx = digest::Context::new(hash);
         ctx.update(&self.buffer);
         ctx.update(extra);
@@ -87,7 +91,7 @@ impl HandshakeHash {
     }
 
     /// Hash/buffer a handshake message.
-    pub fn add_message(&mut self, m: &Message) -> &mut HandshakeHash {
+    pub(crate) fn add_message(&mut self, m: &Message) -> &mut HandshakeHash {
         if let MessagePayload::Handshake(hs) = &m.payload {
             let buf = hs.get_encoding();
             self.update_raw(&buf);
@@ -108,7 +112,7 @@ impl HandshakeHash {
 
     /// Get the hash value if we were to hash `extra` too,
     /// using hash function `hash`.
-    pub fn get_hash_given(&self, extra: &[u8]) -> digest::Digest {
+    pub(crate) fn get_hash_given(&self, extra: &[u8]) -> digest::Digest {
         let mut ctx = self.ctx.clone();
         ctx.update(extra);
         ctx.finish()
@@ -128,7 +132,7 @@ impl HandshakeHash {
     /// Take the current hash value, and encapsulate it in a
     /// 'handshake_hash' handshake message.  Start this hash
     /// again, with that message at the front.
-    pub fn rollup_for_hrr(&mut self) {
+    pub(crate) fn rollup_for_hrr(&mut self) {
         let ctx = &mut self.ctx;
 
         let old_ctx = mem::replace(ctx, digest::Context::new(ctx.algorithm()));
@@ -140,19 +144,19 @@ impl HandshakeHash {
     }
 
     /// Get the current hash value.
-    pub fn get_current_hash(&self) -> digest::Digest {
+    pub(crate) fn get_current_hash(&self) -> digest::Digest {
         self.ctx.clone().finish()
     }
 
     /// Takes this object's buffer containing all handshake messages
     /// so far.  This method only works once; it resets the buffer
     /// to empty.
-    pub fn take_handshake_buf(&mut self) -> Option<Vec<u8>> {
+    pub(crate) fn take_handshake_buf(&mut self) -> Option<Vec<u8>> {
         self.client_auth.take()
     }
 
     /// The digest algorithm
-    pub fn algorithm(&self) -> &'static digest::Algorithm {
+    pub(crate) fn algorithm(&self) -> &'static digest::Algorithm {
         self.ctx.algorithm()
     }
 }

--- a/rustls/src/kx.rs
+++ b/rustls/src/kx.rs
@@ -3,22 +3,22 @@ use crate::msgs::enums::NamedGroup;
 /// The result of a key exchange.  This has our public key,
 /// and the agreed shared secret (also known as the "premaster secret"
 /// in TLS1.0-era protocols, and "Z" in TLS1.3).
-pub struct KeyExchangeResult {
-    pub pubkey: ring::agreement::PublicKey,
-    pub shared_secret: Vec<u8>,
+pub(crate) struct KeyExchangeResult {
+    pub(crate) pubkey: ring::agreement::PublicKey,
+    pub(crate) shared_secret: Vec<u8>,
 }
 
 /// An in-progress key exchange.  This has the algorithm,
 /// our private key, and our public key.
-pub struct KeyExchange {
+pub(crate) struct KeyExchange {
     skxg: &'static SupportedKxGroup,
     privkey: ring::agreement::EphemeralPrivateKey,
-    pub pubkey: ring::agreement::PublicKey,
+    pub(crate) pubkey: ring::agreement::PublicKey,
 }
 
 impl KeyExchange {
     /// Choose a SupportedKxGroup by name, from a list of supported groups.
-    pub fn choose(
+    pub(crate) fn choose(
         name: NamedGroup,
         supported: &[&'static SupportedKxGroup],
     ) -> Option<&'static SupportedKxGroup> {
@@ -31,7 +31,7 @@ impl KeyExchange {
     /// Start a key exchange, using the given SupportedKxGroup.
     ///
     /// This generates an ephemeral key pair and stores it in the returned KeyExchange object.
-    pub fn start(skxg: &'static SupportedKxGroup) -> Option<KeyExchange> {
+    pub(crate) fn start(skxg: &'static SupportedKxGroup) -> Option<KeyExchange> {
         let rng = ring::rand::SystemRandom::new();
         let ours =
             ring::agreement::EphemeralPrivateKey::generate(skxg.agreement_algorithm, &rng).ok()?;
@@ -46,13 +46,13 @@ impl KeyExchange {
     }
 
     /// Return the group being used.
-    pub fn group(&self) -> NamedGroup {
+    pub(crate) fn group(&self) -> NamedGroup {
         self.skxg.name
     }
 
     /// Completes the key exchange, given the peer's public key.  The shared
     /// secret is returned as a KeyExchangeResult.
-    pub fn complete(self, peer: &[u8]) -> Option<KeyExchangeResult> {
+    pub(crate) fn complete(self, peer: &[u8]) -> Option<KeyExchangeResult> {
         let peer_key = ring::agreement::UnparsedPublicKey::new(self.skxg.agreement_algorithm, peer);
         let pubkey = self.pubkey;
         ring::agreement::agree_ephemeral(self.privkey, &peer_key, (), move |v| {

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -214,6 +214,7 @@
     trivial_casts,
     trivial_numeric_casts,
     missing_docs,
+    unreachable_pub,
     unused_import_braces,
     unused_extern_crates,
     unused_qualifications
@@ -294,7 +295,7 @@ pub mod internal {
 }
 
 // The public interface is:
-pub use crate::anchors::{DistinguishedNames, OwnedTrustAnchor, RootCertStore};
+pub use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 pub use crate::builder::{
     ConfigBuilder, ConfigBuilderWithKxGroups, ConfigBuilderWithSuites, ConfigBuilderWithVersions,
 };
@@ -312,6 +313,7 @@ pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
 pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
+pub use crate::msgs::handshake::DistinguishedNames;
 pub use crate::server::builder::{ServerConfigBuilder, ServerConfigBuilderWithClientAuth};
 pub use crate::server::handy::ResolvesServerCertUsingSni;
 pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};

--- a/rustls/src/limited_cache.rs
+++ b/rustls/src/limited_cache.rs
@@ -11,7 +11,7 @@ use std::hash::Hash;
 /// storage.
 ///
 /// This is inefficient: it stores keys twice.
-pub struct LimitedCache<K: Clone + Hash + Eq, V> {
+pub(crate) struct LimitedCache<K: Clone + Hash + Eq, V> {
     map: HashMap<K, V>,
 
     // first item is the oldest key
@@ -23,14 +23,14 @@ where
     K: Eq + Hash + Clone + std::fmt::Debug,
 {
     /// Create a new LimitedCache with the given rough capacity.
-    pub fn new(capacity_order_of_magnitude: usize) -> LimitedCache<K, V> {
+    pub(crate) fn new(capacity_order_of_magnitude: usize) -> LimitedCache<K, V> {
         LimitedCache {
             map: HashMap::with_capacity(capacity_order_of_magnitude),
             oldest: VecDeque::with_capacity(capacity_order_of_magnitude),
         }
     }
 
-    pub fn insert(&mut self, k: K, v: V) {
+    pub(crate) fn insert(&mut self, k: K, v: V) {
         let inserted_new_item = match self.map.entry(k) {
             Entry::Occupied(mut old) => {
                 // nb. does not freshen entry in `oldest`
@@ -54,7 +54,7 @@ where
         }
     }
 
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub(crate) fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
@@ -62,7 +62,7 @@ where
         self.map.get(k)
     }
 
-    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
+    pub(crate) fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,

--- a/rustls/src/prf.rs
+++ b/rustls/src/prf.rs
@@ -30,7 +30,7 @@ fn concat(a: &[u8], b: &[u8]) -> Vec<u8> {
     ret
 }
 
-pub fn prf(out: &mut [u8], alg: hmac::Algorithm, secret: &[u8], label: &[u8], seed: &[u8]) {
+pub(crate) fn prf(out: &mut [u8], alg: hmac::Algorithm, secret: &[u8], label: &[u8], seed: &[u8]) {
     let joined_seed = concat(label, seed);
     p(out, alg, secret, &joined_seed);
 }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -15,9 +15,9 @@ use ring::{aead, hkdf};
 #[derive(Clone, Debug)]
 pub(crate) struct Secrets {
     /// Secret used to encrypt packets transmitted by the client
-    pub client: hkdf::Prk,
+    pub(crate) client: hkdf::Prk,
     /// Secret used to encrypt packets transmitted by the server
-    pub server: hkdf::Prk,
+    pub(crate) server: hkdf::Prk,
 }
 
 impl Secrets {

--- a/rustls/src/rand.rs
+++ b/rustls/src/rand.rs
@@ -5,7 +5,7 @@ use crate::msgs::codec;
 use ring::rand::{SecureRandom, SystemRandom};
 
 /// Fill the whole slice with random material.
-pub fn fill_random(bytes: &mut [u8]) -> Result<(), GetRandomFailed> {
+pub(crate) fn fill_random(bytes: &mut [u8]) -> Result<(), GetRandomFailed> {
     SystemRandom::new()
         .fill(bytes)
         .map_err(|_| GetRandomFailed)
@@ -13,14 +13,14 @@ pub fn fill_random(bytes: &mut [u8]) -> Result<(), GetRandomFailed> {
 
 /// Make a Vec<u8> of the given size
 /// containing random material.
-pub fn random_vec(len: usize) -> Result<Vec<u8>, GetRandomFailed> {
+pub(crate) fn random_vec(len: usize) -> Result<Vec<u8>, GetRandomFailed> {
     let mut v = vec![0; len];
     fill_random(&mut v)?;
     Ok(v)
 }
 
 /// Return a uniformly random u32.
-pub fn random_u32() -> Result<u32, GetRandomFailed> {
+pub(crate) fn random_u32() -> Result<u32, GetRandomFailed> {
     let mut buf = [0u8; 4];
     fill_random(&mut buf)?;
     codec::decode_u32(&buf).ok_or(GetRandomFailed)

--- a/rustls/src/server/common.rs
+++ b/rustls/src/server/common.rs
@@ -2,14 +2,14 @@ use crate::{key, sign};
 
 /// ActiveCertifiedKey wraps CertifiedKey and tracks OSCP and SCT state
 /// in a single handshake.
-pub struct ActiveCertifiedKey<'a> {
+pub(super) struct ActiveCertifiedKey<'a> {
     key: &'a sign::CertifiedKey,
     ocsp: Option<&'a [u8]>,
     sct_list: Option<&'a [u8]>,
 }
 
 impl<'a> ActiveCertifiedKey<'a> {
-    pub fn from_certified_key(key: &sign::CertifiedKey) -> ActiveCertifiedKey {
+    pub(super) fn from_certified_key(key: &sign::CertifiedKey) -> ActiveCertifiedKey {
         ActiveCertifiedKey {
             key,
             ocsp: key.ocsp.as_deref(),
@@ -19,23 +19,23 @@ impl<'a> ActiveCertifiedKey<'a> {
 
     /// Get the certificate chain
     #[inline]
-    pub fn get_cert(&self) -> &[key::Certificate] {
+    pub(super) fn get_cert(&self) -> &[key::Certificate] {
         &self.key.cert
     }
 
     /// Get the signing key
     #[inline]
-    pub fn get_key(&self) -> &dyn sign::SigningKey {
+    pub(super) fn get_key(&self) -> &dyn sign::SigningKey {
         &*self.key.key
     }
 
     #[inline]
-    pub fn get_ocsp(&self) -> Option<&[u8]> {
+    pub(super) fn get_ocsp(&self) -> Option<&[u8]> {
         self.ocsp
     }
 
     #[inline]
-    pub fn get_sct_list(&self) -> Option<&[u8]> {
+    pub(super) fn get_sct_list(&self) -> Option<&[u8]> {
         self.sct_list
     }
 }

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -64,7 +64,7 @@ impl server::StoresServerSessions for ServerSessionMemoryCache {
 }
 
 /// Something which never produces tickets.
-pub struct NeverProducesTickets {}
+pub(super) struct NeverProducesTickets {}
 
 impl server::ProducesTickets for NeverProducesTickets {
     fn enabled(&self) -> bool {
@@ -82,12 +82,12 @@ impl server::ProducesTickets for NeverProducesTickets {
 }
 
 /// Something which always resolves to the same cert chain.
-pub struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
+pub(super) struct AlwaysResolvesChain(Arc<sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
     /// Creates an `AlwaysResolvesChain`, auto-detecting the underlying private
     /// key type and encoding.
-    pub fn new(
+    pub(super) fn new(
         chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
     ) -> Result<AlwaysResolvesChain, Error> {
@@ -102,7 +102,7 @@ impl AlwaysResolvesChain {
     /// key type and encoding.
     ///
     /// If non-empty, the given OCSP response and SCTs are attached.
-    pub fn new_with_extras(
+    pub(super) fn new_with_extras(
         chain: Vec<key::Certificate>,
         priv_key: &key::PrivateKey,
         ocsp: Vec<u8>,

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -58,7 +58,7 @@ pub(super) struct ServerContext<'a> {
     pub(super) data: &'a mut ServerConnectionData,
 }
 
-pub fn incompatible(common: &mut ConnectionCommon, why: &str) -> Error {
+pub(super) fn incompatible(common: &mut ConnectionCommon, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::HandshakeFailure);
     Error::PeerIncompatibleError(why.to_string())
 }
@@ -68,12 +68,12 @@ fn bad_version(common: &mut ConnectionCommon, why: &str) -> Error {
     Error::PeerIncompatibleError(why.to_string())
 }
 
-pub fn decode_error(common: &mut ConnectionCommon, why: &str) -> Error {
+pub(super) fn decode_error(common: &mut ConnectionCommon, why: &str) -> Error {
     common.send_fatal_alert(AlertDescription::DecodeError);
     Error::PeerMisbehavedError(why.to_string())
 }
 
-pub fn can_resume(
+pub(super) fn can_resume(
     suite: SupportedCipherSuite,
     sni: &Option<webpki::DnsName>,
     using_ems: bool,
@@ -92,15 +92,15 @@ pub fn can_resume(
 }
 
 #[derive(Default)]
-pub struct ExtensionProcessing {
+pub(super) struct ExtensionProcessing {
     // extensions to reply with
-    pub exts: Vec<ServerExtension>,
+    pub(super) exts: Vec<ServerExtension>,
 
-    pub send_ticket: bool,
+    pub(super) send_ticket: bool,
 }
 
 impl ExtensionProcessing {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Default::default()
     }
 
@@ -266,17 +266,20 @@ impl ExtensionProcessing {
 }
 
 pub(super) struct ExpectClientHello {
-    pub config: Arc<ServerConfig>,
-    pub extra_exts: Vec<ServerExtension>,
-    pub transcript: HandshakeHashOrBuffer,
-    pub session_id: SessionID,
-    pub using_ems: bool,
-    pub done_retry: bool,
-    pub send_ticket: bool,
+    pub(super) config: Arc<ServerConfig>,
+    pub(super) extra_exts: Vec<ServerExtension>,
+    pub(super) transcript: HandshakeHashOrBuffer,
+    pub(super) session_id: SessionID,
+    pub(super) using_ems: bool,
+    pub(super) done_retry: bool,
+    pub(super) send_ticket: bool,
 }
 
 impl ExpectClientHello {
-    pub fn new(config: Arc<ServerConfig>, extra_exts: Vec<ServerExtension>) -> ExpectClientHello {
+    pub(super) fn new(
+        config: Arc<ServerConfig>,
+        extra_exts: Vec<ServerExtension>,
+    ) -> ExpectClientHello {
         let mut transcript_buffer = HandshakeHashBuffer::new();
 
         if config.verifier.offer_client_auth() {

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 
 #[macro_use]
 mod hs;
-pub mod builder;
+pub(crate) mod builder;
 mod common;
-pub mod handy;
+pub(crate) mod handy;
 mod tls12;
 mod tls13;
 

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -266,7 +266,7 @@ struct EcdsaSigningKey {
 impl EcdsaSigningKey {
     /// Make a new `ECDSASigningKey` from a DER encoding in PKCS#8 format,
     /// expecting a key usable with precisely the given signature scheme.
-    pub fn new(
+    fn new(
         der: &key::PrivateKey,
         scheme: SignatureScheme,
         sigalg: &'static signature::EcdsaSigningAlgorithm,
@@ -336,10 +336,7 @@ struct Ed25519SigningKey {
 impl Ed25519SigningKey {
     /// Make a new `Ed25519SigningKey` from a DER encoding in PKCS#8 format,
     /// expecting a key usable with precisely the given signature scheme.
-    pub fn new(
-        der: &key::PrivateKey,
-        scheme: SignatureScheme,
-    ) -> Result<Ed25519SigningKey, SignError> {
+    fn new(der: &key::PrivateKey, scheme: SignatureScheme) -> Result<Ed25519SigningKey, SignError> {
         Ed25519KeyPair::from_pkcs8_maybe_unchecked(&der.0)
             .map(|kp| Ed25519SigningKey {
                 key: Arc::new(kp),

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -374,7 +374,7 @@ pub static ALL_CIPHERSUITES: &[SupportedCipherSuite] = &[
 pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = ALL_CIPHERSUITES;
 
 // These both O(N^2)!
-pub fn choose_ciphersuite_preferring_client(
+pub(crate) fn choose_ciphersuite_preferring_client(
     client_suites: &[CipherSuite],
     server_suites: &[SupportedCipherSuite],
 ) -> Option<SupportedCipherSuite> {
@@ -390,7 +390,7 @@ pub fn choose_ciphersuite_preferring_client(
     None
 }
 
-pub fn choose_ciphersuite_preferring_server(
+pub(crate) fn choose_ciphersuite_preferring_server(
     client_suites: &[CipherSuite],
     server_suites: &[SupportedCipherSuite],
 ) -> Option<SupportedCipherSuite> {
@@ -406,7 +406,7 @@ pub fn choose_ciphersuite_preferring_server(
 
 /// Return a list of the ciphersuites in `all` with the suites
 /// incompatible with `SignatureAlgorithm` `sigalg` removed.
-pub fn reduce_given_sigalg(
+pub(crate) fn reduce_given_sigalg(
     all: &[SupportedCipherSuite],
     sigalg: SignatureAlgorithm,
 ) -> Vec<SupportedCipherSuite> {
@@ -418,7 +418,7 @@ pub fn reduce_given_sigalg(
 
 /// Return a list of the ciphersuites in `all` with the suites
 /// incompatible with the chosen `version` removed.
-pub fn reduce_given_version(
+pub(crate) fn reduce_given_version(
     all: &[SupportedCipherSuite],
     version: ProtocolVersion,
 ) -> Vec<SupportedCipherSuite> {
@@ -429,7 +429,7 @@ pub fn reduce_given_version(
 }
 
 /// Return true if `sigscheme` is usable by any of the given suites.
-pub fn compatible_sigscheme_for_suites(
+pub(crate) fn compatible_sigscheme_for_suites(
     sigscheme: SignatureScheme,
     common_suites: &[SupportedCipherSuite],
 ) -> bool {

--- a/rustls/src/ticketer.rs
+++ b/rustls/src/ticketer.rs
@@ -32,7 +32,7 @@ impl TimeBase {
 /// any *ring* `aead::Algorithm` to encrypt and authentication
 /// the ticket payload.  It does not enforce any lifetime
 /// constraint.
-pub struct AeadTicketer {
+struct AeadTicketer {
     alg: &'static aead::Algorithm,
     key: aead::LessSafeKey,
     lifetime: u32,
@@ -40,7 +40,7 @@ pub struct AeadTicketer {
 
 impl AeadTicketer {
     /// Make a ticketer with recommended configuration and a random key.
-    pub fn new() -> Result<AeadTicketer, rand::GetRandomFailed> {
+    fn new() -> Result<AeadTicketer, rand::GetRandomFailed> {
         let mut key = [0u8; 32];
         rand::fill_random(&mut key)?;
 

--- a/rustls/src/tls12.rs
+++ b/rustls/src/tls12.rs
@@ -4,7 +4,7 @@ use crate::msgs::codec::{Codec, Reader};
 use crate::msgs::enums::{AlertDescription, ContentType};
 use crate::Error;
 
-pub fn decode_ecdh_params<T: Codec>(
+pub(crate) fn decode_ecdh_params<T: Codec>(
     conn: &mut ConnectionCommon,
     kx_params: &[u8],
 ) -> Result<T, Error> {
@@ -23,7 +23,7 @@ fn decode_ecdh_params_<T: Codec>(kx_params: &[u8]) -> Option<T> {
     }
 }
 
-pub fn complete_ecdh(
+pub(crate) fn complete_ecdh(
     mine: kx::KeyExchange,
     peer_pub_key: &[u8],
 ) -> Result<kx::KeyExchangeResult, Error> {

--- a/rustls/src/verify.rs
+++ b/rustls/src/verify.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::anchors::OwnedTrustAnchor;
-use crate::anchors::{DistinguishedNames, RootCertStore};
+use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 use crate::client::ServerName;
 use crate::error::Error;
 use crate::error::WebPkiOp;
@@ -10,7 +9,7 @@ use crate::key::Certificate;
 #[cfg(feature = "logging")]
 use crate::log::{debug, trace, warn};
 use crate::msgs::enums::SignatureScheme;
-use crate::msgs::handshake::DigitallySignedStruct;
+use crate::msgs::handshake::{DigitallySignedStruct, DistinguishedNames};
 
 use ring::digest::Digest;
 use std::convert::TryFrom;
@@ -44,6 +43,7 @@ static SUPPORTED_SIG_ALGS: SignatureAlgorithms = &[
 /// means their origins can be precisely determined by looking
 /// for their `assertion` constructors.
 pub struct HandshakeSignatureValid(());
+
 impl HandshakeSignatureValid {
     /// Make a `HandshakeSignatureValid`
     pub fn assertion() -> Self {
@@ -51,15 +51,19 @@ impl HandshakeSignatureValid {
     }
 }
 
-pub struct FinishedMessageVerified(());
+pub(crate) struct FinishedMessageVerified(());
+
 impl FinishedMessageVerified {
-    pub fn assertion() -> Self {
+    pub(crate) fn assertion() -> Self {
         Self { 0: () }
     }
 }
 
 /// Zero-sized marker type representing verification of a server cert chain.
+#[allow(unreachable_pub)]
 pub struct ServerCertVerified(());
+
+#[allow(unreachable_pub)]
 impl ServerCertVerified {
     /// Make a `ServerCertVerified`
     pub fn assertion() -> Self {
@@ -78,6 +82,7 @@ impl ClientCertVerified {
 
 /// Something that can verify a server certificate chain, and verify
 /// signatures made by certificates.
+#[allow(unreachable_pub)]
 pub trait ServerCertVerifier: Send + Sync {
     /// Verify the end-entity certificate `end_entity` is valid for the
     /// hostname `dns_name` and chains to at least one trust anchor.
@@ -169,6 +174,7 @@ pub trait ServerCertVerifier: Send + Sync {
 }
 
 /// Something that can verify a client certificate chain
+#[allow(unreachable_pub)]
 pub trait ClientCertVerifier: Send + Sync {
     /// Returns `true` to enable the server to request a client certificate and
     /// `false` to skip requesting a client certificate. Defaults to `true`.
@@ -319,11 +325,13 @@ impl ServerCertVerifier for WebPkiVerifier {
 }
 
 /// Default `ServerCertVerifier`, see the trait impl for more information.
+#[allow(unreachable_pub)]
 pub struct WebPkiVerifier {
     roots: RootCertStore,
     ct_logs: &'static [&'static sct::Log<'static>],
 }
 
+#[allow(unreachable_pub)]
 impl WebPkiVerifier {
     /// Constructs a new `WebPkiVerifier`.
     ///
@@ -606,12 +614,12 @@ fn convert_alg_tls13(
 }
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
-pub fn construct_tls13_client_verify_message(handshake_hash: &Digest) -> Vec<u8> {
+pub(crate) fn construct_tls13_client_verify_message(handshake_hash: &Digest) -> Vec<u8> {
     construct_tls13_verify_message(handshake_hash, b"TLS 1.3, client CertificateVerify\x00")
 }
 
 /// Constructs the signature message specified in section 4.4.3 of RFC8446.
-pub fn construct_tls13_server_verify_message(handshake_hash: &Digest) -> Vec<u8> {
+pub(crate) fn construct_tls13_server_verify_message(handshake_hash: &Digest) -> Vec<u8> {
     construct_tls13_verify_message(handshake_hash, b"TLS 1.3, server CertificateVerify\x00")
 }
 

--- a/rustls/src/x509.rs
+++ b/rustls/src/x509.rs
@@ -20,7 +20,7 @@ fn wrap_in_asn1_len(bytes: &mut Vec<u8>) {
 }
 
 /// Prepend stuff to `bytes` to put it in a DER SEQUENCE.
-pub fn wrap_in_sequence(bytes: &mut Vec<u8>) {
+pub(crate) fn wrap_in_sequence(bytes: &mut Vec<u8>) {
     wrap_in_asn1_len(bytes);
     bytes.insert(0, der::Tag::Sequence as u8);
 }


### PR DESCRIPTION
Makes it more locally obvious what's part of the public API. Also make a number of items private where possible.