### PR TITLE
Export IoState

### DIFF
--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -304,7 +304,7 @@ pub use crate::client::ResolvesClientCert;
 pub use crate::client::ServerName;
 pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientConnection, WriteEarlyData};
-pub use crate::conn::{Connection, Reader, Writer};
+pub use crate::conn::{IoState, Connection, Reader, Writer};
 pub use crate::error::Error;
 pub use crate::error::WebPkiError;
 pub use crate::error::WebPkiOp;


### PR DESCRIPTION
IoState is used in the public interface in the return value of process_new_packets, but isn't public (it's inside the private module conn)

This caused trouble for me when using rustls and defining a wrapper method for process_new_packets, I couldn't declare the return type.

I'm actually surprised Rust allows this.