### PR TITLE
Some remaining API naming fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
     pass the end-entity and intermediate certificates separately.  This means rustls deals with the case
     where the certificate chain is empty, rather than leaving that to ServerCertVerifier/ClientCertVerifier
     implementation.
+  - *Breaking API change*: `SupportedCipherSuite` is now an enum with TLS 1.2 and TLS 1.3 variants. Some of its
+    methods have moved to the inner `Tls12CipherSuite` and `Tls13CipherSuite` types. Instead of
+    `usable_for_version()`, it now has a `version()` method. `get_hash()` has been renamed
+    to `hash_algorithm()` and `usable_for_sigalg()` to `usable_for_signature_algorithm()`.
   - There are now 80% fewer unreachable unwraps in the core crate thanks to large refactoring efforts.
   - *Breaking API change*: the `WebPkiError` variant of `rustls::Error` now includes which operation failed.
   - *Breaking API changes*: These public API items have been renamed to meet naming guidelines:

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -602,7 +602,7 @@ impl State for ExpectServerHello {
         // Start our handshake hash, and input the server-hello.
         let mut transcript = self
             .transcript_buffer
-            .start_hash(suite.get_hash());
+            .start_hash(suite.hash_algorithm());
         transcript.add_message(&m);
 
         let randoms = ConnectionRandoms::new(self.random, server_hello.random, true);
@@ -738,7 +738,7 @@ impl ExpectServerHelloOrHelloRetryRequest {
         let transcript = self
             .next
             .transcript_buffer
-            .start_hash(cs.get_hash());
+            .start_hash(cs.hash_algorithm());
         let mut transcript_buffer = transcript.into_hrr_buffer();
         transcript_buffer.add_message(&m);
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -483,7 +483,7 @@ fn emit_certverify(
         }
     };
 
-    let scheme = signer.get_scheme();
+    let scheme = signer.scheme();
     let sig = signer.sign(&message)?;
     let body = DigitallySignedStruct::new(scheme, sig);
 

--- a/rustls/src/client/tls12.rs
+++ b/rustls/src/client/tls12.rs
@@ -744,7 +744,8 @@ impl hs::State for ExpectServerDone {
 
             // Check the signature is compatible with the ciphersuite.
             let sig = &st.server_kx.kx_sig;
-            if !SupportedCipherSuite::from(suite).usable_for_sigalg(sig.scheme.sign()) {
+            if !SupportedCipherSuite::from(suite).usable_for_signature_algorithm(sig.scheme.sign())
+            {
                 let error_message = format!(
                     "peer signed kx with wrong algorithm (got {:?} expect {:?})",
                     sig.scheme.sign(),

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -475,7 +475,7 @@ impl State for ExpectClientHello {
         cx.common.suite = Some(suite);
 
         // Start handshake hash.
-        let starting_hash = suite.get_hash();
+        let starting_hash = suite.hash_algorithm();
         let transcript = match self.transcript {
             HandshakeHashOrBuffer::Buffer(inner) => inner.start_hash(starting_hash),
             HandshakeHashOrBuffer::Hash(inner) if inner.algorithm() == starting_hash => inner,

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -412,7 +412,7 @@ mod client_hello {
         let signer = signing_key
             .choose_scheme(&sigschemes)
             .ok_or_else(|| Error::General("incompatible signing key".to_string()))?;
-        let sigscheme = signer.get_scheme();
+        let sigscheme = signer.scheme();
         let sig = signer.sign(&msg)?;
 
         let skx = ServerKeyExchangePayload::ECDHE(ECDHEServerKeyExchange {

--- a/rustls/src/server/tls13.rs
+++ b/rustls/src/server/tls13.rs
@@ -654,7 +654,7 @@ mod client_hello {
             .choose_scheme(schemes)
             .ok_or_else(|| hs::incompatible(common, "no overlapping sigschemes"))?;
 
-        let scheme = signer.get_scheme();
+        let scheme = signer.scheme();
         let sig = signer.sign(&message)?;
 
         let cv = DigitallySignedStruct::new(scheme, sig);

--- a/rustls/src/sign.rs
+++ b/rustls/src/sign.rs
@@ -25,7 +25,7 @@ pub trait Signer: Send + Sync {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, Error>;
 
     /// Reveals which scheme will be used when you call `sign()`.
-    fn get_scheme(&self) -> SignatureScheme;
+    fn scheme(&self) -> SignatureScheme;
 }
 
 /// A packaged-together certificate chain, matching `SigningKey` and
@@ -242,7 +242,7 @@ impl Signer for RsaSigner {
             .map_err(|_| Error::General("signing failed".to_string()))
     }
 
-    fn get_scheme(&self) -> SignatureScheme {
+    fn scheme(&self) -> SignatureScheme {
         self.scheme
     }
 }
@@ -312,7 +312,7 @@ impl Signer for EcdsaSigner {
             .map(|sig| sig.as_ref().into())
     }
 
-    fn get_scheme(&self) -> SignatureScheme {
+    fn scheme(&self) -> SignatureScheme {
         self.scheme
     }
 }
@@ -374,7 +374,7 @@ impl Signer for Ed25519Signer {
         Ok(self.key.sign(message).as_ref().into())
     }
 
-    fn get_scheme(&self) -> SignatureScheme {
+    fn scheme(&self) -> SignatureScheme {
         self.scheme
     }
 }

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -194,15 +194,15 @@ impl SupportedCipherSuite {
         }
     }
 
-    /// Return true if this suite is usable for a key only offering `sigalg`
+    /// Return true if this suite is usable for a key only offering `sig_alg`
     /// signatures.  This resolves to true for all TLS1.3 suites.
-    pub fn usable_for_sigalg(&self, sigalg: SignatureAlgorithm) -> bool {
+    pub fn usable_for_signature_algorithm(&self, sig_alg: SignatureAlgorithm) -> bool {
         match self {
             SupportedCipherSuite::Tls13(_) => true, // no constraint expressed by ciphersuite (e.g., TLS1.3)
             SupportedCipherSuite::Tls12(inner) => inner
                 .sign
                 .iter()
-                .any(|scheme| scheme.sign() == sigalg),
+                .any(|scheme| scheme.sign() == sig_alg),
         }
     }
 }
@@ -413,7 +413,7 @@ pub(crate) fn reduce_given_sigalg(
     sigalg: SignatureAlgorithm,
 ) -> Vec<SupportedCipherSuite> {
     all.iter()
-        .filter(|&&suite| suite.usable_for_sigalg(sigalg))
+        .filter(|&&suite| suite.usable_for_signature_algorithm(sigalg))
         .copied()
         .collect()
 }
@@ -438,7 +438,7 @@ pub(crate) fn compatible_sigscheme_for_suites(
     let sigalg = sigscheme.sign();
     common_suites
         .iter()
-        .any(|&suite| suite.usable_for_sigalg(sigalg))
+        .any(|&suite| suite.usable_for_signature_algorithm(sigalg))
 }
 
 #[cfg(test)]

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -53,7 +53,7 @@ pub struct Tls13CipherSuite {
 
 impl Tls13CipherSuite {
     /// Which hash function to use with this suite.
-    pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         self.hkdf_algorithm
             .hmac_algorithm()
             .digest_algorithm()
@@ -62,7 +62,9 @@ impl Tls13CipherSuite {
     /// Can a session using suite self resume from suite prev?
     pub fn can_resume_from(&self, prev: SupportedCipherSuite) -> Option<&'static Self> {
         match prev {
-            SupportedCipherSuite::Tls13(inner) if inner.get_hash() == self.get_hash() => {
+            SupportedCipherSuite::Tls13(inner)
+                if inner.hash_algorithm() == self.hash_algorithm() =>
+            {
                 Some(inner)
             }
             _ => None,
@@ -130,7 +132,7 @@ impl Tls12CipherSuite {
     }
 
     /// Which hash function to use with this suite.
-    pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         self.hmac_algorithm.digest_algorithm()
     }
 }
@@ -158,10 +160,10 @@ impl fmt::Debug for Tls12CipherSuite {
 
 impl SupportedCipherSuite {
     /// Which hash function to use with this suite.
-    pub fn get_hash(&self) -> &'static ring::digest::Algorithm {
+    pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm {
         match self {
-            SupportedCipherSuite::Tls12(inner) => inner.get_hash(),
-            SupportedCipherSuite::Tls13(inner) => inner.get_hash(),
+            SupportedCipherSuite::Tls12(inner) => inner.hash_algorithm(),
+            SupportedCipherSuite::Tls13(inner) => inner.hash_algorithm(),
         }
     }
 


### PR DESCRIPTION
After this, no `get_` prefix remain on public fn signatures, and there are no remaining usages of `sigalg` in public API.