### PR TITLE
Move most client/server-specific API into public client/server modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ If you'd like to help out, please see [CONTRIBUTING.md](CONTRIBUTING.md).
   - *Breaking change*: insulate the rustls public API from webpki API changes:
     - PKI errors are now reported using rustls-specific errors.
     - There is now a rustls-specific root trust anchor type.
+  - *Breaking change*: the following types are no longer exposed in the crate root, and can instead be imported
+    through the `client` module exposed in the crate root: `ResolvesClientCert`, `StoresClientSessions`,
+    `WriteEarlyData`, `ClientSessionMemoryCache`, `NoClientSessionStorage`, `HandshakeSignatureValid`,
+    `ServerCertVerified`, `ServerCertVerifier`, `WebPkiVerifier` and `DangerousClientConfig`.
+  - *Breaking change*: the following types are no longer exposed in the crate root, and can instead be imported
+    through the `server` module exposed in the crate root: `AllowAnonymousOrAuthenticatedClient`,
+    `AllowAnyAuthenticatedClient`, `NoClientAuth`, `ResolvesServerCertUsingSni`, `NoServerSessionStorage`,
+    `ServerSessionMemoryCache`, `StoresServerSessions`, `ClientHello`, `ProducesTickets`, `ResolvesServerCert`,
+    `ClientCertVerified` and `ClientCertVerifier`.
 * 0.20.0-beta2 (2021-07-04)
   - *Breaking change*: internal buffers are now limited to 64 kB by default. Use
     `Connection::set_buffer_limit` to change the buffer limits to suit your application.

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -3,12 +3,9 @@
 extern crate libfuzzer_sys;
 extern crate rustls;
 
-use rustls::{
-    ServerConfig,
-    Connection,
-    ResolvesServerCert,
-    ServerConnection
-};
+use rustls::{ServerConfig, Connection, ServerConnection};
+use rustls::server::ResolvesServerCert;
+
 use std::io;
 use std::sync::Arc;
 
@@ -17,7 +14,7 @@ struct Fail;
 impl ResolvesServerCert for Fail {
     fn resolve(
         &self,
-        _client_hello: rustls::ClientHello,
+        _client_hello: rustls::server::ClientHello,
     ) -> Option<Arc<rustls::sign::CertifiedKey>> {
         None
     }

--- a/rustls-mio/examples/tlsclient.rs
+++ b/rustls-mio/examples/tlsclient.rs
@@ -267,7 +267,7 @@ impl PersistCache {
     }
 }
 
-impl rustls::StoresClientSessions for PersistCache {
+impl rustls::client::StoresClientSessions for PersistCache {
     /// put: insert into in-memory cache, and perhaps persist to disk.
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
         self.cache
@@ -442,7 +442,7 @@ mod danger {
 
     pub struct NoCertificateVerification {}
 
-    impl rustls::ServerCertVerifier for NoCertificateVerification {
+    impl rustls::client::ServerCertVerifier for NoCertificateVerification {
         fn verify_server_cert(
             &self,
             _end_entity: &rustls::Certificate,
@@ -451,8 +451,8 @@ mod danger {
             _scts: &mut dyn Iterator<Item = &[u8]>,
             _ocsp: &[u8],
             _now: std::time::SystemTime,
-        ) -> Result<rustls::ServerCertVerified, rustls::Error> {
-            Ok(rustls::ServerCertVerified::assertion())
+        ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::ServerCertVerified::assertion())
         }
     }
 }

--- a/rustls-mio/examples/tlsserver.rs
+++ b/rustls-mio/examples/tlsserver.rs
@@ -20,12 +20,11 @@ use docopt::Docopt;
 use env_logger;
 
 use rustls;
-use rustls_pemfile;
-
-use rustls::{
-    AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, Connection, NoClientAuth,
-    RootCertStore,
+use rustls::server::{
+    AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
 };
+use rustls::{Connection, RootCertStore};
+use rustls_pemfile;
 
 // Token for our listening socket.
 const LISTENER: mio::Token = mio::Token(0);
@@ -610,7 +609,7 @@ fn make_config(args: &Args) -> Arc<rustls::ServerConfig> {
     config.key_log = Arc::new(rustls::KeyLogFile::new());
 
     if args.flag_resumption {
-        config.session_storage = rustls::ServerSessionMemoryCache::new(256);
+        config.session_storage = rustls::server::ServerSessionMemoryCache::new(256);
     }
 
     if args.flag_tickets {

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -11,9 +11,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rustls;
-use rustls::ClientSessionMemoryCache;
+use rustls::client::{ClientSessionMemoryCache, NoClientSessionStorage};
 use rustls::Connection;
-use rustls::NoClientSessionStorage;
 use rustls::NoServerSessionStorage;
 use rustls::ServerSessionMemoryCache;
 use rustls::Ticketer;

--- a/rustls/examples/internal/bench.rs
+++ b/rustls/examples/internal/bench.rs
@@ -12,11 +12,12 @@ use std::time::{Duration, Instant};
 
 use rustls;
 use rustls::client::{ClientSessionMemoryCache, NoClientSessionStorage};
+use rustls::server::{
+    AllowAnyAuthenticatedClient, NoClientAuth, NoServerSessionStorage, ServerSessionMemoryCache,
+};
 use rustls::Connection;
-use rustls::NoServerSessionStorage;
-use rustls::ServerSessionMemoryCache;
+use rustls::RootCertStore;
 use rustls::Ticketer;
-use rustls::{AllowAnyAuthenticatedClient, NoClientAuth, RootCertStore};
 use rustls::{ClientConfig, ClientConnection};
 use rustls::{ServerConfig, ServerConnection};
 

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -221,7 +221,7 @@ struct DummyServerAuth {
     send_sct: bool,
 }
 
-impl rustls::ServerCertVerifier for DummyServerAuth {
+impl rustls::client::ServerCertVerifier for DummyServerAuth {
     fn verify_server_cert(
         &self,
         _end_entity: &rustls::Certificate,
@@ -230,8 +230,8 @@ impl rustls::ServerCertVerifier for DummyServerAuth {
         _scts: &mut dyn Iterator<Item = &[u8]>,
         _ocsp: &[u8],
         _now: SystemTime,
-    ) -> Result<rustls::ServerCertVerified, rustls::Error> {
-        Ok(rustls::ServerCertVerified::assertion())
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
     }
 
     fn request_scts(&self) -> bool {
@@ -277,11 +277,11 @@ impl rustls::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
 }
 
 struct FixedSignatureSchemeClientCertResolver {
-    resolver: Arc<dyn rustls::ResolvesClientCert>,
+    resolver: Arc<dyn rustls::client::ResolvesClientCert>,
     scheme: rustls::SignatureScheme,
 }
 
-impl rustls::ResolvesClientCert for FixedSignatureSchemeClientCertResolver {
+impl rustls::client::ResolvesClientCert for FixedSignatureSchemeClientCertResolver {
     fn resolve(
         &self,
         acceptable_issuers: &[&[u8]],
@@ -401,17 +401,17 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
     Arc::new(cfg)
 }
 
-struct ClientCacheWithoutKxHints(Arc<rustls::ClientSessionMemoryCache>);
+struct ClientCacheWithoutKxHints(Arc<rustls::client::ClientSessionMemoryCache>);
 
 impl ClientCacheWithoutKxHints {
     fn new() -> Arc<ClientCacheWithoutKxHints> {
         Arc::new(ClientCacheWithoutKxHints(
-            rustls::ClientSessionMemoryCache::new(32),
+            rustls::client::ClientSessionMemoryCache::new(32),
         ))
     }
 }
 
-impl rustls::StoresClientSessions for ClientCacheWithoutKxHints {
+impl rustls::client::StoresClientSessions for ClientCacheWithoutKxHints {
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
         if key.len() > 2 && key[0] == b'k' && key[1] == b'x' {
             true

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -12,7 +12,7 @@ use rustls::internal::msgs::enums::ProtocolVersion;
 use rustls::quic;
 use rustls::quic::ClientQuicExt;
 use rustls::quic::ServerQuicExt;
-use rustls::ClientHello;
+use rustls::server::ClientHello;
 use std::convert::TryInto;
 use std::env;
 use std::fs;
@@ -190,18 +190,18 @@ struct DummyClientAuth {
     mandatory: bool,
 }
 
-impl rustls::ClientCertVerifier for DummyClientAuth {
+impl rustls::server::ClientCertVerifier for DummyClientAuth {
     fn offer_client_auth(&self) -> bool {
         true
     }
 
-    fn client_auth_mandatory(&self, _sni: Option<&rustls::DnsName>) -> Option<bool> {
+    fn client_auth_mandatory(&self, _sni: Option<&rustls::server::DnsName>) -> Option<bool> {
         Some(self.mandatory)
     }
 
     fn client_auth_root_subjects(
         &self,
-        _sni: Option<&rustls::DnsName>,
+        _sni: Option<&rustls::server::DnsName>,
     ) -> Option<rustls::DistinguishedNames> {
         Some(rustls::DistinguishedNames::new())
     }
@@ -210,10 +210,10 @@ impl rustls::ClientCertVerifier for DummyClientAuth {
         &self,
         _end_entity: &rustls::Certificate,
         _intermediates: &[rustls::Certificate],
-        _sni: Option<&rustls::DnsName>,
+        _sni: Option<&rustls::server::DnsName>,
         _now: SystemTime,
-    ) -> Result<rustls::ClientCertVerified, rustls::Error> {
-        Ok(rustls::ClientCertVerified::assertion())
+    ) -> Result<rustls::server::ClientCertVerified, rustls::Error> {
+        Ok(rustls::server::ClientCertVerified::assertion())
     }
 }
 
@@ -261,11 +261,11 @@ impl rustls::sign::SigningKey for FixedSignatureSchemeSigningKey {
 }
 
 struct FixedSignatureSchemeServerCertResolver {
-    resolver: Arc<dyn rustls::ResolvesServerCert>,
+    resolver: Arc<dyn rustls::server::ResolvesServerCert>,
     scheme: rustls::SignatureScheme,
 }
 
-impl rustls::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
+impl rustls::server::ResolvesServerCert for FixedSignatureSchemeServerCertResolver {
     fn resolve(&self, client_hello: ClientHello) -> Option<Arc<rustls::sign::CertifiedKey>> {
         let mut certkey = self.resolver.resolve(client_hello)?;
         Arc::make_mut(&mut certkey).key = Arc::new(FixedSignatureSchemeSigningKey {
@@ -344,7 +344,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
                 mandatory: opts.require_any_client_cert,
             })
         } else {
-            rustls::NoClientAuth::new()
+            rustls::server::NoClientAuth::new()
         };
 
     let cert = load_cert(&opts.cert_file);
@@ -373,7 +373,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
         )
         .unwrap();
 
-    cfg.session_storage = rustls::ServerSessionMemoryCache::new(32);
+    cfg.session_storage = rustls::server::ServerSessionMemoryCache::new(32);
     cfg.max_fragment_size = opts.max_fragment;
 
     if opts.use_signing_scheme > 0 {
@@ -387,7 +387,7 @@ fn make_server_cfg(opts: &Options) -> Arc<rustls::ServerConfig> {
     if opts.tickets {
         cfg.ticketer = rustls::Ticketer::new().unwrap();
     } else if opts.resumes == 0 {
-        cfg.session_storage = Arc::new(rustls::NoServerSessionStorage {});
+        cfg.session_storage = Arc::new(rustls::server::NoServerSessionStorage {});
     }
 
     if !opts.protocols.is_empty() {

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -102,7 +102,7 @@ impl client::ResolvesClientCert for AlwaysResolvesClientCert {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::StoresClientSessions;
+    use crate::client::StoresClientSessions;
 
     #[test]
     fn test_noclientsessionstorage_drops_put() {

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -30,7 +30,8 @@ use crate::SupportedCipherSuite;
 #[cfg(feature = "tls12")]
 use super::tls12;
 use crate::client::common::ClientHelloDetails;
-use crate::client::{tls13, ClientConfig, ClientConnectionData, ServerName};
+use crate::client::{tls13, ClientConfig, ServerName};
+use crate::client::client_conn::ClientConnectionData;
 
 use std::sync::Arc;
 

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -306,7 +306,6 @@ mod builder;
 mod key;
 mod keylog;
 mod kx;
-mod server;
 mod suites;
 mod ticketer;
 mod versions;
@@ -334,12 +333,6 @@ pub use crate::msgs::enums::CipherSuite;
 pub use crate::msgs::enums::ProtocolVersion;
 pub use crate::msgs::enums::SignatureScheme;
 pub use crate::msgs::handshake::DistinguishedNames;
-pub use crate::server::builder::WantsServerCert;
-pub use crate::server::handy::ResolvesServerCertUsingSni;
-pub use crate::server::handy::{NoServerSessionStorage, ServerSessionMemoryCache};
-pub use crate::server::StoresServerSessions;
-pub use crate::server::{ClientHello, ProducesTickets, ResolvesServerCert};
-pub use crate::server::{ServerConfig, ServerConnection};
 pub use crate::stream::{Stream, StreamOwned};
 pub use crate::suites::{
     BulkAlgorithm, SupportedCipherSuite, ALL_CIPHER_SUITES, DEFAULT_CIPHER_SUITES,
@@ -348,9 +341,6 @@ pub use crate::ticketer::Ticketer;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
 pub use crate::tls13::Tls13CipherSuite;
-pub use crate::verify::{
-    AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
-};
 pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
 
 /// Items for use in a client.
@@ -385,6 +375,37 @@ pub mod client {
 }
 
 pub use client::{ClientConfig, ClientConnection, ServerName};
+
+/// Items for use in a server.
+pub mod server {
+    pub(crate) mod builder;
+    mod common;
+    pub(crate) mod handy;
+    mod hs;
+    mod server_conn;
+    #[cfg(feature = "tls12")]
+    mod tls12;
+    mod tls13;
+
+    pub use crate::verify::{
+        AllowAnyAnonymousOrAuthenticatedClient, AllowAnyAuthenticatedClient, NoClientAuth,
+    };
+    pub use builder::WantsServerCert;
+    pub use handy::ResolvesServerCertUsingSni;
+    pub use handy::{NoServerSessionStorage, ServerSessionMemoryCache};
+    #[cfg(feature = "quic")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "quic")))]
+    pub use server_conn::ServerQuicExt;
+    pub use server_conn::StoresServerSessions;
+    pub use server_conn::{ClientHello, ProducesTickets, ResolvesServerCert};
+    pub use server_conn::{ServerConfig, ServerConnection};
+
+    #[cfg(feature = "dangerous_configuration")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
+    pub use crate::verify::{ClientCertVerified, ClientCertVerifier, DnsName};
+}
+
+pub use server::{ServerConfig, ServerConnection};
 
 /// All defined ciphersuites appear in this module.
 ///
@@ -442,10 +463,6 @@ mod quic {
     impl QuicExt for super::ServerConnection {}
 }
 
-#[cfg(feature = "dangerous_configuration")]
-#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
-pub use crate::verify::{ClientCertVerified, ClientCertVerifier, DnsName};
-
 /// This is the rustls manual.
 pub mod manual;
 
@@ -453,7 +470,7 @@ pub mod manual;
 #[allow(clippy::upper_case_acronyms)]
 #[doc(hidden)]
 #[deprecated(since = "0.20.0", note = "Use ResolvesServerCertUsingSni")]
-pub type ResolvesServerCertUsingSNI = ResolvesServerCertUsingSni;
+pub type ResolvesServerCertUsingSNI = server::ResolvesServerCertUsingSni;
 #[allow(clippy::upper_case_acronyms)]
 #[cfg(feature = "dangerous_configuration")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -174,7 +174,7 @@ mod test {
     use super::*;
     use crate::server::ProducesTickets;
     use crate::server::ResolvesServerCert;
-    use crate::StoresServerSessions;
+    use crate::server::StoresServerSessions;
 
     #[test]
     fn test_noserversessionstorage_drops_put() {

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -19,10 +19,11 @@ use crate::server::{ClientHello, ServerConfig};
 use crate::suites;
 use crate::SupportedCipherSuite;
 
+use super::server_conn::ServerConnectionData;
 #[cfg(feature = "tls12")]
 use super::tls12;
 use crate::server::common::ActiveCertifiedKey;
-use crate::server::{tls13, ServerConnectionData};
+use crate::server::tls13;
 
 use std::sync::Arc;
 

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -15,19 +15,12 @@ use crate::verify;
 #[cfg(feature = "quic")]
 use crate::{conn::Protocol, quic};
 
+use super::hs;
+
 use std::fmt;
 use std::io::{self, IoSlice};
 use std::marker::PhantomData;
 use std::sync::Arc;
-
-#[macro_use]
-mod hs;
-pub(crate) mod builder;
-mod common;
-pub(crate) mod handy;
-#[cfg(feature = "tls12")]
-mod tls12;
-mod tls13;
 
 /// A trait for the ability to store server session data.
 ///
@@ -114,7 +107,7 @@ pub struct ClientHello<'a> {
 
 impl<'a> ClientHello<'a> {
     /// Creates a new ClientHello
-    fn new(
+    pub(super) fn new(
         server_name: Option<webpki::DnsNameRef<'a>>,
         signature_schemes: &'a [SignatureScheme],
         alpn: Option<&'a [&'a [u8]]>,
@@ -166,13 +159,13 @@ impl<'a> ClientHello<'a> {
 #[derive(Clone)]
 pub struct ServerConfig {
     /// List of ciphersuites, in preference order.
-    cipher_suites: Vec<SupportedCipherSuite>,
+    pub(super) cipher_suites: Vec<SupportedCipherSuite>,
 
     /// List of supported key exchange groups.
     ///
     /// The first is the highest priority: they will be
     /// offered to the client in this order.
-    kx_groups: Vec<&'static SupportedKxGroup>,
+    pub(super) kx_groups: Vec<&'static SupportedKxGroup>,
 
     /// Ignore the client's ciphersuite order. Instead,
     /// choose the top ciphersuite in the server list
@@ -203,10 +196,10 @@ pub struct ServerConfig {
 
     /// Supported protocol versions, in no particular order.
     /// The default is all supported versions.
-    versions: crate::versions::EnabledVersions,
+    pub(super) versions: crate::versions::EnabledVersions,
 
     /// How to verify client certificates.
-    verifier: Arc<dyn verify::ClientCertVerifier>,
+    pub(super) verifier: Arc<dyn verify::ClientCertVerifier>,
 
     /// How to output key material for debugging.  The default
     /// does nothing.
@@ -436,23 +429,23 @@ impl fmt::Debug for ServerConnection {
 }
 
 #[derive(Default)]
-struct ServerConnectionData {
-    sni: Option<webpki::DnsName>,
-    received_resumption_data: Option<Vec<u8>>,
-    resumption_data: Vec<u8>,
-    client_cert_chain: Option<Vec<key::Certificate>>,
+pub(super) struct ServerConnectionData {
+    pub(super) sni: Option<webpki::DnsName>,
+    pub(super) received_resumption_data: Option<Vec<u8>>,
+    pub(super) resumption_data: Vec<u8>,
+    pub(super) client_cert_chain: Option<Vec<key::Certificate>>,
 
     #[allow(dead_code)] // only supported for QUIC currently
     /// Whether to reject early data even if it would otherwise be accepted
-    reject_early_data: bool,
+    pub(super) reject_early_data: bool,
 }
 
 impl ServerConnectionData {
-    fn get_sni_str(&self) -> Option<&str> {
+    pub(super) fn get_sni_str(&self) -> Option<&str> {
         self.sni.as_ref().map(AsRef::as_ref)
     }
 
-    fn get_sni(&self) -> Option<verify::DnsName> {
+    pub(super) fn get_sni(&self) -> Option<verify::DnsName> {
         self.sni
             .as_ref()
             .map(|name| verify::DnsName(name.clone()))

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -10,6 +10,7 @@ use std::sync::Mutex;
 
 use rustls;
 
+use rustls::client::ResolvesClientCert;
 use rustls::internal::msgs::{codec::Codec, persist::ClientSessionValue};
 #[cfg(feature = "quic")]
 use rustls::quic::{self, ClientQuicExt, QuicExt, ServerQuicExt};
@@ -19,7 +20,7 @@ use rustls::Connection;
 use rustls::Error;
 use rustls::KeyLog;
 use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
-use rustls::{ClientConfig, ClientConnection, ResolvesClientCert};
+use rustls::{ClientConfig, ClientConnection};
 use rustls::{ResolvesServerCert, ServerConfig, ServerConnection};
 use rustls::{Stream, StreamOwned};
 use rustls::{SupportedCipherSuite, ALL_CIPHER_SUITES};
@@ -2811,7 +2812,7 @@ impl rustls::StoresServerSessions for ServerStorage {
 }
 
 struct ClientStorage {
-    storage: Arc<dyn rustls::StoresClientSessions>,
+    storage: Arc<dyn rustls::client::StoresClientSessions>,
     put_count: AtomicUsize,
     get_count: AtomicUsize,
     last_put_key: Mutex<Option<Vec<u8>>>,
@@ -2820,7 +2821,7 @@ struct ClientStorage {
 impl ClientStorage {
     fn new() -> Self {
         ClientStorage {
-            storage: rustls::ClientSessionMemoryCache::new(1024),
+            storage: rustls::client::ClientSessionMemoryCache::new(1024),
             put_count: AtomicUsize::new(0),
             get_count: AtomicUsize::new(0),
             last_put_key: Mutex::new(None),
@@ -2845,7 +2846,7 @@ impl fmt::Debug for ClientStorage {
     }
 }
 
-impl rustls::StoresClientSessions for ClientStorage {
+impl rustls::client::StoresClientSessions for ClientStorage {
     fn put(&self, key: Vec<u8>, value: Vec<u8>) -> bool {
         self.put_count
             .fetch_add(1, Ordering::SeqCst);

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -14,10 +14,13 @@ use rustls::{ClientConfig, ClientConnection};
 use rustls::{ServerConfig, ServerConnection};
 
 #[cfg(feature = "dangerous_configuration")]
+use rustls::client::{
+    HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
+};
+#[cfg(feature = "dangerous_configuration")]
 use rustls::{
     internal::msgs::handshake::DigitallySignedStruct, ClientCertVerified, ClientCertVerifier,
-    DistinguishedNames, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
-    SignatureScheme, WebPkiVerifier,
+    DistinguishedNames, SignatureScheme,
 };
 
 macro_rules! embed_files {

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -6,9 +6,10 @@ use rustls_pemfile;
 
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
+use rustls::server::AllowAnyAuthenticatedClient;
 use rustls::Connection;
 use rustls::Error;
-use rustls::{AllowAnyAuthenticatedClient, RootCertStore};
+use rustls::RootCertStore;
 use rustls::{Certificate, PrivateKey};
 use rustls::{ClientConfig, ClientConnection};
 use rustls::{ServerConfig, ServerConnection};
@@ -18,9 +19,10 @@ use rustls::client::{
     HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier, WebPkiVerifier,
 };
 #[cfg(feature = "dangerous_configuration")]
+use rustls::server::{ClientCertVerified, ClientCertVerifier};
+#[cfg(feature = "dangerous_configuration")]
 use rustls::{
-    internal::msgs::handshake::DigitallySignedStruct, ClientCertVerified, ClientCertVerifier,
-    DistinguishedNames, SignatureScheme,
+    internal::msgs::handshake::DigitallySignedStruct, DistinguishedNames, SignatureScheme,
 };
 
 macro_rules! embed_files {
@@ -541,7 +543,7 @@ pub struct MockClientVerifier {
 
 #[cfg(feature = "dangerous_configuration")]
 impl ClientCertVerifier for MockClientVerifier {
-    fn client_auth_mandatory(&self, sni: Option<&rustls::DnsName>) -> Option<bool> {
+    fn client_auth_mandatory(&self, sni: Option<&rustls::server::DnsName>) -> Option<bool> {
         // This is just an added 'test' to make sure we plumb through the SNI,
         // although its valid for it to be None, its just our tests should (as of now) always provide it
         assert!(sni.is_some());
@@ -550,7 +552,7 @@ impl ClientCertVerifier for MockClientVerifier {
 
     fn client_auth_root_subjects(
         &self,
-        sni: Option<&rustls::DnsName>,
+        sni: Option<&rustls::server::DnsName>,
     ) -> Option<DistinguishedNames> {
         assert!(sni.is_some());
         self.subjects.as_ref().cloned()
@@ -560,7 +562,7 @@ impl ClientCertVerifier for MockClientVerifier {
         &self,
         _end_entity: &Certificate,
         _intermediates: &[Certificate],
-        sni: Option<&rustls::DnsName>,
+        sni: Option<&rustls::server::DnsName>,
         _now: std::time::SystemTime,
     ) -> Result<ClientCertVerified, Error> {
         assert!(sni.is_some());


### PR DESCRIPTION
The full list of items in the crate root was getting to be quite long, making it hard to find stuff even for experienced users (as in, myself). Splitting up client/server-specific items should make it easier to find what you need. In this PR we still reexport `ClientConfig`, `ClientConnection`, `ServerConfig` and `ServerConnection` in the crate root.

Additional benefit of the chosen approach is decreased/explicit visibility of items that were previously defined in the root of the private `client`/`server` modules.