### PR TITLE
Add UnsupportedNameType error for certificate validation routines

### DIFF
--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -218,6 +218,9 @@ pub enum Error {
     /// The peer didn't give us any certificates.
     NoCertificatesPresented,
 
+    /// The certificate verifier doesn't support the given type of name.
+    UnsupportedNameType,
+
     /// We couldn't decrypt a message.  This is invariably fatal.
     DecryptError,
 
@@ -305,6 +308,7 @@ impl fmt::Display for Error {
             }
             Error::CorruptMessage => write!(f, "received corrupt message"),
             Error::NoCertificatesPresented => write!(f, "peer sent no certificates"),
+            Error::UnsupportedNameType => write!(f, "presented server name type wasn't supported"),
             Error::DecryptError => write!(f, "cannot decrypt peer's message"),
             Error::PeerSentOversizedRecord => write!(f, "peer sent excess record size"),
             Error::HandshakeNotComplete => write!(f, "handshake not complete"),


### PR DESCRIPTION
Based off [this comment](https://github.com/ctz/rustls/issues/758#issuecomment-869027675), this PR adds an error variant for custom certificate validation implementations to return when they can't find the correct `ServerName` variant when trying to validate a certificate. 

Intended use case:
```rust
impl ServerCertVerifier for Verifier {
    fn verify_server_cert(&self, 
        end_entity: &rustls::Certificate, 
        intermediates: &[rustls::Certificate], 
        server_name: &rustls::ServerName, 
        scts: &mut dyn Iterator<Item = &[u8]>, 
        ocsp_response: &[u8], 
        now: std::time::SystemTime
    ) -> Result<rustls::ServerCertVerified, Error> {
        ...
        let name = match server_name {
            rustls::ServerName::DnsName(n) => n.as_ref(),
            _ => return Err(Error::UnsupportedNameType)
        };
}
```