### PR TITLE
Rename builders from "With" to "Wants"

### DIFF
--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -1,20 +1,23 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 extern crate webpki;
 
-use rustls::{ConfigBuilder, ClientConnection, Connection, RootCertStore};
+use rustls::{config_builder_with_safe_defaults, ClientConnection, Connection, RootCertStore};
+use std::convert::TryInto;
 use std::io;
 use std::sync::Arc;
-use std::convert::TryInto;
 
 fuzz_target!(|data: &[u8]| {
     let root_store = RootCertStore::empty();
-    let config = Arc::new(ConfigBuilder::with_safe_defaults()
-        .for_client()
-        .unwrap()
-        .with_root_certificates(root_store, &[])
-        .with_no_client_auth());
+    let config = Arc::new(
+        config_builder_with_safe_defaults()
+            .for_client()
+            .unwrap()
+            .with_root_certificates(root_store, &[])
+            .with_no_client_auth(),
+    );
     let example_com = "example.com".try_into().unwrap();
     let mut client = ClientConnection::new(config, example_com).unwrap();
     let _ = client.read_tls(&mut io::Cursor::new(data));

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -1,25 +1,31 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{ConfigBuilder, ServerConnection, Connection, ResolvesServerCert};
+use rustls::{config_builder_with_safe_defaults, Connection, ResolvesServerCert, ServerConnection};
 use std::io;
 use std::sync::Arc;
 
 struct Fail;
 
 impl ResolvesServerCert for Fail {
-    fn resolve(&self, _client_hello: rustls::ClientHello) -> Option<Arc<rustls::sign::CertifiedKey>> {
+    fn resolve(
+        &self,
+        _client_hello: rustls::ClientHello,
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
         None
     }
 }
 
 fuzz_target!(|data: &[u8]| {
-    let config = Arc::new(ConfigBuilder::with_safe_defaults()
-                          .for_server()
-                          .unwrap()
-                          .with_no_client_auth()
-                          .with_cert_resolver(Arc::new(Fail)));
+    let config = Arc::new(
+        config_builder_with_safe_defaults()
+            .for_server()
+            .unwrap()
+            .with_no_client_auth()
+            .with_cert_resolver(Arc::new(Fail)),
+    );
     let mut server = ServerConnection::new(config).unwrap();
     let _ = server.read_tls(&mut io::Cursor::new(data));
 });

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -498,7 +498,8 @@ fn make_config(args: &Args) -> Arc<rustls::ClientConfig> {
         rustls::DEFAULT_VERSIONS.to_vec()
     };
 
-    let config = rustls::ConfigBuilder::with_cipher_suites(&suites)
+    let config = rustls::config_builder()
+        .with_cipher_suites(&suites)
         .with_safe_default_kx_groups()
         .with_protocol_versions(&versions)
         .for_client()

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -19,7 +19,7 @@ use docopt::Docopt;
 
 use env_logger;
 
-use rustls;
+use rustls::{self, config_builder};
 use rustls_pemfile;
 
 use rustls::{
@@ -598,7 +598,8 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     );
     let ocsp = load_ocsp(&args.flag_ocsp);
 
-    let mut config = rustls::ConfigBuilder::with_cipher_suites(&suites)
+    let mut config = config_builder()
+        .with_cipher_suites(&suites)
         .with_safe_default_kx_groups()
         .with_protocol_versions(&versions)
         .for_server()

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -11,8 +11,9 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rustls;
+use rustls::config_builder;
+use rustls::config_builder_with_safe_defaults;
 use rustls::ClientSessionMemoryCache;
-use rustls::ConfigBuilder;
 use rustls::Connection;
 use rustls::NoClientSessionStorage;
 use rustls::NoServerSessionStorage;
@@ -288,7 +289,7 @@ fn make_server_config(
         ClientAuth::No => NoClientAuth::new(),
     };
 
-    let mut cfg = ConfigBuilder::with_safe_defaults()
+    let mut cfg = config_builder_with_safe_defaults()
         .for_server()
         .unwrap()
         .with_client_cert_verifier(client_auth)
@@ -318,7 +319,8 @@ fn make_client_config(
         io::BufReader::new(fs::File::open(params.key_type.path_for("ca.cert")).unwrap());
     root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
-    let cfg = ConfigBuilder::with_cipher_suites(&[params.ciphersuite])
+    let cfg = config_builder()
+        .with_cipher_suites(&[params.ciphersuite])
         .with_safe_default_kx_groups()
         .with_protocol_versions(&[params.version])
         .for_client()

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -348,7 +348,8 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
         rustls::ALL_KX_GROUPS.to_vec()
     };
 
-    let mut cfg = rustls::ConfigBuilder::with_safe_default_cipher_suites()
+    let mut cfg = rustls::config_builder()
+        .with_safe_default_cipher_suites()
         .with_kx_groups(&kx_groups)
         .with_safe_default_protocol_versions()
         .for_server()
@@ -399,7 +400,6 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
             .enable(&rustls::version::TLS13);
     }
 
-
     Arc::new(cfg)
 }
 
@@ -428,7 +428,7 @@ impl rustls::StoresClientSessions for ClientCacheWithoutKxHints {
 }
 
 fn make_client_cfg(opts: &Options) -> Arc<rustls::ClientConfig> {
-    let cfg = rustls::ConfigBuilder::with_safe_defaults()
+    let cfg = rustls::config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_custom_certificate_verifier(Arc::new(DummyServerAuth {

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -4,9 +4,10 @@
 // See: https://github.com/HowNetWorks/trytls-rustls-stub
 //
 
+use rustls::config_builder_with_safe_defaults;
 use webpki_roots;
 
-use rustls::{ClientConfig, ClientConnection, ConfigBuilder, Connection, Error, RootCertStore};
+use rustls::{ClientConfig, ClientConnection, Connection, Error, RootCertStore};
 use std::convert::TryInto;
 use std::env;
 use std::error::Error as StdError;
@@ -36,7 +37,7 @@ fn parse_args(args: &[String]) -> Result<(String, u16, ClientConfig), Box<dyn St
             return Err(From::from("Incorrect number of arguments"));
         }
     };
-    let config = ConfigBuilder::with_safe_defaults()
+    let config = config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_root_certificates(root_store, &[])

--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -15,15 +15,14 @@ use rustls::Connection;
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
-    let config = rustls::ConfigBuilder::with_cipher_suites(&[
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256.into(),
-    ])
-    .with_kx_groups(&[&rustls::kx_group::X25519])
-    .with_protocol_versions(&[&rustls::version::TLS13])
-    .for_client()
-    .unwrap()
-    .with_root_certificates(root_store, &[])
-    .with_no_client_auth();
+    let config = rustls::config_builder()
+        .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256.into()])
+        .with_kx_groups(&[&rustls::kx_group::X25519])
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .for_client()
+        .unwrap()
+        .with_root_certificates(root_store, &[])
+        .with_no_client_auth();
 
     let server_name = "google.com".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();

--- a/rustls/examples/simple_0rtt_client.rs
+++ b/rustls/examples/simple_0rtt_client.rs
@@ -60,7 +60,7 @@ fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
 
-    let mut config = rustls::ConfigBuilder::with_safe_defaults()
+    let mut config = rustls::config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_root_certificates(root_store, &[])

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -21,7 +21,7 @@ use rustls::{Connection, RootCertStore};
 fn main() {
     let mut root_store = RootCertStore::empty();
     root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
-    let config = rustls::ConfigBuilder::with_safe_defaults()
+    let config = rustls::config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_root_certificates(root_store, &[])

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -13,24 +13,67 @@ use crate::versions;
 ///
 /// Example, to make a [`ServerConfig`]:
 ///
-/// ```
+/// ```no_run
 /// # use rustls::config_builder;
+/// # let certs = vec![];
+/// # let private_key = rustls::PrivateKey(vec![]);
 /// config_builder()
 ///     .with_safe_default_cipher_suites()
 ///     .with_safe_default_kx_groups()
 ///     .with_safe_default_protocol_versions()
 ///     .for_server()
-///     .unwrap();
+///     .unwrap()
+///     .with_no_client_auth()
+///     .with_single_cert(certs, private_key)
+///     .expect("bad certificate/key");
+/// ```
+///
+/// This may be shortened to:
+///
+/// ```no_run
+/// # let certs = vec![];
+/// # let private_key = rustls::PrivateKey(vec![]);
+/// # use rustls::config_builder_with_safe_defaults;
+/// config_builder_with_safe_defaults()
+///     .for_server()
+///     .unwrap()
+///     .with_no_client_auth()
+///     .with_single_cert(certs, private_key)
+///     .expect("bad certificate/key");
+/// ```
+///
+/// To make a [`ClientConfig`]:
+///
+/// ```no_run
+/// # use rustls::config_builder;
+/// # let root_certs = rustls::RootCertStore::empty();
+/// # let trusted_ct_logs = &[];
+/// # let certs = vec![];
+/// # let private_key = rustls::PrivateKey(vec![]);
+/// config_builder()
+///     .with_safe_default_cipher_suites()
+///     .with_safe_default_kx_groups()
+///     .with_safe_default_protocol_versions()
+///     .for_client()
+///     .unwrap()
+///     .with_root_certificates(root_certs, trusted_ct_logs)
+///     .with_single_cert(certs, private_key)
+///     .expect("bad certificate/key");
 /// ```
 ///
 /// This may be shortened to:
 ///
 /// ```
 /// # use rustls::config_builder_with_safe_defaults;
+/// # let root_certs = rustls::RootCertStore::empty();
+/// # let trusted_ct_logs = &[];
 /// config_builder_with_safe_defaults()
-///     .for_server()
-///     .unwrap();
+///     .for_client()
+///     .unwrap()
+///     .with_root_certificates(root_certs, trusted_ct_logs)
+///     .with_no_client_auth();
 /// ```
+///
 ///
 /// The types used here fit together like this:
 ///
@@ -90,7 +133,7 @@ impl ConfigWantsCipherSuites {
     }
 }
 
-/// A config builder where we want to know the key exchange groups.
+/// A config builder where we want to know which key exchange groups to use.
 pub struct ConfigWantsKxGroups {
     cipher_suites: Vec<SupportedCipherSuite>,
 }
@@ -137,8 +180,7 @@ impl ConfigWantsVersions {
     }
 }
 
-/// A config builder where we know the cipher suites, key exchange groups,
-/// and protocol versions.
+/// A config builder where we want to know whether this will be a client or a server.
 pub struct ConfigWantsPeerType {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
@@ -169,7 +211,7 @@ impl ConfigWantsPeerType {
         Ok(())
     }
 
-    /// Continue building a `ClientConfig`.
+    /// This config is for a client. Continue by setting client-related options.
     ///
     /// This may fail, if the previous selections are contradictory or
     /// not useful (for example, if no protocol versions are enabled).
@@ -182,7 +224,7 @@ impl ConfigWantsPeerType {
         })
     }
 
-    /// Continue building a `ServerConfig`.
+    /// This config is for a server. Continue by setting server-related options.
     ///
     /// This may fail, if the previous selections are contradictory or
     /// not useful (for example, if no protocol versions are enabled).

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -35,16 +35,16 @@ use crate::versions;
 /// The types used here fit together like this:
 ///
 /// 1. You must make a decision on which cipher suites to use, typically
-///    by calling [`ConfigBuilder::with_safe_default_cipher_suites()`].
-/// 2. You now have a [`ConfigBuilderWithSuites`].  You must make a decision
-///    on key exchange groups: typically by calling [`ConfigBuilderWithSuites::with_safe_default_kx_groups()`].
-/// 3. You now have a [`ConfigBuilderWithKxGroups`].  You must make
+///    by calling [`ConfigWantsCipherSuites::with_safe_default_cipher_suites()`].
+/// 2. Now you must make a decision
+///    on key exchange groups: typically by calling [`ConfigWantsKxGroups::with_safe_default_kx_groups()`].
+/// 3. Now you must make
 ///    a decision on which protocol versions to support, typically by calling
-///    [`ConfigBuilderWithKxGroups::with_safe_default_protocol_versions()`].
-/// 4. You now have a [`ConfigBuilderWithVersions`] and need to decide whether to
-///    make a [`ServerConfig`] or [`ClientConfig`] -- call [`ConfigBuilderWithVersions::for_server()`]
-///    or [`ConfigBuilderWithVersions::for_client()`] respectively.
-/// 5. Now see [`ServerConfigBuilder`] or [`ClientConfigBuilder`] for further steps.
+///    [`ConfigWantsVersions::with_safe_default_protocol_versions()`].
+/// 4. You now need to indicate whether to make a [`ServerConfig`] or [`ClientConfig`],
+///    by calling [`ConfigWantsPeerType::for_server()`]
+///    or [`ConfigWantsPeerType::for_client()`] respectively.
+/// 5. Now see [`ConfigWantsServerVerifier`] or [`ConfigWantsClientVerifier`] for further steps.
 ///
 /// [`ServerConfig`]: crate::ServerConfig
 /// [`ClientConfig`]: crate::ClientConfig
@@ -137,7 +137,7 @@ impl ConfigWantsVersions {
     }
 }
 
-/// A [`ConfigBuilder`] where we know the cipher suites, key exchange groups,
+/// A config builder where we know the cipher suites, key exchange groups,
 /// and protocol versions.
 pub struct ConfigWantsPeerType {
     cipher_suites: Vec<SupportedCipherSuite>,

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -1,7 +1,7 @@
-use crate::client::builder::ClientConfigBuilder;
+use crate::client::builder::ConfigWantsServerVerifier;
 use crate::error::Error;
 use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};
-use crate::server::builder::ServerConfigBuilder;
+use crate::server::builder::ConfigWantsClientVerifier;
 use crate::suites::{SupportedCipherSuite, DEFAULT_CIPHERSUITES};
 use crate::versions;
 
@@ -14,8 +14,9 @@ use crate::versions;
 /// Example, to make a [`ServerConfig`]:
 ///
 /// ```
-/// # use rustls::ConfigBuilder;
-/// ConfigBuilder::with_safe_default_cipher_suites()
+/// # use rustls::config_builder;
+/// config_builder()
+///     .with_safe_default_cipher_suites()
 ///     .with_safe_default_kx_groups()
 ///     .with_safe_default_protocol_versions()
 ///     .for_server()
@@ -25,8 +26,8 @@ use crate::versions;
 /// This may be shortened to:
 ///
 /// ```
-/// # use rustls::ConfigBuilder;
-/// ConfigBuilder::with_safe_defaults()
+/// # use rustls::config_builder_with_safe_defaults;
+/// config_builder_with_safe_defaults()
 ///     .for_server()
 ///     .unwrap();
 /// ```
@@ -47,25 +48,34 @@ use crate::versions;
 ///
 /// [`ServerConfig`]: crate::ServerConfig
 /// [`ClientConfig`]: crate::ClientConfig
-pub struct ConfigBuilder;
+pub fn config_builder() -> ConfigWantsCipherSuites {
+    ConfigWantsCipherSuites {}
+}
 
-impl ConfigBuilder {
-    /// Start building a [`ServerConfig`] or [`ClientConfig`], and accept
-    /// defaults for underlying cryptography.
-    ///
-    /// These are safe defaults, useful for 99% of applications.
-    ///
-    /// [`ServerConfig`]: crate::ServerConfig
-    /// [`ClientConfig`]: crate::ClientConfig
-    pub fn with_safe_defaults() -> ConfigBuilderWithVersions {
-        ConfigBuilder::with_safe_default_cipher_suites()
-            .with_safe_default_kx_groups()
-            .with_safe_default_protocol_versions()
-    }
+/// Start building a [`ServerConfig`] or [`ClientConfig`], and accept
+/// defaults for underlying cryptography.
+///
+/// These are safe defaults, useful for 99% of applications.
+///
+/// [`ServerConfig`]: crate::ServerConfig
+/// [`ClientConfig`]: crate::ClientConfig
+pub fn config_builder_with_safe_defaults() -> ConfigWantsPeerType {
+    ConfigWantsCipherSuites {}
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_safe_default_protocol_versions()
+}
 
+/// A config builder where we want to know the cipher suites.
+pub struct ConfigWantsCipherSuites;
+
+impl ConfigWantsCipherSuites {
     /// Choose a specific set of cipher suites.
-    pub fn with_cipher_suites(cipher_suites: &[SupportedCipherSuite]) -> ConfigBuilderWithSuites {
-        ConfigBuilderWithSuites {
+    pub fn with_cipher_suites(
+        &self,
+        cipher_suites: &[SupportedCipherSuite],
+    ) -> ConfigWantsKxGroups {
+        ConfigWantsKxGroups {
             cipher_suites: cipher_suites.to_vec(),
         }
     }
@@ -75,23 +85,20 @@ impl ConfigBuilder {
     /// Note that this default provides only high-quality suites: there is no need
     /// to filter out low-, export- or NULL-strength cipher suites: rustls does not
     /// implement these.
-    pub fn with_safe_default_cipher_suites() -> ConfigBuilderWithSuites {
-        Self::with_cipher_suites(DEFAULT_CIPHERSUITES)
+    pub fn with_safe_default_cipher_suites(&self) -> ConfigWantsKxGroups {
+        self.with_cipher_suites(DEFAULT_CIPHERSUITES)
     }
 }
 
-/// A [`ConfigBuilder`] where we know the cipher suites.
-pub struct ConfigBuilderWithSuites {
+/// A config builder where we want to know the key exchange groups.
+pub struct ConfigWantsKxGroups {
     cipher_suites: Vec<SupportedCipherSuite>,
 }
 
-impl ConfigBuilderWithSuites {
+impl ConfigWantsKxGroups {
     /// Choose a specific set of key exchange groups.
-    pub fn with_kx_groups(
-        self,
-        kx_groups: &[&'static SupportedKxGroup],
-    ) -> ConfigBuilderWithKxGroups {
-        ConfigBuilderWithKxGroups {
+    pub fn with_kx_groups(self, kx_groups: &[&'static SupportedKxGroup]) -> ConfigWantsVersions {
+        ConfigWantsVersions {
             cipher_suites: self.cipher_suites,
             kx_groups: kx_groups.to_vec(),
         }
@@ -100,21 +107,20 @@ impl ConfigBuilderWithSuites {
     /// Choose the default set of key exchange groups.
     ///
     /// This is a safe default: rustls doesn't implement any poor-quality groups.
-    pub fn with_safe_default_kx_groups(self) -> ConfigBuilderWithKxGroups {
+    pub fn with_safe_default_kx_groups(self) -> ConfigWantsVersions {
         self.with_kx_groups(&ALL_KX_GROUPS)
     }
 }
 
-/// A [`ConfigBuilder`] where we know the cipher suites and key exchange
-/// groups.
-pub struct ConfigBuilderWithKxGroups {
+/// A config builder where we want to know the TLS versions.
+pub struct ConfigWantsVersions {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
 }
 
-impl ConfigBuilderWithKxGroups {
+impl ConfigWantsVersions {
     /// Accept the default protocol versions: both TLS1.2 and TLS1.3 are enabled.
-    pub fn with_safe_default_protocol_versions(self) -> ConfigBuilderWithVersions {
+    pub fn with_safe_default_protocol_versions(self) -> ConfigWantsPeerType {
         self.with_protocol_versions(versions::DEFAULT_VERSIONS)
     }
 
@@ -122,8 +128,8 @@ impl ConfigBuilderWithKxGroups {
     pub fn with_protocol_versions(
         self,
         versions: &[&'static versions::SupportedProtocolVersion],
-    ) -> ConfigBuilderWithVersions {
-        ConfigBuilderWithVersions {
+    ) -> ConfigWantsPeerType {
+        ConfigWantsPeerType {
             cipher_suites: self.cipher_suites,
             kx_groups: self.kx_groups,
             versions: versions::EnabledVersions::new(versions),
@@ -133,13 +139,13 @@ impl ConfigBuilderWithKxGroups {
 
 /// A [`ConfigBuilder`] where we know the cipher suites, key exchange groups,
 /// and protocol versions.
-pub struct ConfigBuilderWithVersions {
+pub struct ConfigWantsPeerType {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
 }
 
-impl ConfigBuilderWithVersions {
+impl ConfigWantsPeerType {
     fn validate(&self) -> Result<(), Error> {
         let mut any_usable_suite = false;
         for suite in &self.cipher_suites {
@@ -167,9 +173,9 @@ impl ConfigBuilderWithVersions {
     ///
     /// This may fail, if the previous selections are contradictory or
     /// not useful (for example, if no protocol versions are enabled).
-    pub fn for_client(self) -> Result<ClientConfigBuilder, Error> {
+    pub fn for_client(self) -> Result<ConfigWantsServerVerifier, Error> {
         self.validate()?;
-        Ok(ClientConfigBuilder {
+        Ok(ConfigWantsServerVerifier {
             cipher_suites: self.cipher_suites,
             kx_groups: self.kx_groups,
             versions: self.versions,
@@ -180,9 +186,9 @@ impl ConfigBuilderWithVersions {
     ///
     /// This may fail, if the previous selections are contradictory or
     /// not useful (for example, if no protocol versions are enabled).
-    pub fn for_server(self) -> Result<ServerConfigBuilder, Error> {
+    pub fn for_server(self) -> Result<ConfigWantsClientVerifier, Error> {
         self.validate()?;
-        Ok(ServerConfigBuilder {
+        Ok(ConfigWantsClientVerifier {
             cipher_suites: self.cipher_suites,
             kx_groups: self.kx_groups,
             versions: self.versions,

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -83,7 +83,7 @@ impl ConfigWantsServerVerifier {
         self,
         verifier: Arc<dyn verify::ServerCertVerifier>,
     ) -> ConfigWantsClientCert {
-        ClientConfigBuilderWithCertVerifier {
+        ConfigWantsClientCert {
             cipher_suites: self.cipher_suites,
             kx_groups: self.kx_groups,
             versions: self.versions,

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -11,49 +11,8 @@ use crate::versions;
 
 use std::sync::Arc;
 
-/// Building a [`ClientConfig`] in a linker-friendly way.
-///
-/// Linker-friendly: meaning unused cipher suites, protocol
-/// versions, key exchange mechanisms, etc. can be discarded
-/// by the linker as they'll be unreferenced.
-///
-/// Example:
-///
-/// ```no_run
-/// # use rustls::config_builder;
-/// # let root_certs = rustls::RootCertStore::empty();
-/// # let trusted_ct_logs = &[];
-/// # let certs = vec![];
-/// # let private_key = rustls::PrivateKey(vec![]);
-/// config_builder()
-///     .with_safe_default_cipher_suites()
-///     .with_safe_default_kx_groups()
-///     .with_safe_default_protocol_versions()
-///     .for_client()
-///     .unwrap()
-///     .with_root_certificates(root_certs, trusted_ct_logs)
-///     .with_single_cert(certs, private_key)
-///     .expect("bad certificate/key");
-/// ```
-///
-/// This may be shortened to:
-///
-/// ```
-/// # use rustls::config_builder_with_safe_defaults;
-/// # let root_certs = rustls::RootCertStore::empty();
-/// # let trusted_ct_logs = &[];
-/// config_builder_with_safe_defaults()
-///     .for_client()
-///     .unwrap()
-///     .with_root_certificates(root_certs, trusted_ct_logs)
-///     .with_no_client_auth();
-/// ```
-///
-/// # Resulting [`ClientConfig`] defaults
-/// * [`ClientConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
-/// * [`ClientConfig::session_storage`]: the default stores 256 sessions in memory.
-/// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
-/// * [`ClientConfig::key_log`]: key material is not logged.
+/// A client config in progress, where the next step is to configure how
+/// to validate server certificates (typically with a set root certificates).
 pub struct ConfigWantsServerVerifier {
     pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,

--- a/rustls/src/client/mod.rs
+++ b/rustls/src/client/mod.rs
@@ -83,6 +83,15 @@ pub trait ResolvesClientCert: Send + Sync {
 ///
 /// Making one of these can be expensive, and should be
 /// once per process rather than once per connection.
+///
+/// These cannot be constructed directly. Create one via [`config_builder`](crate::config_builder).
+///
+/// # Defaults
+///
+/// * [`ClientConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
+/// * [`ClientConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ClientConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
+/// * [`ClientConfig::key_log`]: key material is not logged.
 #[derive(Clone)]
 pub struct ClientConfig {
     /// List of ciphersuites, in preference order.

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -109,7 +109,7 @@
 //! and use it for all connections made by that process.
 //!
 //! ```rust,ignore
-//! let config = rustls::ConfigBuilder::with_safe_defaults()
+//! let config = rustls::config_builder_with_safe_defaults()
 //!     .for_client()
 //!     .unwrap()
 //!     .with_root_certificates(root_store, trusted_ct_logs)
@@ -127,7 +127,7 @@
 //! # let mut root_store = rustls::RootCertStore::empty();
 //! # root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
 //! # let trusted_ct_logs = &[];
-//! # let config = rustls::ConfigBuilder::with_safe_defaults()
+//! # let config = rustls::config_builder_with_safe_defaults()
 //! #     .for_client()
 //! #     .unwrap()
 //! #     .with_root_certificates(root_store, trusted_ct_logs)
@@ -297,9 +297,10 @@ pub mod internal {
 // The public interface is:
 pub use crate::anchors::{OwnedTrustAnchor, RootCertStore};
 pub use crate::builder::{
-    ConfigBuilder, ConfigBuilderWithKxGroups, ConfigBuilderWithSuites, ConfigBuilderWithVersions,
+    config_builder, config_builder_with_safe_defaults, ConfigWantsCipherSuites,
+    ConfigWantsKxGroups, ConfigWantsPeerType, ConfigWantsVersions,
 };
-pub use crate::client::builder::{ClientConfigBuilder, ClientConfigBuilderWithCertVerifier};
+pub use crate::client::builder::{ConfigWantsClientCert, ConfigWantsServerVerifier};
 pub use crate::client::handy::{ClientSessionMemoryCache, NoClientSessionStorage};
 pub use crate::client::ResolvesClientCert;
 pub use crate::client::ServerName;
@@ -316,7 +317,7 @@ pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
 pub use crate::msgs::handshake::DistinguishedNames;
-pub use crate::server::builder::{ServerConfigBuilder, ServerConfigBuilderWithClientAuth};
+pub use crate::server::builder::{ConfigWantsClientVerifier, ConfigWantsServerCert};
 pub use crate::server::handy::ResolvesServerCertUsingSni;
 pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};
 pub use crate::server::StoresServerSessions;

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -10,48 +10,8 @@ use crate::versions;
 
 use std::sync::Arc;
 
-/// Building a [`ServerConfig`] in a linker-friendly way.
-///
-/// Linker-friendly: meaning unused cipher suites, protocol
-/// versions, key exchange mechanisms, etc. can be discarded
-/// by the linker as they'll be unreferenced.
-///
-/// Example:
-///
-/// ```no_run
-/// # use rustls::config_builder;
-/// # let certs = vec![];
-/// # let private_key = rustls::PrivateKey(vec![]);
-/// config_builder()
-///     .with_safe_default_cipher_suites()
-///     .with_safe_default_kx_groups()
-///     .with_safe_default_protocol_versions()
-///     .for_server()
-///     .unwrap()
-///     .with_no_client_auth()
-///     .with_single_cert(certs, private_key)
-///     .expect("bad certificate/key");
-/// ```
-///
-/// This may be shortened to:
-///
-/// ```no_run
-/// # use rustls::config_builder_with_safe_defaults;
-/// # let certs = vec![];
-/// # let private_key = rustls::PrivateKey(vec![]);
-/// config_builder_with_safe_defaults()
-///     .for_server()
-///     .unwrap()
-///     .with_no_client_auth()
-///     .with_single_cert(certs, private_key)
-///     .expect("bad certificate/key");
-/// ```
-///
-/// # Resulting [`ServerConfig`] defaults
-/// * [`ServerConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
-/// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
-/// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
-/// * [`ServerConfig::key_log`]: key material is not logged.
+/// A server config in progress, where the next step is to configure whether
+/// and how to authenticate clients.
 pub struct ConfigWantsClientVerifier {
     pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -19,10 +19,11 @@ use std::sync::Arc;
 /// Example:
 ///
 /// ```no_run
-/// # use rustls::ConfigBuilder;
+/// # use rustls::config_builder;
 /// # let certs = vec![];
 /// # let private_key = rustls::PrivateKey(vec![]);
-/// ConfigBuilder::with_safe_default_cipher_suites()
+/// config_builder()
+///     .with_safe_default_cipher_suites()
 ///     .with_safe_default_kx_groups()
 ///     .with_safe_default_protocol_versions()
 ///     .for_server()
@@ -35,10 +36,10 @@ use std::sync::Arc;
 /// This may be shortened to:
 ///
 /// ```no_run
-/// # use rustls::ConfigBuilder;
+/// # use rustls::config_builder_with_safe_defaults;
 /// # let certs = vec![];
 /// # let private_key = rustls::PrivateKey(vec![]);
-/// ConfigBuilder::with_safe_defaults()
+/// config_builder_with_safe_defaults()
 ///     .for_server()
 ///     .unwrap()
 ///     .with_no_client_auth()
@@ -51,19 +52,19 @@ use std::sync::Arc;
 /// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
 /// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
 /// * [`ServerConfig::key_log`]: key material is not logged.
-pub struct ServerConfigBuilder {
+pub struct ConfigWantsClientVerifier {
     pub(crate) cipher_suites: Vec<SupportedCipherSuite>,
     pub(crate) kx_groups: Vec<&'static SupportedKxGroup>,
     pub(crate) versions: versions::EnabledVersions,
 }
 
-impl ServerConfigBuilder {
+impl ConfigWantsClientVerifier {
     /// Choose how to verify client certificates.
     pub fn with_client_cert_verifier(
         self,
         client_cert_verifier: Arc<dyn verify::ClientCertVerifier>,
-    ) -> ServerConfigBuilderWithClientAuth {
-        ServerConfigBuilderWithClientAuth {
+    ) -> ConfigWantsServerCert {
+        ConfigWantsServerCert {
             cipher_suites: self.cipher_suites,
             kx_groups: self.kx_groups,
             versions: self.versions,
@@ -72,21 +73,21 @@ impl ServerConfigBuilder {
     }
 
     /// Disable client authentication.
-    pub fn with_no_client_auth(self) -> ServerConfigBuilderWithClientAuth {
+    pub fn with_no_client_auth(self) -> ConfigWantsServerCert {
         self.with_client_cert_verifier(verify::NoClientAuth::new())
     }
 }
 
-/// A [`ServerConfigBuilder`] where we know the cipher suites, key exchange
-/// groups, enabled versions, and client auth policy.
-pub struct ServerConfigBuilderWithClientAuth {
+/// A config builder for a server, where we want to know how to provide a
+/// server certificate to a connecting peer.
+pub struct ConfigWantsServerCert {
     cipher_suites: Vec<SupportedCipherSuite>,
     kx_groups: Vec<&'static SupportedKxGroup>,
     versions: versions::EnabledVersions,
     verifier: Arc<dyn verify::ClientCertVerifier>,
 }
 
-impl ServerConfigBuilderWithClientAuth {
+impl ConfigWantsServerCert {
     /// Sets a single certificate chain and matching private key.  This
     /// certificate and key is used for all subsequent connections,
     /// irrespective of things like SNI hostname.

--- a/rustls/src/server/mod.rs
+++ b/rustls/src/server/mod.rs
@@ -152,7 +152,14 @@ impl<'a> ClientHello<'a> {
 /// Making one of these can be expensive, and should be
 /// once per process rather than once per connection.
 ///
-/// Create one of these via `ServerConfigBuilder`.
+/// These cannot be constructed directly. Create one via [`config_builder`](crate::config_builder).
+///
+/// # Defaults
+///
+/// * [`ServerConfig::max_fragment_size`]: the default is `None`: TLS packets are not fragmented to a specific size.
+/// * [`ServerConfig::session_storage`]: the default stores 256 sessions in memory.
+/// * [`ServerConfig::alpn_protocols`]: the default is empty -- no ALPN protocol is negotiated.
+/// * [`ServerConfig::key_log`]: key material is not logged.
 #[derive(Clone)]
 pub struct ServerConfig {
     /// List of ciphersuites, in preference order.

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -3040,12 +3040,16 @@ mod test_quic {
         assert!(!server.is_handshaking());
         assert!(compatible_keys(&server_1rtt, &client_1rtt));
         assert!(!compatible_keys(&server_hs, &server_1rtt));
-        assert!(step(&mut client, &mut server)
-            .unwrap()
-            .is_none());
-        assert!(step(&mut server, &mut client)
-            .unwrap()
-            .is_none());
+        assert!(
+            step(&mut client, &mut server)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            step(&mut server, &mut client)
+                .unwrap()
+                .is_none()
+        );
 
         // 0-RTT handshake
         let mut client = ClientConnection::new_quic(
@@ -3055,9 +3059,11 @@ mod test_quic {
             client_params.into(),
         )
         .unwrap();
-        assert!(client
-            .negotiated_cipher_suite()
-            .is_some());
+        assert!(
+            client
+                .negotiated_cipher_suite()
+                .is_some()
+        );
 
         let mut server = ServerConnection::new_quic(
             Arc::clone(&server_config),
@@ -3197,13 +3203,15 @@ mod test_quic {
         client_config.alpn_protocols = vec!["foo".into()];
         let client_config = Arc::new(client_config);
 
-        assert!(ClientConnection::new_quic(
-            client_config,
-            quic::Version::V1,
-            dns_name("localhost"),
-            b"client params".to_vec(),
-        )
-        .is_err());
+        assert!(
+            ClientConnection::new_quic(
+                client_config,
+                quic::Version::V1,
+                dns_name("localhost"),
+                b"client params".to_vec(),
+            )
+            .is_err()
+        );
 
         let mut server_config = make_server_config(KeyType::ED25519);
         server_config

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -2,12 +2,11 @@ use std::convert::{TryFrom, TryInto};
 use std::io;
 use std::sync::Arc;
 
-use rustls;
+use rustls::{self, config_builder_with_safe_defaults};
 use rustls_pemfile;
 
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
-use rustls::ConfigBuilder;
 use rustls::Connection;
 use rustls::Error;
 use rustls::{AllowAnyAuthenticatedClient, RootCertStore};
@@ -222,7 +221,7 @@ impl KeyType {
 }
 
 pub fn make_server_config(kt: KeyType) -> ServerConfig {
-    ConfigBuilder::with_safe_defaults()
+    config_builder_with_safe_defaults()
         .for_server()
         .unwrap()
         .with_no_client_auth()
@@ -244,7 +243,7 @@ pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfi
 
     let client_auth = AllowAnyAuthenticatedClient::new(client_auth_roots);
 
-    ConfigBuilder::with_safe_defaults()
+    config_builder_with_safe_defaults()
         .for_server()
         .unwrap()
         .with_client_cert_verifier(client_auth)
@@ -257,7 +256,7 @@ pub fn make_client_config(kt: KeyType) -> ClientConfig {
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
     root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
-    ConfigBuilder::with_safe_defaults()
+    config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_root_certificates(root_store, &[])
@@ -269,7 +268,7 @@ pub fn make_client_config_with_auth(kt: KeyType) -> ClientConfig {
     let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
     root_store.add_parsable_certificates(&rustls_pemfile::certs(&mut rootbuf).unwrap());
 
-    ConfigBuilder::with_safe_defaults()
+    config_builder_with_safe_defaults()
         .for_client()
         .unwrap()
         .with_root_certificates(root_store, &[])


### PR DESCRIPTION
This makes for a clearer connection between each type in the builder
state machine and the methods it provides.

This also removes ConfigBuilder as a type, since it's really just the
entry point into the state machine; it's now "ConfigWantsCipherSuites."

The entry point into the state machine is now one of two functions:

  config_builder() // full configuration
  config_builder_with_safe_defaults() // pick everything for me

This improves consistency: all settings are now added via methods.
Previously, the first-round settings (cipher suites) were set by
associated function, while everything else was set by method.

This is a followup to my suggestion at https://github.com/ctz/rustls/issues/758#issuecomment-868966850; there is some additional justification there.

You can see generated documentation for this branch at https://hoffman-andrews.com/rustls-with-to-wants/rustls/?search=config:

![image](https://user-images.githubusercontent.com/220205/123507843-9e6a5b80-d620-11eb-9055-1de2166a6a03.png)

I still have a few touch-ups on the docs to make, but wanted to get feedback on the idea before proceeding.