### PR TITLE
Make verifier field of configs public

### DIFF
--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -132,7 +132,7 @@ pub struct ClientConfig {
     pub enable_sni: bool,
 
     /// How to verify the server certificate chain.
-    verifier: Arc<dyn verify::ServerCertVerifier>,
+    pub verifier: Arc<dyn verify::ServerCertVerifier>,
 
     /// How to output key material for debugging.  The default
     /// does nothing.

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -196,7 +196,7 @@ pub struct ServerConfig {
     pub versions: crate::versions::EnabledVersions,
 
     /// How to verify client certificates.
-    verifier: Arc<dyn verify::ClientCertVerifier>,
+    pub verifier: Arc<dyn verify::ClientCertVerifier>,
 
     /// How to output key material for debugging.  The default
     /// does nothing.


### PR DESCRIPTION
This matches the visibility of other fields on ServerConfig and ClientConfig.

Related to #758 