### PR TITLE
Make ClientConfigBuilder public

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 ///     .with_no_client_auth();
 /// ```
 ///
-/// # Resulting [`ConfigConfig`] defaults
+/// # Resulting [`ClientConfig`] defaults
 /// * [`ClientConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
 /// * [`ClientConfig::session_storage`]: the default stores 256 sessions in memory.
 /// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
@@ -77,6 +77,7 @@ impl ClientConfigBuilder {
     }
 
     #[cfg(feature = "dangerous_configuration")]
+    /// Set a custom certificate verifier.
     pub fn with_custom_certificate_verifier(
         self,
         verifier: Arc<dyn verify::ServerCertVerifier>,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -299,6 +299,7 @@ pub use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 pub use crate::builder::{
     ConfigBuilder, ConfigBuilderWithKxGroups, ConfigBuilderWithSuites, ConfigBuilderWithVersions,
 };
+pub use crate::client::builder::{ClientConfigBuilder, ClientConfigBuilderWithCertVerifier};
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::ServerName;


### PR DESCRIPTION
This was originally submitted as #735, but for some reason that is unclear to me, that was merged only to a branch in the origin rather than main.