### PR TITLE
Deny warnings in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         run: cargo test --all-features
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: -D warnings
 
       - name: cargo build (debug; no default features)
         run: cargo build --no-default-features

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -623,10 +623,10 @@ fn exec(opts: &Options, mut sess: ClientOrServer, count: usize) {
         }
 
         if sess.wants_read() {
-            let len = match sess.read_tls(&mut conn) {
-                Ok(len) => len,
-                Err(ref err) if err.kind() == io::ErrorKind::ConnectionReset => 0,
-                err @ Err(_) => err.expect("read failed"),
+            match sess.read_tls(&mut conn) {
+                Ok(_) => {}
+                Err(ref err) if err.kind() == io::ErrorKind::ConnectionReset => {}
+                Err(err) => panic!("invalid read: {}", err),
             };
 
             if let Err(err) = sess.process_new_packets() {


### PR DESCRIPTION
b84721ef0d72e7f2747105f6b76a6bcbb8aa0ea4 left an unused variable. Start to deny warnings in CI and fix it.