### PR TITLE
Flatten PKI error variants

### DIFF
--- a/rustls-mio/tests/badssl.rs
+++ b/rustls-mio/tests/badssl.rs
@@ -38,7 +38,9 @@ mod online {
         polite();
         connect("expired.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPkiError\(CertExpired, ValidateServerCert\)")
+            .expect(
+                r#"TLS error: InvalidCertificateData\("invalid peer certificate: CertExpired"\)"#,
+            )
             .go()
             .unwrap();
     }
@@ -48,7 +50,7 @@ mod online {
         polite();
         connect("wrong.host.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPkiError\(CertNotValidForName, ValidateForDnsName\)")
+            .expect(r#"TLS error: InvalidCertificateData\("invalid peer certificate: CertNotValidForName"\)"#)
             .go()
             .unwrap();
     }
@@ -58,7 +60,9 @@ mod online {
         polite();
         connect("self-signed.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPkiError\((UnknownIssuer|CertExpired), ValidateServerCert\)")
+            .expect(
+                r#"TLS error: InvalidCertificateData\("invalid peer certificate: UnknownIssuer"\)"#,
+            )
             .go()
             .unwrap();
     }
@@ -133,7 +137,9 @@ mod online {
         polite();
         connect("sha1-2016.badssl.com")
             .fails()
-            .expect(r"TLS error: WebPkiError\(CertExpired, ValidateServerCert\)")
+            .expect(
+                r#"TLS error: InvalidCertificateData\("invalid peer certificate: CertExpired"\)"#,
+            )
             .go()
             .unwrap();
     }

--- a/rustls/examples/internal/bogo_shim.rs
+++ b/rustls/examples/internal/bogo_shim.rs
@@ -492,7 +492,7 @@ fn quit_err(why: &str) -> ! {
 
 fn handle_err(err: rustls::Error) -> ! {
     use rustls::internal::msgs::enums::{AlertDescription, ContentType};
-    use rustls::{Error, WebPkiError};
+    use rustls::Error;
     use std::{thread, time};
 
     println!("TLS error: {:?}", err);
@@ -525,13 +525,9 @@ fn handle_err(err: rustls::Error) -> ! {
         Error::AlertReceived(AlertDescription::DecompressionFailure) => {
             quit_err(":SSLV3_ALERT_DECOMPRESSION_FAILURE:")
         }
-        Error::WebPkiError(WebPkiError::BadEncoding, ..) => quit(":CANNOT_PARSE_LEAF_CERT:"),
-        Error::WebPkiError(WebPkiError::InvalidSignatureForPublicKey, ..) => {
-            quit(":BAD_SIGNATURE:")
-        }
-        Error::WebPkiError(WebPkiError::UnsupportedSignatureAlgorithmForPublicKey, ..) => {
-            quit(":WRONG_SIGNATURE_TYPE:")
-        }
+        Error::InvalidCertificateEncoding => quit(":CANNOT_PARSE_LEAF_CERT:"),
+        Error::InvalidCertificateSignature => quit(":BAD_SIGNATURE:"),
+        Error::InvalidCertificateSignatureType => quit(":WRONG_SIGNATURE_TYPE:"),
         Error::PeerSentOversizedRecord => quit(":DATA_LENGTH_TOO_LONG:"),
         _ => {
             println_err!("unhandled error: {:?}", err);

--- a/rustls/examples/internal/trytls_shim.rs
+++ b/rustls/examples/internal/trytls_shim.rs
@@ -81,7 +81,11 @@ fn communicate(
 
             if let Err(err) = client.process_new_packets() {
                 return match err {
-                    Error::WebPkiError(..) | Error::AlertReceived(_) => Ok(Verdict::Reject(err)),
+                    Error::InvalidCertificateData(_)
+                    | Error::InvalidCertificateSignature
+                    | Error::InvalidCertificateSignatureType
+                    | Error::InvalidCertificateEncoding
+                    | Error::AlertReceived(_) => Ok(Verdict::Reject(err)),
                     _ => Err(From::from(format!("{:?}", err))),
                 };
             }

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -2,7 +2,7 @@
 use crate::bs_debug;
 use crate::check::check_message;
 use crate::conn::{ConnectionCommon, ConnectionRandoms};
-use crate::error::{Error, WebPkiError};
+use crate::error::Error;
 use crate::hash_hs::HandshakeHashBuffer;
 use crate::key_schedule::KeyScheduleEarly;
 use crate::kx;
@@ -802,7 +802,7 @@ impl State for ExpectServerHelloOrHelloRetryRequest {
 
 pub(super) fn send_cert_error_alert(common: &mut ConnectionCommon, err: Error) -> Error {
     match err {
-        Error::WebPkiError(WebPkiError::BadEncoding, _) => {
+        Error::InvalidCertificateEncoding => {
             common.send_fatal_alert(AlertDescription::DecodeError);
         }
         Error::PeerMisbehavedError(_) => {

--- a/rustls/src/error.rs
+++ b/rustls/src/error.rs
@@ -5,185 +5,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::time::SystemTimeError;
 
-/// Reasons for a WebPKI operation to fail, used in [`Error`].
-#[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
-pub enum WebPkiError {
-    /// Encountered an illegal encoding.
-    BadEncoding,
-
-    /// Encountered an illegal encoding of a time field.
-    BadTimeEncoding,
-
-    /// A CA certificate was used as an end-entity.
-    CaUsedAsEndEntity,
-
-    /// A certificate was expired, ie the verification time was after
-    /// the notAfter instant.
-    CertExpired,
-
-    /// A certificate was not issued for the given name.
-    CertNotValidForName,
-
-    /// A certificate was not yet valid, ie the verification time was before
-    /// the notBefore instant.
-    CertNotValidYet,
-
-    /// An end-entity certificate was used as a CA
-    EndEntityUsedAsCa,
-
-    /// An X.509 extension had an invalid value
-    ExtensionValueInvalid,
-
-    /// An X.509 certificate had an illegal validity period; for example
-    /// notBefore was after notAfter
-    InvalidCertValidity,
-
-    /// The given signature is invalid.
-    InvalidSignatureForPublicKey,
-
-    /// A certificate violated name constraits required by its issuing path.
-    NameConstraintViolation,
-
-    /// A certificate violated path length constraits required by its issuing path.
-    PathLenConstraintViolation,
-
-    /// A certificate contained inconsistent signature algorithms.
-    SignatureAlgorithmMismatch,
-
-    /// A certificate did not contain the the required extended key usage bits.
-    RequiredEkuNotFound,
-
-    /// It wasn't possible to construct a path from the given end-entity
-    /// certificate to one of the trusted issuers.
-    UnknownIssuer,
-
-    /// An X.509 certificate was encountered that had an illegal version, or
-    /// a version other than 3.
-    UnsupportedCertVersion,
-
-    /// An X.509 extension was encountered that had a missing or malformed extensions.
-    MissingOrMalformedExtension,
-
-    /// An X.509 unrecognized extension was encountered with the critical bit set.
-    UnsupportedCriticalExtension,
-
-    /// The given certified public key cannot verify signatures of this type.
-    UnsupportedSignatureAlgorithmForPublicKey,
-
-    /// The given signature algorithm is not supported.
-    UnsupportedSignatureAlgorithm,
-}
-
-impl From<webpki::Error> for WebPkiError {
-    fn from(e: webpki::Error) -> Self {
-        use webpki::Error;
-        match e {
-            Error::BadDer => Self::BadEncoding,
-            Error::BadDerTime => Self::BadTimeEncoding,
-            Error::CaUsedAsEndEntity => Self::CaUsedAsEndEntity,
-            Error::CertExpired => Self::CertExpired,
-            Error::CertNotValidForName => Self::CertNotValidForName,
-            Error::CertNotValidYet => Self::CertNotValidYet,
-            Error::EndEntityUsedAsCa => Self::EndEntityUsedAsCa,
-            Error::ExtensionValueInvalid => Self::ExtensionValueInvalid,
-            Error::InvalidCertValidity => Self::InvalidCertValidity,
-            Error::InvalidSignatureForPublicKey => Self::InvalidSignatureForPublicKey,
-            Error::NameConstraintViolation => Self::NameConstraintViolation,
-            Error::PathLenConstraintViolated => Self::PathLenConstraintViolation,
-            Error::SignatureAlgorithmMismatch => Self::SignatureAlgorithmMismatch,
-            Error::RequiredEkuNotFound => Self::RequiredEkuNotFound,
-            Error::UnknownIssuer => Self::UnknownIssuer,
-            Error::UnsupportedCertVersion => Self::UnsupportedCertVersion,
-            Error::MissingOrMalformedExtensions => Self::MissingOrMalformedExtension,
-            Error::UnsupportedCriticalExtension => Self::UnsupportedCriticalExtension,
-            Error::UnsupportedSignatureAlgorithmForPublicKey => {
-                Self::UnsupportedSignatureAlgorithmForPublicKey
-            }
-            Error::UnsupportedSignatureAlgorithm => Self::UnsupportedSignatureAlgorithm,
-        }
-    }
-}
-
-impl fmt::Display for WebPkiError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WebPkiError::BadEncoding => write!(f, "bad DER encoding"),
-            WebPkiError::BadTimeEncoding => write!(f, "bad DER encoding of time"),
-            WebPkiError::CaUsedAsEndEntity => write!(f, "CA certificate used as end-entity"),
-            WebPkiError::CertExpired => write!(f, "certificate expired"),
-            WebPkiError::CertNotValidForName => write!(f, "certificate not valid for name"),
-            WebPkiError::CertNotValidYet => write!(f, "certificate not yet valid"),
-            WebPkiError::EndEntityUsedAsCa => write!(f, "end-entity certificate used as CA"),
-            WebPkiError::ExtensionValueInvalid => write!(f, "invalid X.509 extension value"),
-            WebPkiError::InvalidCertValidity => write!(f, "invalid certificate validity period"),
-            WebPkiError::InvalidSignatureForPublicKey => {
-                write!(f, "invalid signature for certified key")
-            }
-            WebPkiError::NameConstraintViolation => {
-                write!(f, "certificate violates name constraint")
-            }
-            WebPkiError::PathLenConstraintViolation => {
-                write!(f, "certificate violates path length constraint")
-            }
-            WebPkiError::SignatureAlgorithmMismatch => {
-                write!(f, "certificate contains inconsistent signature algorithm")
-            }
-            WebPkiError::RequiredEkuNotFound => {
-                write!(f, "certificate does not have a required extended key usage")
-            }
-            WebPkiError::UnknownIssuer => write!(
-                f,
-                "a valid path from an end-entity to a CA certificate could not be found"
-            ),
-            WebPkiError::UnsupportedCertVersion => {
-                write!(f, "certificate has a version other than v3")
-            }
-            WebPkiError::MissingOrMalformedExtension => {
-                write!(f, "certificate has a missing or malformed X.509 extension")
-            }
-            WebPkiError::UnsupportedCriticalExtension => {
-                write!(f, "certificate has an unrecognized critical extension")
-            }
-            WebPkiError::UnsupportedSignatureAlgorithmForPublicKey => write!(
-                f,
-                "type mismatch between certified key and signature algorithm"
-            ),
-            WebPkiError::UnsupportedSignatureAlgorithm => {
-                write!(f, "unsupported signature algorithm")
-            }
-        }
-    }
-}
-
-/// Which WebPKI operation was performed, used in [`Error`].
-#[derive(Debug, PartialEq, Clone)]
-#[non_exhaustive]
-pub enum WebPkiOp {
-    /// Validate server certificate.
-    ValidateServerCert,
-    /// Validate client certificate.
-    ValidateClientCert,
-    /// Validate certificate for DNS name
-    ValidateForDnsName,
-    /// Parse end entity certificate.
-    ParseEndEntity,
-    /// Verify message signature using the certificate.
-    VerifySignature,
-}
-
-impl fmt::Display for WebPkiOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            WebPkiOp::ValidateServerCert => write!(f, "validate server certificate"),
-            WebPkiOp::ValidateClientCert => write!(f, "validate client certificate"),
-            WebPkiOp::ValidateForDnsName => write!(f, "validate certificate for DNS name"),
-            WebPkiOp::ParseEndEntity => write!(f, "parse end entity certificate"),
-            WebPkiOp::VerifySignature => write!(f, "verify signature"),
-        }
-    }
-}
-
 /// rustls reports protocol errors using this type.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
@@ -235,8 +56,17 @@ pub enum Error {
     /// We received a fatal alert.  This means the peer is unhappy.
     AlertReceived(AlertDescription),
 
-    /// The presented certificate chain is invalid.
-    WebPkiError(WebPkiError, WebPkiOp),
+    /// We received an invalidly encoded certificate from the peer.
+    InvalidCertificateEncoding,
+
+    /// We received a certificate with invalid signature type.
+    InvalidCertificateSignatureType,
+
+    /// We received a certificate with invalid signature.
+    InvalidCertificateSignature,
+
+    /// We received a certificate which includes invalid data.
+    InvalidCertificateData(String),
 
     /// The presented SCT(s) were invalid.
     InvalidSct(sct::Error),
@@ -300,11 +130,17 @@ impl fmt::Display for Error {
             Error::PeerIncompatibleError(ref why) => write!(f, "peer is incompatible: {}", why),
             Error::PeerMisbehavedError(ref why) => write!(f, "peer misbehaved: {}", why),
             Error::AlertReceived(ref alert) => write!(f, "received fatal alert: {:?}", alert),
-            Error::WebPkiError(ref err, ref reason) => {
-                write!(f, "certificate error in operation: ")
-                    .and_then(|_| reason.fmt(f))
-                    .and_then(|_| write!(f, ": "))
-                    .and_then(|_| err.fmt(f))
+            Error::InvalidCertificateEncoding => {
+                write!(f, "invalid peer certificate encoding")
+            }
+            Error::InvalidCertificateSignatureType => {
+                write!(f, "invalid peer certificate signature type")
+            }
+            Error::InvalidCertificateSignature => {
+                write!(f, "invalid peer certificate signature")
+            }
+            Error::InvalidCertificateData(ref reason) => {
+                write!(f, "invalid peer certificate contents: {}", reason)
             }
             Error::CorruptMessage => write!(f, "received corrupt message"),
             Error::NoCertificatesPresented => write!(f, "peer sent no certificates"),
@@ -319,7 +155,7 @@ impl fmt::Display for Error {
             Error::BadMaxFragmentSize => {
                 write!(f, "the supplied max_fragment_size was too small or large")
             }
-            Error::General(ref err) => write!(f, "unexpected error: {}", err), // (please file a bug)
+            Error::General(ref err) => write!(f, "unexpected error: {}", err),
         }
     }
 }
@@ -342,7 +178,6 @@ impl From<rand::GetRandomFailed> for Error {
 #[cfg(test)]
 mod tests {
     use super::Error;
-    use super::{WebPkiError, WebPkiOp};
 
     #[test]
     fn smoke() {
@@ -365,60 +200,10 @@ mod tests {
             Error::PeerIncompatibleError("no tls1.2".to_string()),
             Error::PeerMisbehavedError("inconsistent something".to_string()),
             Error::AlertReceived(AlertDescription::ExportRestriction),
-            Error::WebPkiError(
-                WebPkiError::ExtensionValueInvalid,
-                WebPkiOp::ValidateServerCert,
-            ),
-            Error::WebPkiError(WebPkiError::BadEncoding, WebPkiOp::ValidateClientCert),
-            Error::WebPkiError(WebPkiError::BadTimeEncoding, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::CaUsedAsEndEntity, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::CertExpired, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(
-                WebPkiError::CertNotValidForName,
-                WebPkiOp::ValidateForDnsName,
-            ),
-            Error::WebPkiError(WebPkiError::CertNotValidYet, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::EndEntityUsedAsCa, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::ExtensionValueInvalid, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::InvalidCertValidity, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(
-                WebPkiError::InvalidSignatureForPublicKey,
-                WebPkiOp::VerifySignature,
-            ),
-            Error::WebPkiError(
-                WebPkiError::NameConstraintViolation,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::PathLenConstraintViolation,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::SignatureAlgorithmMismatch,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(WebPkiError::RequiredEkuNotFound, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(WebPkiError::UnknownIssuer, WebPkiOp::ParseEndEntity),
-            Error::WebPkiError(
-                WebPkiError::UnsupportedCertVersion,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::MissingOrMalformedExtension,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::UnsupportedCriticalExtension,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::UnsupportedSignatureAlgorithmForPublicKey,
-                WebPkiOp::ParseEndEntity,
-            ),
-            Error::WebPkiError(
-                WebPkiError::UnsupportedSignatureAlgorithm,
-                WebPkiOp::ParseEndEntity,
-            ),
+            Error::InvalidCertificateEncoding,
+            Error::InvalidCertificateSignatureType,
+            Error::InvalidCertificateSignature,
+            Error::InvalidCertificateData("Data".into()),
             Error::InvalidSct(sct::Error::MalformedSct),
             Error::General("undocumented error".to_string()),
             Error::FailedToGetCurrentTime,
@@ -433,67 +218,6 @@ mod tests {
             println!("{:?}:", err);
             println!("  fmt '{}'", err);
         }
-    }
-
-    #[test]
-    fn webpki_mappings() {
-        use webpki::Error;
-
-        fn check(err: Error, expect: WebPkiError) {
-            let got: WebPkiError = err.into();
-            assert_eq!(got, expect);
-        }
-
-        check(Error::BadDer, WebPkiError::BadEncoding);
-        check(Error::BadDerTime, WebPkiError::BadTimeEncoding);
-        check(Error::CaUsedAsEndEntity, WebPkiError::CaUsedAsEndEntity);
-        check(Error::CertExpired, WebPkiError::CertExpired);
-        check(Error::CertNotValidForName, WebPkiError::CertNotValidForName);
-        check(Error::CertNotValidYet, WebPkiError::CertNotValidYet);
-        check(Error::EndEntityUsedAsCa, WebPkiError::EndEntityUsedAsCa);
-        check(
-            Error::ExtensionValueInvalid,
-            WebPkiError::ExtensionValueInvalid,
-        );
-        check(Error::InvalidCertValidity, WebPkiError::InvalidCertValidity);
-        check(
-            Error::InvalidSignatureForPublicKey,
-            WebPkiError::InvalidSignatureForPublicKey,
-        );
-        check(
-            Error::NameConstraintViolation,
-            WebPkiError::NameConstraintViolation,
-        );
-        check(
-            Error::PathLenConstraintViolated,
-            WebPkiError::PathLenConstraintViolation,
-        );
-        check(
-            Error::SignatureAlgorithmMismatch,
-            WebPkiError::SignatureAlgorithmMismatch,
-        );
-        check(Error::RequiredEkuNotFound, WebPkiError::RequiredEkuNotFound);
-        check(Error::UnknownIssuer, WebPkiError::UnknownIssuer);
-        check(
-            Error::UnsupportedCertVersion,
-            WebPkiError::UnsupportedCertVersion,
-        );
-        check(
-            Error::MissingOrMalformedExtensions,
-            WebPkiError::MissingOrMalformedExtension,
-        );
-        check(
-            Error::UnsupportedCriticalExtension,
-            WebPkiError::UnsupportedCriticalExtension,
-        );
-        check(
-            Error::UnsupportedSignatureAlgorithmForPublicKey,
-            WebPkiError::UnsupportedSignatureAlgorithmForPublicKey,
-        );
-        check(
-            Error::UnsupportedSignatureAlgorithm,
-            WebPkiError::UnsupportedSignatureAlgorithm,
-        );
     }
 
     #[test]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -328,8 +328,6 @@ pub use crate::client::StoresClientSessions;
 pub use crate::client::{ClientConfig, ClientConnection, WriteEarlyData};
 pub use crate::conn::{Connection, IoState, Reader, Writer};
 pub use crate::error::Error;
-pub use crate::error::WebPkiError;
-pub use crate::error::WebPkiOp;
 pub use crate::key::{Certificate, PrivateKey};
 pub use crate::keylog::{KeyLog, KeyLogFile, NoKeyLog};
 pub use crate::kx::{SupportedKxGroup, ALL_KX_GROUPS};

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -23,7 +23,6 @@ use rustls::{ClientConfig, ClientConnection, ResolvesClientCert};
 use rustls::{ResolvesServerCert, ServerConfig, ServerConnection};
 use rustls::{Stream, StreamOwned};
 use rustls::{SupportedCipherSuite, ALL_CIPHER_SUITES};
-use rustls::{WebPkiError, WebPkiOp};
 
 #[cfg(feature = "dangerous_configuration")]
 use rustls::ClientCertVerified;
@@ -786,9 +785,8 @@ fn client_checks_server_certificate_with_given_name() {
             let err = do_handshake_until_error(&mut client, &mut server);
             assert_eq!(
                 err,
-                Err(ErrorFromPeer::Client(Error::WebPkiError(
-                    WebPkiError::CertNotValidForName,
-                    WebPkiOp::ValidateForDnsName,
+                Err(ErrorFromPeer::Client(Error::InvalidCertificateData(
+                    "invalid peer certificate: CertNotValidForName".into(),
                 )))
             );
         }


### PR DESCRIPTION
This gets rid of the `WebPkiError` and `WebPkiOp` types in favor of a small number of `Error` variants:

* `InvalidCertificateEncoding` -- represents `BadDer` and `BadDerTime`
* `InvalidCertificateSignature` -- represents `InvalidSignatureForPublicKey`
* `InvalidCertificateSignatureType` -- represents `UnsupportedSignatureAlgorithm` and `UnsupportedSignatureAlgorithmForPublicKey`
* `InvalidCertificateData`

This plays off of the distinctions useful to the bogo test suite as well as the need to send a different alert for invalid encoding errors.

Alternatively, we could still combine this with `WebPkiOp`. However, my feeling is that `WebPkiOp` doesn't quite carry its weight.

Fixes #782.