### PR TITLE
Improve accuracy of panic reductions in core library crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
     pass the end-entity and intermediate certificates separately.  This means rustls deals with the case
     where the certificate chain is empty, rather than leaving that to ServerCertVerifier/ClientCertVerifier
     implementation.
-  - There are now 40% fewer unreachable unwraps in the core crate thanks to large refactoring efforts.
+  - There are now 80% fewer unreachable unwraps in the core crate thanks to large refactoring efforts.
   - *Breaking API change*: the `WebPkiError` variant of `rustls::Error` now includes which operation failed.
   - *Breaking API changes*: These public API items have been renamed to meet naming guidelines:
     - `rustls::TLSError` to `rustls::Error`.


### PR DESCRIPTION
By my count, it has been reduced from 144 to 29 in non-test library
code in the rustls crate. (This was a somewhat manual count of
`unwrap()`, `panic!()` and `unreachable!()` calls.)

(I'm not sure how you got to the 40% number? It's from a while ago but wasn't accurate at the time, either. I think it probably includes unwrap calls in test code in library files?)