### PR TITLE
Remove `webpki::TrustAnchor` from the public API.

### DIFF
--- a/rustls/examples/limitedclient.rs
+++ b/rustls/examples/limitedclient.rs
@@ -10,11 +10,23 @@ use std::net::TcpStream;
 use rustls;
 use webpki_roots;
 
-use rustls::Connection;
+use rustls::{Connection, OwnedTrustAnchor};
 
 fn main() {
     let mut root_store = rustls::RootCertStore::empty();
-    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
+    root_store.add_server_trust_anchors(
+        webpki_roots::TLS_SERVER_ROOTS
+            .0
+            .iter()
+            .map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }),
+    );
+
     let config = rustls::ClientConfig::builder()
         .with_cipher_suites(&[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256.into()])
         .with_kx_groups(&[&rustls::kx_group::X25519])

--- a/rustls/examples/simpleclient.rs
+++ b/rustls/examples/simpleclient.rs
@@ -16,11 +16,22 @@ use std::net::TcpStream;
 use rustls;
 use webpki_roots;
 
-use rustls::{Connection, RootCertStore};
+use rustls::{Connection, OwnedTrustAnchor, RootCertStore};
 
 fn main() {
     let mut root_store = RootCertStore::empty();
-    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
+    root_store.add_server_trust_anchors(
+        webpki_roots::TLS_SERVER_ROOTS
+            .0
+            .iter()
+            .map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }),
+    );
     let config = rustls::ClientConfig::builder()
         .with_safe_defaults()
         .with_root_certificates(root_store, &[])

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -101,7 +101,18 @@
 //!
 //! ```rust,ignore
 //! let mut root_store = rustls::RootCertStore::empty();
-//! root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
+//! root_store.add_server_trust_anchors(
+//!     webpki_roots::TLS_SERVER_ROOTS
+//!         .0
+//!         .iter()
+//!         .map(|ta| {
+//!             rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+//!                 ta.subject,
+//!                 ta.spki,
+//!                 ta.name_constraints,
+//!             )
+//!         })
+//! );
 //! let trusted_ct_logs = &[];
 //! ```
 //!
@@ -124,7 +135,18 @@
 //! # use std::sync::Arc;
 //! # use std::convert::TryInto;
 //! # let mut root_store = rustls::RootCertStore::empty();
-//! # root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0);
+//! # root_store.add_server_trust_anchors(
+//! #  webpki_roots::TLS_SERVER_ROOTS
+//! #      .0
+//! #      .iter()
+//! #      .map(|ta| {
+//! #          rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
+//! #              ta.subject,
+//! #              ta.spki,
+//! #              ta.name_constraints,
+//! #          )
+//! #      })
+//! # );
 //! # let trusted_ct_logs = &[];
 //! # let config = rustls::ClientConfig::builder()
 //! #     .with_safe_defaults()


### PR DESCRIPTION
The `webpki::TrustAnchor` type will change significantly in the near
future. Change Rustls's public APIs so that we can upgrade to the new
version of webpki without it being a breaking change. That is, allow
webpki and Rustls to evolve at different paces.

We expect that a future version of `webpki-roots` will also remove the
`webpki::TrustAnchor` from its public API, replacing it with its own
similar type.

The new `from_subject_spki_name_constraints` constructor will allow such
refactorings to be done without having to create a separate crate to
contain the types.

This makes the use of webpki-roots a bit messier than now, but most
applications probably shouldn't be using webpki-roots anyway.